### PR TITLE
Fix error when removing images without JS-enabled

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/product/add_product_image.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/add_product_image.html.erb
@@ -29,13 +29,18 @@
                   <%= link_to(image.filename, url_for(image.file), class: "govuk-link govuk-link--no-visited-state") %>
                 </th>
                 <td class="govuk-table__cell">
-                  <%=
-                    if image_count > 1
-                      link_to("Remove <span class='govuk-visually-hidden'>#{image.filename}</span>".html_safe,
-                              responsible_person_notification_draft_delete_product_image_path(@notification.responsible_person, @notification, image_id: image.id),
-                              method: :delete)
-                    end
-                  %>
+                  <% if image_count > 1 %>
+                    <%=
+                      deletion_url = responsible_person_notification_draft_delete_product_image_path(@notification.responsible_person,
+                                                                                                     @notification,
+                                                                                                     image_id: image.id)
+                      form_with(url: deletion_url, method: :delete) do |f|
+                        govukButton(type: :submit,
+                                    classes: "govuk-button--secondary",
+                                    html: "Remove <span class='govuk-visually-hidden'>#{image.filename}</span>".html_safe)
+                      end
+                    %>
+                  <% end %>
                 </td>
               </tr>
           <% end %>

--- a/cosmetics-web/spec/features/notification_wizard/adding_and_removing_label_images_spec.rb
+++ b/cosmetics-web/spec/features/notification_wizard/adding_and_removing_label_images_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
       click_button "Save and upload another image"
       expect_product_label_images(["testImage.png", "testLabelImage.jpg"])
 
-      click_link("Remove", match: :first)
+      click_button("Remove", match: :first)
       expect_product_label_images(["testImage.png"])
 
       click_button "Save and continue"

--- a/cosmetics-web/spec/support/helpers/product_wizard.rb
+++ b/cosmetics-web/spec/support/helpers/product_wizard.rb
@@ -103,9 +103,9 @@ def expect_product_label_images(images_names)
       expect(page).to have_link(name)
     end
     if images_count > 1
-      expect(page).to have_link("Remove", count: images_count)
+      expect(page).to have_button("Remove", count: images_count)
     else
-      expect(page).not_to have_link("Remove")
+      expect(page).not_to have_button("Remove")
     end
   end
 end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1199)

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
When browsing without JS enabled, the link to remove an image was triggering a server error.
This is caused by the delete links mapping to an AJAX call that cannot be executed without JavaScript.

Fixed it by replacing the deletion link with a deletion button that triggers a form POST request.

### When JS is enabled
![Screenshot from 2022-08-23 14-21-46](https://user-images.githubusercontent.com/1227578/186177873-d168b491-83d8-467e-b8b3-7f9bf8714520.png)

### When JS is disabled/not available
![image](https://user-images.githubusercontent.com/1227578/186178323-4d7b7702-2cd9-4ad5-a083-5e765a3a1435.png)

## Review apps



<!--- Edit links after PR is created -->
https://cosmetics-pr-2575-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2575-search-web.london.cloudapps.digital/
