### PR TITLE
Split for_list logic between model & controller

### DIFF
--- a/cosmetics-web/app/controllers/poison_centres/ingredients_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/ingredients_controller.rb
@@ -2,6 +2,14 @@ class PoisonCentres::IngredientsController < SearchApplicationController
   PER_PAGE = 20
 
   def index
-    @ingredients = Ingredient.for_list(order: params[:sort_by]).page(params[:page]).per(PER_PAGE)
+    ingredient_list = case params[:sort_by]
+                      when "date"
+                        Ingredient.unique_names_by_created_last
+                      when "name_desc"
+                        Ingredient.unique_names.by_name_desc
+                      else
+                        Ingredient.unique_names.by_name_asc
+                      end
+    @ingredients = ingredient_list.page(params[:page]).per(PER_PAGE)
   end
 end

--- a/cosmetics-web/spec/models/ingredient_spec.rb
+++ b/cosmetics-web/spec/models/ingredient_spec.rb
@@ -130,24 +130,22 @@ RSpec.describe Ingredient, type: :model do
     end
   end
 
-  describe ".for_list" do
-    context "when asked to order by date" do
-      let(:ingredient1) { create(:exact_ingredient, inci_name: "NaCl", created_at: 2.days.ago) }
-      let(:ingredient2) { create(:exact_ingredient, inci_name: "Aqua", created_at: 1.week.ago) }
-      let(:ingredient3) { create(:exact_ingredient, inci_name: "Sodium", created_at: 2.weeks.ago) }
-      let(:ingredient4) { create(:exact_ingredient, inci_name: "Aqua", created_at: 3.weeks.ago) }
+  describe ".unique_names_by_created_last" do
+    let(:ingredient1) { create(:exact_ingredient, inci_name: "NaCl", created_at: 2.days.ago) }
+    let(:ingredient2) { create(:exact_ingredient, inci_name: "Aqua", created_at: 1.week.ago) }
+    let(:ingredient3) { create(:exact_ingredient, inci_name: "Sodium", created_at: 2.weeks.ago) }
+    let(:ingredient4) { create(:exact_ingredient, inci_name: "Aqua", created_at: 3.weeks.ago) }
 
-      before do
-        ingredient1
-        ingredient2
-        ingredient3
-        ingredient4
-      end
+    before do
+      ingredient1
+      ingredient2
+      ingredient3
+      ingredient4
+    end
 
-      it "displays correct data" do
-        result = described_class.for_list(order: "date")
-        expect(result.map(&:id)).to eq([ingredient1.id, ingredient3.id, ingredient4.id])
-      end
+    it "returns unique ingredients from newest to oldest creation" do
+      expect(described_class.unique_names_by_created_last.map(&:id))
+        .to eq([ingredient1.id, ingredient3.id, ingredient4.id])
     end
   end
 end

--- a/cosmetics-web/spec/requests/ingredient_list_spec.rb
+++ b/cosmetics-web/spec/requests/ingredient_list_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Ingredient list", type: :request do
+  include RSpecHtmlMatchers
+
+  let(:ingredient1) { create(:exact_ingredient, inci_name: "NaCl", created_at: 2.days.ago) }
+  let(:ingredient2) { create(:exact_ingredient, inci_name: "Aqua", created_at: 1.week.ago) }
+  let(:ingredient3) { create(:exact_ingredient, inci_name: "Sodium", created_at: 2.weeks.ago) }
+  let(:ingredient4) { create(:exact_ingredient, inci_name: "Aqua", created_at: 3.weeks.ago) }
+
+  before do
+    ingredient1
+    ingredient2
+    ingredient3
+    ingredient4
+  end
+
+  describe "GET #index" do
+    before do
+      sign_in_as_poison_centre_user
+    end
+
+    RSpec.shared_examples "unique ingredient names" do
+      it "returns unique ingredient names" do
+        within("ul.govuk-list--bullet li") do
+          expect(response.body).to have_tag("a.govuk-link", count: 3)
+                               .and have_tag("a.govuk-link", text: "Aqua", count: 1)
+                               .and have_tag("a.govuk-link", text: "Sodium", count: 1)
+                               .and have_tag("a.govuk-link", text: "NaCl", count: 1)
+        end
+      end
+    end
+
+    context "when sorting by date" do
+      before do
+        get poison_centre_ingredients_path(sort_by: "date")
+      end
+
+      include_examples "unique ingredient names"
+
+      it "orders ingredients from last to first added" do
+        expect(response.body).to match(/NaCl.*Sodium.*Aqua/m)
+      end
+    end
+
+    context "when sorting by name_desc" do
+      before do
+        get poison_centre_ingredients_path(sort_by: "name_desc")
+      end
+
+      include_examples "unique ingredient names"
+
+      it "orders ingredients by name from last to first" do
+        expect(response.body).to match(/Sodium.*NaCl.*Aqua/m)
+      end
+    end
+
+    context "when sorting by name_asc" do
+      before do
+        get poison_centre_ingredients_path(sort_by: "name_asc")
+      end
+
+      include_examples "unique ingredient names"
+
+      it "orders ingredients by name from last to first" do
+        expect(response.body).to match(/Aqua.*NaCl.*Sodium/m)
+      end
+    end
+
+    context "without sorting parameter" do
+      before do
+        get poison_centre_ingredients_path
+      end
+
+      include_examples "unique ingredient names"
+
+      it "orders ingredients by name from last to first" do
+        expect(response.body).to match(/Aqua.*NaCl.*Sodium/m)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Ingredient.for_list(param)` is wrapping both controller and model logic.

This refactor proposal splits this between:
- Model fetching specific sets of data through scopes.
- Controller is in charge of querying the model for different data based on the order parameters.
