### PR TITLE
Dont run reindexing on delete

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -247,7 +247,6 @@ class Notification < ApplicationRecord
       self.state = :deleted
 
       save!(validate: false)
-      ReindexOpensearchJob.perform_later
     end
   end
 


### PR DESCRIPTION
Looks like reindexing causes inaccurate search results.  Later we might find a non-invasive way of reindexing. We are still reindexing entire OS cluster at night.