### PR TITLE
Fix missing shades inputs

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -71,7 +71,7 @@ class ResponsiblePersons::Notifications::Components::BuildController < SubmitApp
     when :select_nanomaterials
       return jump_to_step(:number_of_shades) if @component.notification.nano_materials.blank?
     when :add_shades
-      @component.shades = ["", ""] if @component.shades.nil?
+      @component.shades = ["", ""] if @component.shades.blank?
     when :add_cmrs
       create_required_cmrs
     when :after_select_nanomaterials_routing

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -192,7 +192,7 @@ private
   def update_add_shades
     @component.update(component_params)
 
-    if params.key?(:add_shade) && params[:add_shade]
+    if params[:add_shade]
       @component.shades.push ""
       render :add_shades
     elsif params.key?(:remove_shade_with_id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
## Description
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1376)

The check over the component having `nil` as shades value works fine for pre-creating two empty shades when reaching the "add shades" page for the first time.

The problem is that when the user skips the addition of the shades by not introducing any value in the shades fields, the component shades value will become an empty array `[]`.

This is not very consistent from a model data point, and we will probably want to migrate all production data to ensure we go for either `nil` or `[]` as shades attribute value when the component has no shades.

Besides that, there is a user interface issue when not filling any shades and then re-visiting the step and moving back to the same point again.

With the current code, a component with shades `[]` won't match the condition to display two empty shades in the form so the form will be displayed without any input field.

Checking that there are no shades (empty array or nil) resolves this and ensures user flow consistency. Either when visiting it for the first time or revisiting it.


## Screenshots of flow to reproduce the bug
![Screenshot from 2022-08-19 11-58-31](https://user-images.githubusercontent.com/1227578/185609905-1f826c62-5b6a-448e-92af-f009037f0a4f.png)
![Screenshot from 2022-08-19 11-58-42](https://user-images.githubusercontent.com/1227578/185609920-43fdd94f-2732-4c3a-9b01-0c5af13cd269.png)
![Screenshot from 2022-08-19 11-58-53](https://user-images.githubusercontent.com/1227578/185609926-2736f2ce-cd07-4749-b6fd-5618f86ba377.png)
![Screenshot from 2022-08-19 11-59-05](https://user-images.githubusercontent.com/1227578/185609936-2a97257d-2ebb-4691-82e8-995fb77d01e2.png)
![Screenshot from 2022-08-19 12-00-27](https://user-images.githubusercontent.com/1227578/185609942-d924df69-8e02-47a1-9b23-c099723458d1.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2572-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2572-search-web.london.cloudapps.digital/


