### PR TITLE
Show review period end in nanomaterial notification pages

### DIFF
--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -48,6 +48,7 @@
               <th class="govuk-visually-hidden">&nbsp;</th>
               <th id="uknotified" scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
               <th id="eunotified" scope="col" class="govuk-table__header"><abbr>EU</abbr> notified</th>
+              <th id="reviewperiodenddate" scope="col" class="govuk-table__header">6 month review period end</th>
               <th id="uknumber" scope="col" class="govuk-table__header"><abbr>UK</abbr> nanomaterial number</th>
           </tr>
         </thead>
@@ -80,6 +81,9 @@
                     else
                       "No"
                     end %>
+              </td>
+              <td headers="reviewperiodenddate <%= item %> <%= meta %>" class="govuk-table__cell">
+                <%= display_full_month_date notification.can_be_made_available_on_uk_market_from %>
               </td>
               <td headers="uknumber <%= item %> <%= meta %>" class="govuk-table__cell">
                 <abbr>UKN</abbr>-<%= notification.id %>

--- a/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/show.html.erb
@@ -24,14 +24,6 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Notified in the <abbr>UK</abbr>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= display_full_month_date @nanomaterial_notification.submitted_at %>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
           Notified in the <abbr>EU</abbr>
         </dt>
         <dd class="govuk-summary-list__value">
@@ -40,6 +32,22 @@
               else
                 "No"
               end %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Notified in the <abbr>UK</abbr>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= display_full_month_date @nanomaterial_notification.submitted_at %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Review period end
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= display_full_month_date @nanomaterial_notification.can_be_made_available_on_uk_market_from %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
       end
     end
 
-    scenario "CSV downloas link is invisible when no nano notifications" do
+    scenario "CSV download link is invisible when no nano notifications" do
       visit "/responsible_persons/#{responsible_person.id}/nanomaterials"
 
       expect(page).not_to have_selector("a", text: "Download a CSV file of notified nanomaterials")
@@ -63,6 +63,7 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     expect(page).to have_link("My nanomaterial")
     expect(page).to have_selector("td[headers='uknotified item-1 meta-1']", text: "10 June 2021")
     expect(page).to have_selector("td[headers='eunotified item-1 meta-1']", text: "No")
+    expect(page).to have_selector("td[headers='reviewperiodenddate item-1 meta-1']", text: "10 December 2021")
     expect(page).to have_selector("td[headers='uknumber item-1 meta-1']", text: "UKN-#{id}")
 
     click_link("My nanomaterial")
@@ -103,6 +104,7 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     expect(page).to have_link("My EU nanomaterial")
     expect(page).to have_selector("td[headers='uknotified item-1 meta-1']", text: "10 June 2021")
     expect(page).to have_selector("td[headers='eunotified item-1 meta-1']", text: "1 February 2017")
+    expect(page).to have_selector("td[headers='reviewperiodenddate item-1 meta-1']", text: "1 August 2017")
     expect(page).to have_selector("td[headers='uknumber item-1 meta-1']", text: "UKN-#{id}")
 
     click_link("My EU nanomaterial")

--- a/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/features/nanomaterial_notifications_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     expect(page).to have_h1("My nanomaterial")
     expect(page).to have_summary_item(key: "Notified in the UK", value: "10 June 2021")
     expect(page).to have_summary_item(key: "Notified in the EU", value: "No")
+    expect(page).to have_summary_item(key: "Review period end", value: "10 December 2021")
     expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{id}")
     expect(page).to have_summary_item(key: "PDF file", value: "testPdf.pdf")
   end
@@ -112,6 +113,7 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     expect(page).to have_h1("My EU nanomaterial")
     expect(page).to have_summary_item(key: "Notified in the UK", value: "10 June 2021")
     expect(page).to have_summary_item(key: "Notified in the EU", value: "1 February 2017")
+    expect(page).to have_summary_item(key: "Review period end", value: "1 August 2017")
     expect(page).to have_summary_item(key: "UK nanomaterial number", value: "UKN-#{id}")
     expect(page).to have_summary_item(key: "PDF file", value: "testPdf.pdf")
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
Jira tickets [1540](https://regulatorydelivery.atlassian.net/browse/COSBETA-1540) and [1541](https://regulatorydelivery.atlassian.net/browse/COSBETA-1541)

## Description
<!--- Describe your changes in detail -->
Add the "Review period end" date on the Nanomaterial Notification index page and each individual Nanomaterial Notification page.
![image](https://user-images.githubusercontent.com/1227578/187461627-9870da89-9827-4148-80f5-c1eb6f06719c.png)

----

![image](https://user-images.githubusercontent.com/1227578/187461727-19daae5d-2175-4f1b-8223-792712152593.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2582-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2582-search-web.london.cloudapps.digital/
