### PR TITLE
Replace render calls with Govuk Design gem helpers

### DIFF
--- a/cosmetics-web/app/views/nanomaterial_notifications/notified_to_eu.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/notified_to_eu.html.erb
@@ -25,7 +25,7 @@
         <% error_class = "govuk-input--error" %>
       <% end %>
 
-      <% date_notified_to_eu_html = render("components/govuk_date_input",
+      <% date_notified_to_eu_html = govukDateInput(
         id: "notified_to_eu_on",
         fieldset: {
           legend: {

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.html.erb
@@ -47,32 +47,34 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@responsible_persons_details_form, url: wizard_path, method: :put, html: { novalidate: true }) do |form| %>
-      <%= render("form_components/govuk_radios",
-                 form: form,
-                 key: :account_type,
-                 formGroup: { classes: "govuk-!-margin-top-6" },
-                 fieldset: { legend: { html: "Is the <abbr>UK</abbr> Responsible Person a business or an individual?".html_safe,
-                             classes: "govuk-fieldset__legend--s" } },
-                 classes: "govuk-radios--small",
-                 items: [
-                   { html: "Limited company or Limited Liability Partnership (<abbr>LLP</abbr>)".html_safe,
-                     id: "account_type_business",
-                     value: :business,
-                     label: { classes: "govuk-!-padding-bottom-0" } },
-                   { text: "Individual or sole trader",
-                     id: "account_type_individual",
-                     value: :individual,
-                     label: { classes: "govuk-!-padding-bottom-0" } },
-                 ]) %>
+      <%= govukRadios(
+            form: form,
+            key: :account_type,
+            formGroup: { classes: "govuk-!-margin-top-6" },
+            fieldset: { legend: { html: "Is the <abbr>UK</abbr> Responsible Person a business or an individual?".html_safe,
+                        classes: "govuk-fieldset__legend--s" } },
+            classes: "govuk-radios--small",
+            items: [
+              { html: "Limited company or Limited Liability Partnership (<abbr>LLP</abbr>)".html_safe,
+                id: "account_type_business",
+                value: :business,
+                label: { classes: "govuk-!-padding-bottom-0" } },
+              { text: "Individual or sole trader",
+                id: "account_type_individual",
+                value: :individual,
+                label: { classes: "govuk-!-padding-bottom-0" } },
+            ],
+          ) %>
 
-      <%= render("form_components/govuk_input",
-                 form: form,
-                 key: :name,
-                 id: "name",
-                 classes: "govuk-input govuk-!-width-two-thirds",
-                 label: { text: "Name", classes: "govuk-label--s" },
-                 hint: { text: "The name of the business, individual or sole trader named as the legal entity of Responsible Person.",
-                         classes: "govuk-!-font-size-16 govuk-!-width-three-quarters" }) %>
+      <%= govukInput(
+            form: form,
+            key: :name,
+            id: "name",
+            classes: "govuk-input govuk-!-width-two-thirds",
+            label: { text: "Name", classes: "govuk-label--s" },
+            hint: { text: "The name of the business, individual or sole trader named as the legal entity of Responsible Person.",
+                    classes: "govuk-!-font-size-16 govuk-!-width-three-quarters" },
+          ) %>
       <fieldset class="govuk-fieldset ">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
           <h2 class="govuk-fieldset__heading">
@@ -83,21 +85,23 @@
           The address of the legal entity named as the Responsible Person.
         </div>
 
-        <%= render("form_components/govuk_input",
-                   form: form,
-                   key: :address_line_1,
-                   id: "address_line_1",
-                   classes: "govuk-!-width-three-quarters",
-                   formGroup: { classes: "govuk-!-margin-bottom-5" },
-                   described_by: "address-hint",
-                   label: { html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>".html_safe }) %>
+        <%= govukInput(
+              form: form,
+              key: :address_line_1,
+              id: "address_line_1",
+              classes: "govuk-!-width-three-quarters",
+              formGroup: { classes: "govuk-!-margin-bottom-5" },
+              described_by: "address-hint",
+              label: { html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>".html_safe },
+            ) %>
 
-        <%= render("form_components/govuk_input",
-                   form: form,
-                   key: :address_line_2,
-                   id: "address_line_2",
-                   classes: "govuk-!-width-three-quarters",
-                   label: { html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>".html_safe }) %>
+        <%= govukInput(
+              form: form,
+              key: :address_line_2,
+              id: "address_line_2",
+              classes: "govuk-!-width-three-quarters",
+              label: { html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>".html_safe },
+            ) %>
 
         <%= govukInput(form: form, key: :city, id: "city", classes: "govuk-input govuk-!-width-two-thirds", label: { text: "Town or city" }) %>
         <%= govukInput(form: form, key: :county, id: "county", classes: "govuk-input govuk-!-width-two-thirds", label: { text: "County" }) %>

--- a/cosmetics-web/app/views/responsible_persons/edit.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/edit.html.erb
@@ -44,23 +44,24 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@responsible_person, method: :put, html: { novalidate: true }) do |form| %>
-      <%= render("form_components/govuk_radios",
-                 form: form,
-                 key: :account_type,
-                 formGroup: { classes: "govuk-!-margin-top-6" },
-                 fieldset: { legend: { html: "Is the <abbr>UK</abbr> Responsible Person a business or an individual?".html_safe,
-                             classes: "govuk-fieldset__legend--s" } },
-                 classes: "govuk-radios--small",
-                 items: [
-                   { html: "Limited company or Limited Liability Partnership (<abbr>LLP</abbr>)".html_safe,
-                     id: "account_type_business",
-                     value: :business,
-                     label: { classes: "govuk-!-padding-bottom-0" } },
-                   { text: "Individual or sole trader",
-                     id: "account_type_individual",
-                     value: :individual,
-                     label: { classes: "govuk-!-padding-bottom-0" } },
-                 ]) %>
+      <%= govukRadios(
+            form: form,
+            key: :account_type,
+            formGroup: { classes: "govuk-!-margin-top-6" },
+            fieldset: { legend: { html: "Is the <abbr>UK</abbr> Responsible Person a business or an individual?".html_safe,
+                        classes: "govuk-fieldset__legend--s" } },
+            classes: "govuk-radios--small",
+            items: [
+              { html: "Limited company or Limited Liability Partnership (<abbr>LLP</abbr>)".html_safe,
+                id: "account_type_business",
+                value: :business,
+                label: { classes: "govuk-!-padding-bottom-0" } },
+              { text: "Individual or sole trader",
+                id: "account_type_individual",
+                value: :individual,
+                label: { classes: "govuk-!-padding-bottom-0" } },
+            ],
+          ) %>
       <fieldset class="govuk-fieldset ">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
           <h2 class="govuk-fieldset__heading">
@@ -71,21 +72,23 @@
           The address of the legal entity named as the Responsible Person.
         </div>
 
-        <%= render("form_components/govuk_input",
-                   form: form,
-                   key: :address_line_1,
-                   id: "address_line_1",
-                   classes: "govuk-!-width-three-quarters",
-                   formGroup: { classes: "govuk-!-margin-bottom-5" },
-                   described_by: "address-hint",
-                   label: { html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>".html_safe }) %>
+        <%= govukInput(
+              form: form,
+              key: :address_line_1,
+              id: "address_line_1",
+              classes: "govuk-!-width-three-quarters",
+              formGroup: { classes: "govuk-!-margin-bottom-5" },
+              described_by: "address-hint",
+              label: { html: "Building and street <span class='govuk-visually-hidden'>line 1 of 2</span>".html_safe },
+            ) %>
 
-        <%= render("form_components/govuk_input",
-                   form: form,
-                   key: :address_line_2,
-                   id: "address_line_2",
-                   classes: "govuk-!-width-three-quarters",
-                   label: { html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>".html_safe }) %>
+        <%= govukInput(
+              form: form,
+              key: :address_line_2,
+              id: "address_line_2",
+              classes: "govuk-!-width-three-quarters",
+              label: { html: "<span class='govuk-visually-hidden'>Building and street line 2 of 2</span>".html_safe },
+            ) %>
 
         <%= govukInput(form: form, key: :city, id: "city", classes: "govuk-input govuk-!-width-two-thirds", label: { text: "Town or city" }) %>
         <%= govukInput(form: form, key: :county, id: "county", classes: "govuk-input govuk-!-width-two-thirds", label: { text: "County" }) %>

--- a/cosmetics-web/app/views/responsible_persons/invitations/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/invitations/new.html.erb
@@ -19,18 +19,16 @@
         <li>submit cosmetic product notifications</li>
         <li>invite team members</li>
       </ul>
-      <%= render("form_components/govuk_input",
-        key: :name,
-        id: "responsible_persons_invite_member_form_name",
-        type: :text,
-        form: form,
-        label: { text: "Full name" }) %>
-      <%= render("form_components/govuk_input",
-        key: :email,
-        id: "responsible_persons_invite_member_form_email",
-        type: :email_field,
-        form: form,
-        label: { text: "Email address" }) %>
+      <%= govukInput(key: :name,
+                     id: "responsible_persons_invite_member_form_name",
+                     type: :text,
+                     form: form,
+                     label: { text: "Full name" }) %>
+      <%= govukInput(key: :email,
+                     id: "responsible_persons_invite_member_form_email",
+                     type: :email_field,
+                     form: form,
+                     label: { text: "Email address" }) %>
 
       <div class="govuk-form-group">
         <%= govukButton text: "Send invitation" %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/product/contains_nanomaterials.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/contains_nanomaterials.html.erb
@@ -22,29 +22,29 @@
         </ul>
 
         <% count_input_html = capture do %>
-          <%= render("form_components/govuk_input",
-                     form: form,
-                     key: :nanomaterials_count,
-                     id: "nanomaterials_count",
-                     label: { text: "How many nanomaterials?" },
-                     classes: "govuk-input--width-3") %>
+          <%= govukInput(form: form,
+                         key: :nanomaterials_count,
+                         id: "nanomaterials_count",
+                         label: { text: "How many nanomaterials?" },
+                         classes: "govuk-input--width-3") %>
         <% end %>
-        <%= render("form_components/govuk_radios",
-                   form: form,
-                   key: :contains_nanomaterials,
-                   fieldset: { legend: { text: "Does #{@notification.product_name} contain nanomaterials?",
-                   classes: "govuk-label--m" } },
-                   items: [
-                     { text: "Yes",
-                       value: "yes",
-                       id: "contains_nanomaterials_yes",
-                       conditional: { html: count_input_html },
-                       checked: errors.include?(:nanomaterials_count) || form.object.contains_nanomaterials? },
-                     { text: "No",
-                       value: "no",
-                       id: "contains_nanomaterials_no",
-                       checked: errors.exclude?(:nanomaterials_count) && answer_checked?("no") },
-                    ]) %>
+        <%= govukRadios(
+              form: form,
+              key: :contains_nanomaterials,
+              fieldset: { legend: { text: "Does #{@notification.product_name} contain nanomaterials?",
+              classes: "govuk-label--m" } },
+              items: [
+                { text: "Yes",
+                  value: "yes",
+                  id: "contains_nanomaterials_yes",
+                  conditional: { html: count_input_html },
+                  checked: errors.include?(:nanomaterials_count) || form.object.contains_nanomaterials? },
+                { text: "No",
+                  value: "no",
+                  id: "contains_nanomaterials_no",
+                  checked: errors.exclude?(:nanomaterials_count) && answer_checked?("no") },
+              ],
+            ) %>
         <%= govukButton text: "Continue" %>
 
       </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
@@ -30,32 +30,33 @@
         </p>
 
         <% count_input_html = capture do %>
-          <%= render("form_components/govuk_input",
-                     form: form,
-                     key: :components_count,
-                     id: "components_count",
-                     classes: "govuk-input--width-3",
-                     label: { text: "How many items does it contain?" },
-                     value: @notification.components_count > 0 ? @notification.components_count : '') %>
+          <%= govukInput(form: form,
+                         key: :components_count,
+                         id: "components_count",
+                         classes: "govuk-input--width-3",
+                         label: { text: "How many items does it contain?" },
+                         value: @notification.components_count > 0 ? @notification.components_count : '') %>
         <% end %>
-        <%= render("form_components/govuk_radios",
-                   form: form,
-                   key: :single_or_multi_component,
-                   hint: { text: "The product draft is currently a single item product. You can add more items by making it a multi-item kit.", classes: "govuk-!-font-size-16 govuk-!-width-three-quarters govuk-!-margin-botton-6", id: "single_or_multi_component_form_single_or_multi_component-hint" },
-                   fieldset: { legend: { text: "Is the product a multi-item kit?", classes: "govuk-label--m"}},
-                   items: [
-                     { text: "Yes",
-                       value: "multiple",
-                       id: "single_or_multi_component_multiple",
-                       conditional: { html: count_input_html },
-                       checked: errors.include?(:components_count) || form.object.multi_component? },
-                     { text: "No, this is a single product",
-                       value: "single",
-                       id: "single_or_multi_component_single",
-                       checked: errors.exclude?(:components_count) &&
-                                  (form.object.single_component? || (form.object.multi_component? && @notification.components.count == 1)) },
-                   ]
-                  ) %>
+        <%= govukRadios(
+              form: form,
+              key: :single_or_multi_component,
+              hint: { text: "The product draft is currently a single item product. You can add more items by making it a multi-item kit.",
+                      classes: "govuk-!-font-size-16 govuk-!-width-three-quarters govuk-!-margin-botton-6",
+                      id: "single_or_multi_component_form_single_or_multi_component-hint" },
+              fieldset: { legend: { text: "Is the product a multi-item kit?", classes: "govuk-label--m"}},
+              items: [
+                { text: "Yes",
+                  value: "multiple",
+                  id: "single_or_multi_component_multiple",
+                  conditional: { html: count_input_html },
+                  checked: errors.include?(:components_count) || form.object.multi_component? },
+                { text: "No, this is a single product",
+                  value: "single",
+                  id: "single_or_multi_component_single",
+                  checked: errors.exclude?(:components_count) &&
+                            (form.object.single_component? || (form.object.multi_component? && @notification.components.count == 1)) },
+              ],
+            ) %>
         <%= govukButton text: "Continue" %>
       </div>
     </div>

--- a/cosmetics-web/app/views/responsible_persons/select.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/select.html.erb
@@ -24,14 +24,15 @@
         </h1>
       <% end %>
 
-      <%= render("form_components/govuk_radios",
-                form: form,
-                key: :selection,
-                idPrefix: "change-rp",
-                fieldset: { legend: { html: heading, classes: "govuk-fieldset__legend govuk-fieldset__legend--l" } },
-                hint: previous_present ? { text: "Replace #{ @responsible_persons_selection_form.previous.name } as the Responsible Person."  } : nil,
-                classes: "govuk-!-padding-top-3 govuk-!-padding-bottom-1",
-                items: @responsible_persons_selection_form.radio_items) %>
+      <%= govukRadios(
+            form: form,
+            key: :selection,
+            idPrefix: "change-rp",
+            fieldset: { legend: { html: heading, classes: "govuk-fieldset__legend govuk-fieldset__legend--l" } },
+            hint: previous_present ? { text: "Replace #{ @responsible_persons_selection_form.previous.name } as the Responsible Person."  } : nil,
+            classes: "govuk-!-padding-top-3 govuk-!-padding-bottom-1",
+            items: @responsible_persons_selection_form.radio_items,
+          ) %>
       <div class="govuk-button-group">
         <%= govukButton text: "Save and continue" %>
         <%= link_to("Cancel",


### PR DESCRIPTION
Since the upgrade to Govuk Design System Rails gem to v0.9.x, we can
directly call the helper instead of rendering the partial.

Follow up from #2561. 

I forgot to check for `render("component...` and render("form_component...` (both with parenthesis) when replacing the render with helper calls.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
