### PR TITLE
Post repo organisation switch fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Create GitHub deployment for Staging
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: master
       run: |
         source cosmetics-web/deploy-github-functions.sh
@@ -28,7 +28,7 @@ jobs:
 
     - name: Initiate Staging deployment status
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
 
@@ -62,7 +62,7 @@ jobs:
     - name: Update Staging deployment status (success)
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
         environment_url=https://staging-submit.cosmetic-product-notifications.service.gov.uk/
@@ -71,14 +71,14 @@ jobs:
     - name: Update Staging deployment status (failure)
       if: failure()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
         gh_deploy_failure staging $LOG_URL
 
     - name: Create GitHub deployment for Production
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: master
       run: |
         source cosmetics-web/deploy-github-functions.sh
@@ -86,7 +86,7 @@ jobs:
 
     - name: Initiate Production deployment status
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
         gh_deploy_initiate production $LOG_URL
@@ -114,7 +114,7 @@ jobs:
     - name: Update Production deployment status (success)
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
         environment_url=https://submit.cosmetic-product-notifications.service.gov.uk/
@@ -123,7 +123,7 @@ jobs:
     - name: Update Production deployment status (failure)
       if: failure()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
         gh_deploy_failure production $LOG_URL

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Deactivate Github deployment
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
         gh_deploy_deactivate_dangling review-app-$PR_NUMBER

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Create GitHub deployment
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: ${{ github.head_ref }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
@@ -23,7 +23,7 @@ jobs:
 
     - name: Initiate deployment status
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
 
@@ -62,7 +62,7 @@ jobs:
     - name: Update deployment status (success)
       if: success()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
 
@@ -73,7 +73,7 @@ jobs:
     - name: Update deployment status (failure)
       if: failure()
       env:
-        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
         gh_deploy_failure review-app-${PR_NUMBER} $LOG_URL

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Office for Product Safety & Standards Services
+# Cosmetic product notifications
 
 [![Build Status](https://travis-ci.org/UKGovernmentBEIS/beis-opss.svg?branch=master)](https://travis-ci.org/UKGovernmentBEIS/beis-opss)
 [![Coverage Status](https://coveralls.io/repos/github/UKGovernmentBEIS/beis-opss/badge.svg?branch=master)](https://coveralls.io/github/UKGovernmentBEIS/beis-opss?branch=master)


### PR DESCRIPTION
Changes to be done after moving the repository from BEIS to OPSS own repository:
- Change the Readme title to match the service name
- Change GitHub actions authentication token to the one provided by Github for automatic token authentication.