### PR TITLE
Change nanomaterial journey

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
@@ -5,8 +5,8 @@ class ResponsiblePersons::Notifications::Nanomaterials::BuildController < Submit
   before_action :set_notification
   before_action :set_nano_element
 
-  steps :add_nanomaterial_name,
-        :select_purposes,
+  steps :select_purposes,
+        :add_nanomaterial_name,
         :after_select_purposes_routing, # step to do routing after select purposes
         :confirm_restrictions,
         :confirm_usage,
@@ -22,7 +22,7 @@ class ResponsiblePersons::Notifications::Nanomaterials::BuildController < Submit
   # In case of array, the first block that evaluates to true will determine back page
   BACK_ROUTING = {
     # first 3 checkboxes
-    select_purposes: :add_nanomaterial_name,
+    add_nanomaterial_name: :select_purposes,
     confirm_restrictions: :select_purposes,
     confirm_usage: :confirm_restrictions,
     non_standard_nanomaterial_notified: {

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
@@ -103,7 +103,7 @@ module  ResponsiblePersons::Notifications::Nanomaterials
     end
 
     def purpose_params
-      form_params = params.permit(purposes_form: [:purpose_type, *NanoElementPurposes.predefined.map(&:name)])
+      form_params = params.permit(purposes_form: [:purpose_type, *NanoElementPurposes.standard.map(&:name)])
                           .fetch(:purposes_form, {})
 
       { purposes: form_params.select { |_, v| v == "1" }.keys, purpose_type: form_params[:purpose_type] }

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
@@ -101,7 +101,7 @@ private
 
   def purpose_params
     selected_purposes = params
-        .permit(nano_element: NanoElement.purposes).fetch(:nano_element, {})
+        .permit(nano_element: NanoElementPurposes.all).fetch(:nano_element, {})
         .select { |_, value| value == "1" }.keys
     { purposes: selected_purposes }
   end

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
@@ -7,8 +7,8 @@ module  ResponsiblePersons::Notifications::Nanomaterials
     before_action :set_nano_element
 
     steps :select_purposes,
-          :add_nanomaterial_name,
           :after_select_purposes_routing, # step to do routing after select purposes
+          :add_nanomaterial_name,
           :confirm_restrictions,
           :confirm_usage,
           :after_standard_nanomaterial_routing, # step to check if non standard route needs to take place
@@ -48,7 +48,7 @@ module  ResponsiblePersons::Notifications::Nanomaterials
         if @nano_element.non_standard? && @nano_element.purposes.one?
           return jump_to_step(:non_standard_nanomaterial_notified)
         else
-          return jump_to_step(:confirm_restrictions)
+          return jump_to_step(:add_nanomaterial_name)
         end
       when :after_standard_nanomaterial_routing
         if @nano_element.non_standard?

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
@@ -100,10 +100,15 @@ private
   end
 
   def purpose_params
-    selected_purposes = params
-        .permit(nano_element: NanoElementPurposes.all).fetch(:nano_element, {})
-        .select { |_, value| value == "1" }.keys
-    { purposes: selected_purposes }
+    form_params = params.permit(nano_element: [:purpose_type, *NanoElementPurposes.predefined]).fetch(:nano_element, {})
+    purpose_type = form_params[:purpose_type]
+    return { purposes: [] } unless purpose_type
+
+    if purpose_type == NanoElementPurposes.other.name
+      { purposes: [NanoElementPurposes.other.name] }
+    else
+      { purposes: form_params.select { |_, v| v == "1" }.keys }
+    end
   end
 
   def update_select_purposes_step

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials/build_controller.rb
@@ -1,178 +1,179 @@
-class ResponsiblePersons::Notifications::Nanomaterials::BuildController < SubmitApplicationController
-  include Wicked::Wizard
-  include WizardConcern
+module  ResponsiblePersons::Notifications::Nanomaterials
+  class BuildController < SubmitApplicationController
+    include Wicked::Wizard
+    include WizardConcern
 
-  before_action :set_notification
-  before_action :set_nano_element
+    before_action :set_notification
+    before_action :set_nano_element
 
-  steps :select_purposes,
-        :add_nanomaterial_name,
-        :after_select_purposes_routing, # step to do routing after select purposes
-        :confirm_restrictions,
-        :confirm_usage,
-        :after_standard_nanomaterial_routing, # step to check if non standard route needs to take place
-        :non_standard_nanomaterial_notified, # when non standard
-        :when_products_containing_nanomaterial_can_be_placed_on_market,
-        :notify_your_nanomaterial, # FLOW TERMINATION
-        :must_be_listed, # used when confirm restrictions fails - FLOW TERMINATION
-        :must_conform_to_restrictions, # used when confirm usage fails - FLOW TERMINATION
-        :completed
+    steps :select_purposes,
+          :add_nanomaterial_name,
+          :after_select_purposes_routing, # step to do routing after select purposes
+          :confirm_restrictions,
+          :confirm_usage,
+          :after_standard_nanomaterial_routing, # step to check if non standard route needs to take place
+          :non_standard_nanomaterial_notified, # when non standard
+          :when_products_containing_nanomaterial_can_be_placed_on_market,
+          :notify_your_nanomaterial, # FLOW TERMINATION
+          :must_be_listed, # used when confirm restrictions fails - FLOW TERMINATION
+          :must_conform_to_restrictions, # used when confirm usage fails - FLOW TERMINATION
+          :completed
 
-  # Key is current page, value is page to go back to.
-  # In case of array, the first block that evaluates to true will determine back page
-  BACK_ROUTING = {
-    # first 3 checkboxes
-    add_nanomaterial_name: :select_purposes,
-    confirm_restrictions: :select_purposes,
-    confirm_usage: :confirm_restrictions,
-    non_standard_nanomaterial_notified: {
-      confirm_usage: -> { @nano_element.multi_purpose? },
-      select_purposes: -> { !@nano_element.multi_purpose? },
-    },
-    when_products_containing_nanomaterial_can_be_placed_on_market: :non_standard_nanomaterial_notified,
-    notify_your_nanomaterial: :non_standard_nanomaterial_notified,
-    must_be_listed: :confirm_restrictions,
-    must_conform_to_restrictions: :confirm_usage,
-  }.freeze
+    # Key is current page, value is page to go back to.
+    # In case of array, the first block that evaluates to true will determine back page
+    BACK_ROUTING = {
+      # first 3 checkboxes
+      add_nanomaterial_name: :select_purposes,
+      confirm_restrictions: :select_purposes,
+      confirm_usage: :confirm_restrictions,
+      non_standard_nanomaterial_notified: {
+        confirm_usage: -> { @nano_element.multi_purpose? },
+        select_purposes: -> { !@nano_element.multi_purpose? },
+      },
+      when_products_containing_nanomaterial_can_be_placed_on_market: :non_standard_nanomaterial_notified,
+      notify_your_nanomaterial: :non_standard_nanomaterial_notified,
+      must_be_listed: :confirm_restrictions,
+      must_conform_to_restrictions: :confirm_usage,
+    }.freeze
 
-  def new
-    redirect_to wizard_path(steps.first)
-  end
-
-  def show
-    case step
-    when :after_select_purposes_routing
-      if @nano_element.non_standard? && @nano_element.purposes.one?
-        return jump_to_step(:non_standard_nanomaterial_notified)
-      else
-        return jump_to_step(:confirm_restrictions)
-      end
-    when :after_standard_nanomaterial_routing
-      if @nano_element.non_standard?
-        return jump_to_step(:non_standard_nanomaterial_notified)
-      else
-        return jump_to_step(:completed)
-      end
-    when :completed
-      @notification.reload.try_to_complete_nanomaterials!
-      return render "responsible_persons/notifications/task_completed"
+    def new
+      redirect_to wizard_path(steps.first)
     end
 
-    render_wizard
-  end
+    def show
+      case step
+      when :select_purposes
+        @purposes_form = NanoElementPurposesForm.new(purposes: @nano_element.purposes)
+      when :after_select_purposes_routing
+        if @nano_element.non_standard? && @nano_element.purposes.one?
+          return jump_to_step(:non_standard_nanomaterial_notified)
+        else
+          return jump_to_step(:confirm_restrictions)
+        end
+      when :after_standard_nanomaterial_routing
+        if @nano_element.non_standard?
+          return jump_to_step(:non_standard_nanomaterial_notified)
+        else
+          return jump_to_step(:completed)
+        end
+      when :completed
+        @notification.reload.try_to_complete_nanomaterials!
+        return render "responsible_persons/notifications/task_completed"
+      end
 
-  def update
-    case step
-    when :select_purposes
-      update_select_purposes_step
-    when :confirm_restrictions
-      update_confirm_restrictions_step
-    when :confirm_usage
-      update_confirm_usage_step
-    when :non_standard_nanomaterial_notified
-      update_non_standard_nanomaterial_step
-    when :when_products_containing_nanomaterial_can_be_placed_on_market
-      jump_to_step(:completed)
-    else
-      if @nano_element.update_with_context(nano_element_params, step)
+      render_wizard
+    end
+
+    def update
+      case step
+      when :select_purposes
+        update_select_purposes_step
+      when :confirm_restrictions
+        update_confirm_restrictions_step
+      when :confirm_usage
+        update_confirm_usage_step
+      when :non_standard_nanomaterial_notified
+        update_non_standard_nanomaterial_step
+      when :when_products_containing_nanomaterial_can_be_placed_on_market
+        jump_to_step(:completed)
+      else
+        if @nano_element.update_with_context(nano_element_params, step)
+          render_next_step @nano_element
+        else
+          rerender_current_step
+        end
+      end
+    end
+
+  private
+
+    def set_nano_element
+      @nano_element = NanoElement.find(params[:nanomaterial_nano_element_id])
+      @notification = @nano_element.nano_material.notification
+    end
+
+    def nano_element_params
+      params.fetch(:nano_element, {}).permit(
+        :inci_name,
+        :confirm_restrictions,
+        :purposes,
+        :confirm_usage,
+        :confirm_toxicology_notified,
+      )
+    end
+
+    def purpose_params
+      form_params = params.permit(purposes_form: [:purpose_type, *NanoElementPurposes.predefined.map(&:name)])
+                          .fetch(:purposes_form, {})
+
+      { purposes: form_params.select { |_, v| v == "1" }.keys, purpose_type: form_params[:purpose_type] }
+    end
+
+    def update_select_purposes_step
+      @purposes_form = NanoElementPurposesForm.new(**purpose_params)
+
+      if @purposes_form.valid? && @nano_element.update_with_context({ purposes: @purposes_form.purposes }, step)
         render_next_step @nano_element
       else
         rerender_current_step
       end
     end
-  end
 
-private
+    def update_confirm_restrictions_step
+      confirm_restrictions = params.dig(:nano_element, :confirm_restrictions)
 
-  def set_nano_element
-    @nano_element = NanoElement.find(params[:nanomaterial_nano_element_id])
-    @notification = @nano_element.nano_material.notification
-  end
-
-  def nano_element_params
-    params.fetch(:nano_element, {}).permit(
-      :inci_name,
-      :confirm_restrictions,
-      :purposes,
-      :confirm_usage,
-      :confirm_toxicology_notified,
-    )
-  end
-
-  def purpose_params
-    form_params = params.permit(nano_element: [:purpose_type, *NanoElementPurposes.predefined]).fetch(:nano_element, {})
-    purpose_type = form_params[:purpose_type]
-    return { purposes: [] } unless purpose_type
-
-    if purpose_type == NanoElementPurposes.other.name
-      { purposes: [NanoElementPurposes.other.name] }
-    else
-      { purposes: form_params.select { |_, v| v == "1" }.keys }
+      @nano_element.update_with_context(nano_element_params, step)
+      case confirm_restrictions
+      when "yes"
+        redirect_to wizard_path(:confirm_usage)
+      when "no"
+        redirect_to wizard_path(:must_be_listed)
+      else
+        @nano_element.errors.add :confirm_restrictions, "Select an option"
+        rerender_current_step
+      end
     end
-  end
 
-  def update_select_purposes_step
-    if @nano_element.update_with_context(purpose_params, step)
-      render_next_step @nano_element
-    else
-      rerender_current_step
+    def update_confirm_usage_step
+      confirm_usage = params.dig(:nano_element, :confirm_usage)
+
+      @nano_element.update_with_context(nano_element_params, step)
+      case confirm_usage
+      when "yes"
+        render_next_step @nano_element
+      when "no"
+        jump_to_step :must_conform_to_restrictions
+      else
+        @nano_element.errors.add :confirm_usage, "Select an option"
+        rerender_current_step
+      end
     end
-  end
 
-  def update_confirm_restrictions_step
-    confirm_restrictions = params.dig(:nano_element, :confirm_restrictions)
+    def update_non_standard_nanomaterial_step
+      confirm_toxicology_notified = params.dig(:nano_element, :confirm_toxicology_notified)
 
-    @nano_element.update_with_context(nano_element_params, step)
-    case confirm_restrictions
-    when "yes"
-      redirect_to wizard_path(:confirm_usage)
-    when "no"
-      redirect_to wizard_path(:must_be_listed)
-    else
-      @nano_element.errors.add :confirm_restrictions, "Select an option"
-      rerender_current_step
+      @nano_element.update_with_context(nano_element_params, step)
+      case confirm_toxicology_notified
+      when "yes"
+        jump_to_step(:when_products_containing_nanomaterial_can_be_placed_on_market)
+      when "no"
+        jump_to_step(:notify_your_nanomaterial)
+      when "not sure"
+        jump_to_step(:notify_your_nanomaterial)
+      else
+        @nano_element.errors.add :confirm_toxicology_notified, "Select an option"
+        rerender_current_step
+      end
     end
-  end
 
-  def update_confirm_usage_step
-    confirm_usage = params.dig(:nano_element, :confirm_usage)
-
-    @nano_element.update_with_context(nano_element_params, step)
-    case confirm_usage
-    when "yes"
-      render_next_step @nano_element
-    when "no"
-      jump_to_step :must_conform_to_restrictions
-    else
-      @nano_element.errors.add :confirm_usage, "Select an option"
-      rerender_current_step
+    def get_next_nano_element
+      @nano_element.nano_material.nano_elements.order(:id).each_cons(2) do |element, next_element|
+        return next_element if element == @nano_element
+      end
     end
-  end
 
-  def update_non_standard_nanomaterial_step
-    confirm_toxicology_notified = params.dig(:nano_element, :confirm_toxicology_notified)
-
-    @nano_element.update_with_context(nano_element_params, step)
-    case confirm_toxicology_notified
-    when "yes"
-      jump_to_step(:when_products_containing_nanomaterial_can_be_placed_on_market)
-    when "no"
-      jump_to_step(:notify_your_nanomaterial)
-    when "not sure"
-      jump_to_step(:notify_your_nanomaterial)
-    else
-      @nano_element.errors.add :confirm_toxicology_notified, "Select an option"
-      rerender_current_step
+    def model
+      @nano_element
     end
-  end
-
-  def get_next_nano_element
-    @nano_element.nano_material.nano_elements.order(:id).each_cons(2) do |element, next_element|
-      return next_element if element == @nano_element
-    end
-  end
-
-  def model
-    @nano_element
   end
 end

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials_controller.rb
@@ -1,20 +1,25 @@
 class ResponsiblePersons::Notifications::NanomaterialsController < SubmitApplicationController
+  PURPOSES_FORM_CLASS = ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurposesForm
+
   before_action :set_notification
 
   def new
-    @nano_element = NanoElement.new
+    @purposes_form = PURPOSES_FORM_CLASS.new
   end
 
   def create
-    @nano_element = NanoElement.new(nano_element_params.merge(nano_material: @notification.nano_materials.new))
+    @purposes_form = PURPOSES_FORM_CLASS.new(**purpose_params)
+    return render "new" unless @purposes_form.valid?
 
-    if @nano_element.save(context: :add_nanomaterial_name)
+    nano_element = NanoElement.new(purposes: @purposes_form.purposes, nano_material: @notification.nano_materials.new)
+
+    if nano_element.save(context: :select_purposes)
       @notification.update_state(NotificationStateConcern::READY_FOR_NANOMATERIALS)
       redirect_to responsible_person_notification_nanomaterial_build_path(
         @notification.responsible_person,
         @notification,
-        @nano_element,
-        :select_purposes,
+        nano_element,
+        :after_select_purposes_routing,
       )
     else
       render "new"
@@ -31,7 +36,10 @@ private
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 
-  def nano_element_params
-    params.fetch(:nano_element, {}).permit(:inci_name)
+  def purpose_params
+    form_params = params.permit(purposes_form: [:purpose_type, *NanoElementPurposes.standard.map(&:name)])
+                        .fetch(:purposes_form, {})
+
+    { purposes: form_params.select { |_, v| v == "1" }.keys, purpose_type: form_params[:purpose_type] }
   end
 end

--- a/cosmetics-web/app/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form.rb
@@ -1,6 +1,6 @@
 module ResponsiblePersons::Notifications::Nanomaterials
   class NanoElementPurposesForm < Form
-    PREDEFINED_TYPE = "predefined".freeze
+    STANDARD_TYPE = "standard".freeze
     OTHER_TYPE = NanoElementPurposes.other.name.freeze
     ALLOWED_PURPOSES = NanoElementPurposes.all.map(&:name).freeze
 
@@ -10,8 +10,8 @@ module ResponsiblePersons::Notifications::Nanomaterials
     attr_reader :purpose_type, :purposes
 
     validates :purpose_type, presence: true
-    validates :purpose_type, inclusion: { in: [PREDEFINED_TYPE, OTHER_TYPE] }, allow_blank: true
-    validates :purposes, presence: true, if: -> { purpose_type == PREDEFINED_TYPE }
+    validates :purpose_type, inclusion: { in: [STANDARD_TYPE, OTHER_TYPE] }, allow_blank: true
+    validates :purposes, presence: true, if: -> { purpose_type == STANDARD_TYPE }
     validate :validate_purposes
 
     def initialize(purpose_type: nil, purposes: [])
@@ -26,11 +26,11 @@ module ResponsiblePersons::Notifications::Nanomaterials
       return purpose_type if purpose_type.present?
       return if purposes.blank?
 
-      purposes.include?(OTHER_TYPE) ? OTHER_TYPE : PREDEFINED_TYPE # infers type from purposes
+      purposes.include?(OTHER_TYPE) ? OTHER_TYPE : STANDARD_TYPE # infers type from purposes
     end
 
     def initialize_purposes(purposes, purpose_type)
-      purpose_type == OTHER_TYPE ? [OTHER_TYPE] : purposes # For 'other' type, overrides any given predefined purpose
+      purpose_type == OTHER_TYPE ? [OTHER_TYPE] : purposes # For 'other' type, overrides any given standard purpose
     end
 
     def validate_purposes
@@ -38,7 +38,7 @@ module ResponsiblePersons::Notifications::Nanomaterials
       invalid_purposes.each { |purpose| errors.add(:purposes, message: :inclusion, purpose:) }
 
       if purposes.include?(OTHER_TYPE) && purposes.size > 1
-        errors.add(:purposes, message: :predefined_or_other)
+        errors.add(:purposes, message: :standard_or_other)
       end
     end
   end

--- a/cosmetics-web/app/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form.rb
@@ -1,0 +1,45 @@
+module ResponsiblePersons::Notifications::Nanomaterials
+  class NanoElementPurposesForm < Form
+    PREDEFINED_TYPE = "predefined".freeze
+    OTHER_TYPE = NanoElementPurposes.other.name.freeze
+    ALLOWED_PURPOSES = NanoElementPurposes.all.map(&:name).freeze
+
+    attribute :purpose_type, :string
+    attribute :purposes, array: true, default: []
+
+    attr_reader :purpose_type, :purposes
+
+    validates :purpose_type, presence: true
+    validates :purpose_type, inclusion: { in: [PREDEFINED_TYPE, OTHER_TYPE] }, allow_blank: true
+    validates :purposes, presence: true, if: -> { purpose_type == PREDEFINED_TYPE }
+    validate :validate_purposes
+
+    def initialize(purpose_type: nil, purposes: [])
+      super
+      @purpose_type = initialize_purpose_type(purpose_type, purposes)
+      @purposes = initialize_purposes(purposes, purpose_type)
+    end
+
+  private
+
+    def initialize_purpose_type(purpose_type, purposes)
+      return purpose_type if purpose_type.present?
+      return if purposes.blank?
+
+      purposes.include?(OTHER_TYPE) ? OTHER_TYPE : PREDEFINED_TYPE # infers type from purposes
+    end
+
+    def initialize_purposes(purposes, purpose_type)
+      purpose_type == OTHER_TYPE ? [OTHER_TYPE] : purposes # For 'other' type, overrides any given predefined purpose
+    end
+
+    def validate_purposes
+      invalid_purposes = (purposes - ALLOWED_PURPOSES)
+      invalid_purposes.each { |purpose| errors.add(:purposes, message: :inclusion, purpose:) }
+
+      if purposes.include?(OTHER_TYPE) && purposes.size > 1
+        errors.add(:purposes, message: :predefined_or_other)
+      end
+    end
+  end
+end

--- a/cosmetics-web/app/helpers/nanomaterial_helper.rb
+++ b/cosmetics-web/app/helpers/nanomaterial_helper.rb
@@ -1,10 +1,4 @@
 module NanomaterialHelper
-  def nanomaterial_purpose_options
-    NanoElementPurposes.all.each_with_object({}) do |purpose, h|
-      h[purpose.name] = purpose.display_name.upcase_first
-    end
-  end
-
   def ec_regulation_annex_details_for_nanomaterial_purposes(purposes)
     annex_numbers = purposes.filter_map { |purpose| NanoElementPurposes.find(purpose)&.annex_number }
     "#{'Annex'.pluralize(annex_numbers.count)} #{to_sentence(annex_numbers, last_word_connector: ' and ')}"

--- a/cosmetics-web/app/helpers/nanomaterial_helper.rb
+++ b/cosmetics-web/app/helpers/nanomaterial_helper.rb
@@ -1,50 +1,12 @@
 module NanomaterialHelper
   def get_nanomaterial_purpose_options
-    NanoElement.purposes.index_with { |purpose| get_label_for_nanomaterial_purpose(purpose) }
-  end
-
-  def get_label_for_nanomaterial_purpose(purpose)
-    get_display_name_for_nanomaterial_purpose(purpose).upcase_first
-  end
-
-  def get_display_name_for_nanomaterial_purpose(purpose)
-    DISPLAY_NAME_FOR_PURPOSE[purpose.to_sym]
-  end
-
-  def get_ec_regulation_annex_details_for_nanomaterial_purposes(purposes)
-    annex_numbers = purposes.filter_map { |purpose| get_ec_regulation_annex_number_for_nanomaterial_purpose(purpose) }
-    "#{'Annex'.pluralize(annex_numbers.count)} #{to_sentence(annex_numbers, last_word_connector: ' and ')}"
-  end
-
-  def get_ec_regulation_annex_number_for_nanomaterial_purpose(purpose)
-    ANNEX_NUMBER_FOR_PURPOSE[purpose.to_sym]
-  end
-
-  def get_ec_regulation_link_for_annex_number(annex_number)
-    case annex_number
-    when 4
-      "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223#d1e32-176-1"
-    when 5
-      "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223#d1e32-192-1"
-    when 6
-      "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223#d1e32-201-1"
-    else
-      "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223"
+    NanoElementPurposes.all.each_with_object({}) do |purpose, h|
+      h[purpose.name] = purpose.display_name.upcase_first
     end
   end
 
-  DISPLAY_NAME_FOR_PURPOSE = {
-    colorant: "colourant",
-    preservative: "preservative",
-    uv_filter: "UV filter",
-    other: "another purpose",
-  }.freeze
-
-  ANNEX_NUMBER_FOR_PURPOSE = {
-    colorant: 4,
-    preservative: 5,
-    uv_filter: 6,
-  }.freeze
-
-  private_constant :ANNEX_NUMBER_FOR_PURPOSE, :DISPLAY_NAME_FOR_PURPOSE
+  def get_ec_regulation_annex_details_for_nanomaterial_purposes(purposes)
+    annex_numbers = purposes.filter_map { |purpose| NanoElementPurposes.find(purpose)&.annex_number }
+    "#{'Annex'.pluralize(annex_numbers.count)} #{to_sentence(annex_numbers, last_word_connector: ' and ')}"
+  end
 end

--- a/cosmetics-web/app/helpers/nanomaterial_helper.rb
+++ b/cosmetics-web/app/helpers/nanomaterial_helper.rb
@@ -1,11 +1,11 @@
 module NanomaterialHelper
-  def get_nanomaterial_purpose_options
+  def nanomaterial_purpose_options
     NanoElementPurposes.all.each_with_object({}) do |purpose, h|
       h[purpose.name] = purpose.display_name.upcase_first
     end
   end
 
-  def get_ec_regulation_annex_details_for_nanomaterial_purposes(purposes)
+  def ec_regulation_annex_details_for_nanomaterial_purposes(purposes)
     annex_numbers = purposes.filter_map { |purpose| NanoElementPurposes.find(purpose)&.annex_number }
     "#{'Annex'.pluralize(annex_numbers.count)} #{to_sentence(annex_numbers, last_word_connector: ' and ')}"
   end

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -11,12 +11,8 @@ class NanoElement < ApplicationRecord
     end
   end
 
-  def self.purposes
-    %w[colorant preservative uv_filter other].freeze
-  end
-
   validates :purposes, presence: true, on: :select_purposes
-  validates :purposes, array: { presence: true, inclusion: { in: NanoElement.purposes } }
+  validates :purposes, array: { presence: true, inclusion: { in: NanoElementPurposes.all.map(&:name) } }
 
   def display_name
     [iupac_name, inci_name, inn_name, xan_name, cas_number, ec_number, einecs_number, elincs_number]

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -1,4 +1,8 @@
 class NanoElement < ApplicationRecord
+  YES = "yes".freeze
+  NO = "no".freeze
+  NOT_SURE = "not sure".freeze
+
   belongs_to :nano_material
 
   # TODO: add uniqueness validation across notifications
@@ -38,16 +42,19 @@ class NanoElement < ApplicationRecord
   end
 
   def completed?
-    ((standard? && inci_name.present? && confirm_usage == "yes" && confirm_restrictions == "yes") ||
-      (non_standard? && confirm_toxicology_notified == "yes")) && !blocked?
+    ((standard? && inci_name.present? && confirm_usage == YES && confirm_restrictions == YES) ||
+      (non_standard? && confirm_toxicology_notified == YES)) && !blocked?
   end
 
   def blocked?
-    confirm_usage == "no" || confirm_restrictions == "no" || confirm_toxicology_notified == "no" || confirm_toxicology_notified == "not sure"
+    confirm_usage == NO ||
+      confirm_restrictions == NO ||
+      confirm_toxicology_notified == NO ||
+      confirm_toxicology_notified == NOT_SURE
   end
 
   def toxicology_required?
-    non_standard? && (confirm_toxicology_notified == "not sure" || confirm_toxicology_notified == "no")
+    non_standard? && (confirm_toxicology_notified == NOT_SURE || confirm_toxicology_notified == NO)
   end
 
   def toxicology_required_or_empty?
@@ -55,18 +62,16 @@ class NanoElement < ApplicationRecord
   end
 
   def conforms_to_restrictions?
-    (confirm_restrictions != "no" && confirm_usage != "no") && !toxicology_required_or_empty?
+    (confirm_restrictions != NO && confirm_usage != NO) && !toxicology_required_or_empty?
   end
 
 private
 
   def restrictions_confirmed_required?
     confirm_restrictions.nil? ||
-      (confirm_restrictions == "no") ||
-      (
-        (confirm_restrictions == "yes" && usage_confirmed_required?) ||
-       (confirm_usage == "no" && toxicology_required_or_empty?)
-      )
+      (confirm_restrictions == NO) ||
+      ((confirm_restrictions == YES && usage_confirmed_required?) ||
+       (confirm_usage == NO && toxicology_required_or_empty?))
   end
 
   def usage_confirmed_required?

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -30,7 +30,7 @@ class NanoElement < ApplicationRecord
   end
 
   def non_standard?
-    purposes.present? && purposes.include?("other")
+    purposes.present? && purposes.include?(NanoElementPurposes.other.name)
   end
 
   def multi_purpose?
@@ -39,7 +39,7 @@ class NanoElement < ApplicationRecord
 
   def completed?
     ((standard? && inci_name.present? && confirm_usage == "yes" && confirm_restrictions == "yes") ||
-      (purposes&.include?("other") && confirm_toxicology_notified == "yes")) && !blocked?
+      (non_standard? && confirm_toxicology_notified == "yes")) && !blocked?
   end
 
   def blocked?
@@ -47,7 +47,7 @@ class NanoElement < ApplicationRecord
   end
 
   def toxicology_required?
-    purposes&.include?("other") && (confirm_toxicology_notified == "not sure" || confirm_toxicology_notified == "no")
+    non_standard? && (confirm_toxicology_notified == "not sure" || confirm_toxicology_notified == "no")
   end
 
   def toxicology_required_or_empty?

--- a/cosmetics-web/app/models/nano_element_purposes.rb
+++ b/cosmetics-web/app/models/nano_element_purposes.rb
@@ -1,5 +1,9 @@
 class NanoElementPurposes
-  Purpose = Struct.new(:name, :display_name, :annex_number, :link, keyword_init: true)
+  Purpose = Struct.new(:name, :display_name, :annex_number, :link, keyword_init: true) do
+    def upcase_display_name
+      display_name.upcase_first
+    end
+  end
 
   COLORANT = Purpose.new(
     name: "colorant",

--- a/cosmetics-web/app/models/nano_element_purposes.rb
+++ b/cosmetics-web/app/models/nano_element_purposes.rb
@@ -33,15 +33,15 @@ class NanoElementPurposes
     link: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223",
   ).freeze
 
-  PREDEFINED_PURPOSES = [COLORANT, PRESERVATIVE, UV_FILTER].freeze
-  ALL_PURPOSES = (PREDEFINED_PURPOSES + [OTHER]).freeze
+  STANDARD_PURPOSES = [COLORANT, PRESERVATIVE, UV_FILTER].freeze
+  ALL_PURPOSES = (STANDARD_PURPOSES + [OTHER]).freeze
 
-  private_constant :COLORANT, :PRESERVATIVE, :UV_FILTER, :OTHER, :PREDEFINED_PURPOSES, :ALL_PURPOSES
+  private_constant :COLORANT, :PRESERVATIVE, :UV_FILTER, :OTHER, :STANDARD_PURPOSES, :ALL_PURPOSES
 
   class << self
     def find(purpose) = ALL_PURPOSES.find { |p| p.name == purpose }
     def all = ALL_PURPOSES
-    def predefined = PREDEFINED_PURPOSES
+    def standard = STANDARD_PURPOSES
     def colorant = COLORANT
     def preservative = PRESERVATIVE
     def uv_filter = UV_FILTER

--- a/cosmetics-web/app/models/nano_element_purposes.rb
+++ b/cosmetics-web/app/models/nano_element_purposes.rb
@@ -1,0 +1,46 @@
+class NanoElementPurposes
+  Purpose = Struct.new(:name, :display_name, :annex_number, :link, keyword_init: true)
+
+  COLORANT = Purpose.new(
+    name: "colorant",
+    display_name: "colourant",
+    annex_number: 4,
+    link: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223#d1e32-176-1",
+  ).freeze
+
+  PRESERVATIVE = Purpose.new(
+    name: "preservative",
+    display_name: "preservative",
+    annex_number: 5,
+    link: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223#d1e32-192-1",
+  ).freeze
+
+  UV_FILTER = Purpose.new(
+    name: "uv_filter",
+    display_name: "UV filter",
+    annex_number: 6,
+    link: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223#d1e32-201-1",
+  ).freeze
+
+  OTHER = Purpose.new(
+    name: "other",
+    display_name: "another purpose",
+    annex_number: nil,
+    link: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex:32009R1223",
+  ).freeze
+
+  PREDEFINED_PURPOSES = [COLORANT, PRESERVATIVE, UV_FILTER].freeze
+  ALL_PURPOSES = (PREDEFINED_PURPOSES + [OTHER]).freeze
+
+  private_constant :COLORANT, :PRESERVATIVE, :UV_FILTER, :OTHER, :PREDEFINED_PURPOSES, :ALL_PURPOSES
+
+  class << self
+    def find(purpose) = ALL_PURPOSES.find { |p| p.name == purpose }
+    def all = ALL_PURPOSES
+    def predefined = PREDEFINED_PURPOSES
+    def colorant = COLORANT
+    def preservative = PRESERVATIVE
+    def uv_filter = UV_FILTER
+    def other = OTHER
+  end
+end

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/_purposes_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/_purposes_form.html.erb
@@ -7,7 +7,7 @@
   end
 %>
 
-<%= form_with(model: purposes_form, url: form_url, scope: :purposes_form, method: form_method) do |f| %>
+<%= form_with(model: purposes_form, url: form_url, scope: :purposes_form, method: form_method, html: { novalidate: true }) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= error_summary(purposes_form.errors,

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/_purposes_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/_purposes_form.html.erb
@@ -1,0 +1,39 @@
+<%
+  standard_purposes = NanoElementPurposes.standard
+  standard_purposes_items = standard_purposes.map do |purpose|
+    { key: purpose.name,
+      text: purpose.upcase_display_name,
+      checked: purposes_form.purposes&.include?(purpose.name) }
+  end
+%>
+
+<%= form_with(model: purposes_form, url: form_url, scope: :purposes_form, method: form_method) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= error_summary(purposes_form.errors,
+                        map_errors: { purpose_type: :purposes_form_purpose_type_standard,
+                                      purposes: :purposes_form_colorant }) %>
+      <% standard_purposes_checkboxes_html = capture do %>
+        <%= govukCheckboxes(
+              form: f,
+              key: :purposes,
+              fieldset: { legend: { text: "Select all that apply", isPageHeading: false } },
+              items: standard_purposes_items,
+            ) %>
+      <% end %>
+      <%= govukRadios(
+            form: f,
+            key: :purpose_type,
+            fieldset: { legend: { text: "What is the purpose of this nanomaterial?",
+                                  classes: "govuk-label--l",
+                                  isPageHeading: true } },
+            items: [{ text: to_sentence(standard_purposes.map(&:upcase_display_name), last_word_connector: " or "),
+                      value: "standard",
+                      conditional: { html: standard_purposes_checkboxes_html } },
+                    { text: NanoElementPurposes.other.upcase_display_name,
+                      value: NanoElementPurposes.other.name }]
+          ) %>
+      <%= govukButton text: "Continue" %>
+    </div>
+  </div>
+<% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
@@ -2,7 +2,7 @@
 
 <% page_title title, errors: @nano_element.errors.any? %>
 <% content_for :after_header do %>
-  <%= link_to "Back", responsible_person_notification_draft_path(@notification.responsible_person, @notification), class: "govuk-back-link" %>
+  <%= govukBackLink text: "Back", href: previous_wizard_path %>
 <% end %>
 
 <% input_hint = capture do %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
@@ -8,8 +8,9 @@
 <% input_hint = capture do %>
     <p>This is the International Nomenclature for Cosmetic Ingredients name.</p>
     <p>
-      View the <%= link_to("Annex 4 list of colourants",
-                          get_ec_regulation_link_for_annex_number(4),
+      <% colorant = NanoElementPurposes.colorant %>
+      View the <%= link_to("Annex #{colorant.annex_number} list of colourants",
+                          colorant.link,
                           class: "govuk-link govuk-link--no-visited-state",
                           target: "_blank",
                           rel: "noopener") %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
@@ -5,16 +5,19 @@
   <%= govukBackLink text: "Back", href: previous_wizard_path %>
 <% end %>
 
+<%
+  purposes_links = @nano_element.purposes.map do |purpose_name|
+    purpose = NanoElementPurposes.find(purpose_name)
+    link_to("Annex #{purpose.annex_number} list of #{purpose.display_name.pluralize}",
+             purpose.link,
+             class: "govuk-link govuk-link--no-visited-state",
+             target: "_blank",
+             rel: "noopener")
+  end
+%>
 <% input_hint = capture do %>
     <p>This is the International Nomenclature for Cosmetic Ingredients name.</p>
-    <p>
-      <% colorant = NanoElementPurposes.colorant %>
-      View the <%= link_to("Annex #{colorant.annex_number} list of colourants",
-                          colorant.link,
-                          class: "govuk-link govuk-link--no-visited-state",
-                          target: "_blank",
-                          rel: "noopener") %>
-    </p>
+    <p>View the <%= to_sentence(purposes_links,last_word_connector: " and ").html_safe %></p>
 <% end %>
 
 

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/add_nanomaterial_name.html.erb
@@ -5,17 +5,29 @@
   <%= link_to "Back", responsible_person_notification_draft_path(@notification.responsible_person, @notification), class: "govuk-back-link" %>
 <% end %>
 
+<% input_hint = capture do %>
+    <p>This is the International Nomenclature for Cosmetic Ingredients name.</p>
+    <p>
+      View the <%= link_to("Annex 4 list of colourants",
+                          get_ec_regulation_link_for_annex_number(4),
+                          class: "govuk-link govuk-link--no-visited-state",
+                          target: "_blank",
+                          rel: "noopener") %>
+    </p>
+<% end %>
+
+
 <%= form_with model: @nano_element, url: wizard_path, html: { novalidate: true }, method: :put do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= error_summary_for(@nano_element) %>
       <%= govukInput(form: form,
                      key: :inci_name,
-                     classes: "govuk-!-margin-top-7",
+                     classes: "govuk-!-margin-top-2",
                      label: { html: "What is the nanomaterial <abbr title='International Nomenclature for Cosmetic Ingredients'>INCI</abbr> name?".html_safe ,
                              classes: "govuk-label--l",
                              isPageHeading: true },
-                     hint: { html: 'This is the International Nomenclature for Cosmetic Ingredients name.' }) %>
+                     hint: { html: input_hint }) %>
       <%= govukButton text: "Save and continue" %>
     </div>
   </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_restrictions.html.erb
@@ -6,14 +6,13 @@
   <h1 class="govuk-fieldset__heading govuk-label--l"><%= question %></h1>
 
   <p>
-    <%
-      @nano_element.purposes.reject { |p| p == "other" }.each do |purpose|
-        purpose = NanoElementPurposes.find(purpose)
-        link_text = "Annex #{purpose.annex_number} list of #{purpose.display_name.pluralize}"
-        concat("View the " + link_to(link_text, purpose.link, target: "_blank", rel: "noopener"))
-        concat "<br>"
-      end
-    %>
+    <% @nano_element.purposes.reject { |p| p == "other" }.each do |purpose| %>
+      <% purpose = NanoElementPurposes.find(purpose)
+         link_text = "Annex #{purpose.annex_number} list of #{purpose.display_name.pluralize}" %>
+      View the
+      <%= link_to(link_text, purpose.link, target: "_blank", rel: "noopener") %>
+      <br>
+    <% end %>
   </p>
 <% end %>
 

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_restrictions.html.erb
@@ -6,14 +6,14 @@
   <h1 class="govuk-fieldset__heading govuk-label--l"><%= question %></h1>
 
   <p>
-    <% @nano_element.purposes.reject { |p| p == "other" }.each do |purpose| %>
-      <% purpose_name = get_display_name_for_nanomaterial_purpose(purpose) %>
-      <% annex_number = get_ec_regulation_annex_number_for_nanomaterial_purpose(purpose) %>
-      <% link_text = "Annex #{annex_number} list of #{purpose_name.pluralize}" %>
-      <% link_url = get_ec_regulation_link_for_annex_number(annex_number) %>
-      View the <%= link_to link_text, link_url, target: "_blank", rel: "noopener" %>
-      <br>
-    <% end %>
+    <%
+      @nano_element.purposes.reject { |p| p == "other" }.each do |purpose|
+        purpose = NanoElementPurposes.find(purpose)
+        link_text = "Annex #{purpose.annex_number} list of #{purpose.display_name.pluralize}"
+        concat("View the " + link_to(link_text, purpose.link, target: "_blank", rel: "noopener"))
+        concat "<br>"
+      end
+    %>
   </p>
 <% end %>
 

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_restrictions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_restrictions.html.erb
@@ -1,5 +1,5 @@
 <% title = "Confirm use in accordance with the restrictions" %>
-<% annex_details = get_ec_regulation_annex_details_for_nanomaterial_purposes(@nano_element.purposes) %>
+<% annex_details = ec_regulation_annex_details_for_nanomaterial_purposes(@nano_element.purposes) %>
 <% question = "Is #{@nano_element.inci_name} listed in EC regulation 1223/2009, #{annex_details}?" %>
 
 <% legend_html = capture do %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_usage.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/confirm_usage.html.erb
@@ -1,5 +1,5 @@
 <% title = "Confirm usage" %>
-<% annex_details = get_ec_regulation_annex_details_for_nanomaterial_purposes(@nano_element.purposes) %>
+<% annex_details = ec_regulation_annex_details_for_nanomaterial_purposes(@nano_element.purposes) %>
 <% question = "Does the #{@nano_element.inci_name} conform to the restrictions set out in #{annex_details}?" %>
 
 <% page_title title, errors: @nano_element.errors.any? %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
@@ -1,6 +1,6 @@
 <% title = "Select nanomaterial purpose" %>
-<% question = "What is the purpose of #{@nano_element.inci_name}?" %>
-<% items = get_nanomaterial_purpose_options.map { |purpose, label|
+<% question = "What is the purpose of this nanomaterial?" %>
+<% items = nanomaterial_purpose_options.map { |purpose, label|
     { key: purpose, text: label, checked: @nano_element.purposes&.include?(purpose), disable_ghost: true }
   } %>
 

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
@@ -1,8 +1,13 @@
-<% title = "Select nanomaterial purpose" %>
-<% question = "What is the purpose of this nanomaterial?" %>
-<% items = nanomaterial_purpose_options.map { |purpose, label|
-    { key: purpose, text: label, checked: @nano_element.purposes&.include?(purpose), disable_ghost: true }
-  } %>
+<%
+  title = "Select nanomaterial purpose"
+  question = "What is the purpose of this nanomaterial?"
+  items = NanoElementPurposes.all.map do |purpose|
+    { key: purpose.name,
+      text: purpose.display_name.upcase_first,
+      checked: @nano_element.purposes&.include?(purpose.name),
+      disable_ghost: true }
+  end
+%>
 
 <% page_title title, errors: @nano_element.errors.messages.include?(:purposes) %>
 <% content_for :after_header do %>
@@ -27,3 +32,13 @@
     </div>
   </div>
 <% end %>
+<%#
+  <%= govukRadios(
+        form: form,
+        key: :purposes,
+        fieldset: { legend: { text: question,
+                              classes: "govuk-label--l",
+                              isPageHeading: true } },
+        items: [{ text: "Yes", value: "true" },
+                { text: "No", value: "false" }]
+      ) %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
@@ -1,44 +1,46 @@
 <%
-  title = "Select nanomaterial purpose"
-  question = "What is the purpose of this nanomaterial?"
-  items = NanoElementPurposes.all.map do |purpose|
+  predefined_purposes = NanoElementPurposes.predefined
+  predefined_purposes_items = predefined_purposes.map do |purpose|
     { key: purpose.name,
-      text: purpose.display_name.upcase_first,
-      checked: @nano_element.purposes&.include?(purpose.name),
-      disable_ghost: true }
+      text: purpose.upcase_display_name,
+      checked: @nano_element.purposes&.include?(purpose.name) }
   end
 %>
 
-<% page_title title, errors: @nano_element.errors.messages.include?(:purposes) %>
+<% page_title("Select nanomaterial purpose", errors: @nano_element.errors.messages.include?(:purposes)) %>
 <% content_for :after_header do %>
-  <%= govukBackLink text: "Back", href: previous_wizard_path %>
+  <%= govukBackLink text: "Back", href: responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>
 <% end %>
 
 <%= form_with(model: @nano_element, url: wizard_path, method: :put) do |form| %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-
+    <div class="govuk-grid-column-full">
       <% if @nano_element.errors.messages.include?(:purposes) %>
-        <%= govukErrorSummary(titleText: "There is a problem", errorList: [{text: @nano_element.errors.messages[:purposes][0], href: "#nano_element_colorant"}] ) %>
+        <%= govukErrorSummary(titleText: "There is a problem",
+                              errorList: [{text: @nano_element.errors.messages[:purposes][0],
+                              href: "#nano_element_colorant"}] ) %>
       <% end %>
-      <%= govukCheckboxes(
+      <% predefined_purposes_checkboxes_html = capture do %>
+        <%= govukCheckboxes(
+              form: form,
+              key: :purposes,
+              fieldset: { legend: { text: "Select all that apply", isPageHeading: false } },
+              items: predefined_purposes_items,
+            ) %>
+      <% end %>
+      <%= govukRadios(
             form: form,
-            key: :purposes,
-            fieldset: { legend: { text: question, classes: "govuk-label--l", isPageHeading: true } },
-            items: items,
+            key: :purpose_type,
+            fieldset: { legend: { text: "What is the purpose of this nanomaterial?",
+                                  classes: "govuk-label--l",
+                                  isPageHeading: true } },
+            items: [{ text: to_sentence(predefined_purposes.map(&:upcase_display_name), last_word_connector: " or "),
+                      value: "predefined",
+                      conditional: { html: predefined_purposes_checkboxes_html } },
+                    { text: NanoElementPurposes.other.upcase_display_name,
+                      value: NanoElementPurposes.other.name }]
           ) %>
       <%= govukButton text: "Continue" %>
-
     </div>
   </div>
 <% end %>
-<%#
-  <%= govukRadios(
-        form: form,
-        key: :purposes,
-        fieldset: { legend: { text: question,
-                              classes: "govuk-label--l",
-                              isPageHeading: true } },
-        items: [{ text: "Yes", value: "true" },
-                { text: "No", value: "false" }]
-      ) %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
@@ -1,6 +1,6 @@
 <%
-  predefined_purposes = NanoElementPurposes.predefined
-  predefined_purposes_items = predefined_purposes.map do |purpose|
+  standard_purposes = NanoElementPurposes.standard
+  standard_purposes_items = standard_purposes.map do |purpose|
     { key: purpose.name,
       text: purpose.upcase_display_name,
       checked: @purposes_form.purposes&.include?(purpose.name) }
@@ -16,14 +16,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= error_summary(@purposes_form.errors,
-                        map_errors: { purpose_type: :purposes_form_purpose_type_predefined,
+                        map_errors: { purpose_type: :purposes_form_purpose_type_standard,
                                       purposes: :purposes_form_colorant }) %>
-      <% predefined_purposes_checkboxes_html = capture do %>
+      <% standard_purposes_checkboxes_html = capture do %>
         <%= govukCheckboxes(
               form: f,
               key: :purposes,
               fieldset: { legend: { text: "Select all that apply", isPageHeading: false } },
-              items: predefined_purposes_items,
+              items: standard_purposes_items,
             ) %>
       <% end %>
       <%= govukRadios(
@@ -32,9 +32,9 @@
             fieldset: { legend: { text: "What is the purpose of this nanomaterial?",
                                   classes: "govuk-label--l",
                                   isPageHeading: true } },
-            items: [{ text: to_sentence(predefined_purposes.map(&:upcase_display_name), last_word_connector: " or "),
-                      value: "predefined",
-                      conditional: { html: predefined_purposes_checkboxes_html } },
+            items: [{ text: to_sentence(standard_purposes.map(&:upcase_display_name), last_word_connector: " or "),
+                      value: "standard",
+                      conditional: { html: standard_purposes_checkboxes_html } },
                     { text: NanoElementPurposes.other.upcase_display_name,
                       value: NanoElementPurposes.other.name }]
           ) %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
@@ -1,44 +1,6 @@
-<%
-  standard_purposes = NanoElementPurposes.standard
-  standard_purposes_items = standard_purposes.map do |purpose|
-    { key: purpose.name,
-      text: purpose.upcase_display_name,
-      checked: @purposes_form.purposes&.include?(purpose.name) }
-  end
-%>
-
 <% page_title("Select nanomaterial purpose", errors: @purposes_form.errors.any?) %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>
 <% end %>
 
-<%= form_with(model: @purposes_form, url: wizard_path, scope: :purposes_form, method: :put) do |f| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= error_summary(@purposes_form.errors,
-                        map_errors: { purpose_type: :purposes_form_purpose_type_standard,
-                                      purposes: :purposes_form_colorant }) %>
-      <% standard_purposes_checkboxes_html = capture do %>
-        <%= govukCheckboxes(
-              form: f,
-              key: :purposes,
-              fieldset: { legend: { text: "Select all that apply", isPageHeading: false } },
-              items: standard_purposes_items,
-            ) %>
-      <% end %>
-      <%= govukRadios(
-            form: f,
-            key: :purpose_type,
-            fieldset: { legend: { text: "What is the purpose of this nanomaterial?",
-                                  classes: "govuk-label--l",
-                                  isPageHeading: true } },
-            items: [{ text: to_sentence(standard_purposes.map(&:upcase_display_name), last_word_connector: " or "),
-                      value: "standard",
-                      conditional: { html: standard_purposes_checkboxes_html } },
-                    { text: NanoElementPurposes.other.upcase_display_name,
-                      value: NanoElementPurposes.other.name }]
-          ) %>
-      <%= govukButton text: "Continue" %>
-    </div>
-  </div>
-<% end %>
+<%= render partial: "purposes_form", locals: { purposes_form: @purposes_form, form_url: wizard_path, form_method: :put } %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
@@ -3,33 +3,31 @@
   predefined_purposes_items = predefined_purposes.map do |purpose|
     { key: purpose.name,
       text: purpose.upcase_display_name,
-      checked: @nano_element.purposes&.include?(purpose.name) }
+      checked: @purposes_form.purposes&.include?(purpose.name) }
   end
 %>
 
-<% page_title("Select nanomaterial purpose", errors: @nano_element.errors.messages.include?(:purposes)) %>
+<% page_title("Select nanomaterial purpose", errors: @purposes_form.errors.messages.include?(:purposes)) %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>
 <% end %>
 
-<%= form_with(model: @nano_element, url: wizard_path, method: :put) do |form| %>
+<%= form_with(model: @purposes_form, url: wizard_path, scope: :purposes_form, method: :put) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <% if @nano_element.errors.messages.include?(:purposes) %>
-        <%= govukErrorSummary(titleText: "There is a problem",
-                              errorList: [{text: @nano_element.errors.messages[:purposes][0],
-                              href: "#nano_element_colorant"}] ) %>
-      <% end %>
+      <%= error_summary(@purposes_form.errors,
+                        map_errors: { purpose_type: :purposes_form_purpose_type_predefined,
+                                      purposes: :purposes_form_colorant }) %>
       <% predefined_purposes_checkboxes_html = capture do %>
         <%= govukCheckboxes(
-              form: form,
+              form: f,
               key: :purposes,
               fieldset: { legend: { text: "Select all that apply", isPageHeading: false } },
               items: predefined_purposes_items,
             ) %>
       <% end %>
       <%= govukRadios(
-            form: form,
+            form: f,
             key: :purpose_type,
             fieldset: { legend: { text: "What is the purpose of this nanomaterial?",
                                   classes: "govuk-label--l",

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/select_purposes.html.erb
@@ -7,7 +7,7 @@
   end
 %>
 
-<% page_title("Select nanomaterial purpose", errors: @purposes_form.errors.messages.include?(:purposes)) %>
+<% page_title("Select nanomaterial purpose", errors: @purposes_form.errors.any?) %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>
 <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/new.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/new.html.erb
@@ -1,22 +1,8 @@
-<% title = "What is the nanomaterial INCI name?" %>
-
-<% page_title title, errors: @nano_element.errors.any? %>
+<% page_title("Select nanomaterial purpose", errors: @purposes_form.errors.any?) %>
 <% content_for :after_header do %>
-  <%= link_to "Back", responsible_person_notification_draft_path(@notification.responsible_person, @notification), class: "govuk-back-link" %>
+  <%= govukBackLink text: "Back", href: responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>
 <% end %>
 
-<%= form_with model: @nano_element, url: responsible_person_notification_nanomaterials_path(@notification.responsible_person, @notification), html: { novalidate: true }, method: :post do |form| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= error_summary_for(@nano_element) %>
-      <%= govukInput(form: form,
-                     key: :inci_name,
-                     classes: "govuk-!-margin-top-7",
-                     label: { html: "What is the nanomaterial <abbr title='International Nomenclature for Cosmetic Ingredients'>INCI</abbr> name?".html_safe ,
-                             classes: "govuk-label--l",
-                             isPageHeading: true },
-                     hint: { html: 'This is the International Nomenclature for Cosmetic Ingredients name.' }) %>
-      <%= govukButton text: "Save and continue" %>
-    </div>
-  </div>
-<% end %>
+<% form_url = responsible_person_notification_nanomaterials_path(@notification.responsible_person, @notification) %>
+<%= render partial: "responsible_persons/notifications/nanomaterials/build/purposes_form",
+           locals: { purposes_form: @purposes_form, form_url: form_url, form_method: :post } %>

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -228,6 +228,15 @@ en:
           attributes:
             component_id:
               blank: "Select an item"
+        responsible_persons/notifications/nanomaterials/nano_element_purposes_form:
+          attributes:
+            purpose_type:
+              blank: "Select either the predefined or another purposes"
+              inclusion: "%{value} is not a valid purpose type"
+            purposes:
+              blank: "Select one or more purposes"
+              inclusion: "%{purpose} is not a valid purpose"
+              predefined_or_other: "Select either any predefined or 'other' as purposes"
         responsible_persons/notifications/product/contains_nanomaterials_form:
           attributes:
             contains_nanomaterials:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -231,10 +231,10 @@ en:
         responsible_persons/notifications/nanomaterials/nano_element_purposes_form:
           attributes:
             purpose_type:
-              blank: "Select either the standard or another purposes"
+              blank: "Select the purpose of this nanomaterial"
               inclusion: "%{value} is not a valid purpose type"
             purposes:
-              blank: "Select one or more purposes"
+              blank: "Select the purpose"
               inclusion: "%{purpose} is not a valid purpose"
               standard_or_other: "Select either any standard or 'other' as purposes"
         responsible_persons/notifications/product/contains_nanomaterials_form:

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -231,12 +231,12 @@ en:
         responsible_persons/notifications/nanomaterials/nano_element_purposes_form:
           attributes:
             purpose_type:
-              blank: "Select either the predefined or another purposes"
+              blank: "Select either the standard or another purposes"
               inclusion: "%{value} is not a valid purpose type"
             purposes:
               blank: "Select one or more purposes"
               inclusion: "%{purpose} is not a valid purpose"
-              predefined_or_other: "Select either any predefined or 'other' as purposes"
+              standard_or_other: "Select either any standard or 'other' as purposes"
         responsible_persons/notifications/product/contains_nanomaterials_form:
           attributes:
             contains_nanomaterials:

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/nanomaterials/build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/nanomaterials/build_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::BuildController
   describe "GET #new" do
     it "redirects to the first step of the wizard" do
       get(:new, params:)
-      expect(response).to redirect_to(responsible_person_notification_nanomaterial_build_path(responsible_person, notification, nano_element1, :add_nanomaterial_name))
+      expect(response).to redirect_to(responsible_person_notification_nanomaterial_build_path(responsible_person, notification, nano_element1, :select_purposes))
     end
   end
 
@@ -79,23 +79,28 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::BuildController
       let(:select_purposes_params) { params.merge(id: :select_purposes) }
 
       it "updates the nano-element with the selected purposes" do
-        post(:update, params: select_purposes_params.merge(nano_element: { "colorant": "0", "preservative": "1", "uv_filter": "1", "other": "0" }))
+        post(:update, params: select_purposes_params.merge(purposes_form: { "colorant": "0", "preservative": "1", "uv_filter": "1", "purpose_type": "standard" }))
         expect(nano_element1.reload.purposes).to eq(%w[preservative uv_filter])
       end
 
       it "ignores invalid purpose values" do
-        post(:update, params: select_purposes_params.merge(nano_element: { "colorant": "1", "invalid_purpose": "1", "other": "0" }))
+        post(:update, params: select_purposes_params.merge(purposes_form: { "colorant": "1", "invalid_purpose": "1", "purpose_type": "standard" }))
         expect(nano_element1.reload.purposes).to eq(%w[colorant])
       end
 
       it "redirects to the next page when purposes are selected" do
-        post(:update, params: select_purposes_params.merge(nano_element: { "preservative": "1" }))
+        post(:update, params: select_purposes_params.merge(purposes_form: { "preservative": "1", "purpose_type": "standard" }))
         expect(response).to redirect_to(responsible_person_notification_nanomaterial_build_path(responsible_person, notification, nano_element1, :after_select_purposes_routing))
       end
 
-      it "sets error when no purpose is selected" do
+      it "sets error when no purpose type is selected" do
         post(:update, params: select_purposes_params)
-        expect(assigns(:nano_element).errors[:purposes]).to include("Choose an option")
+        expect(assigns(:purposes_form).errors[:purpose_type]).to include("Select the purpose of this nanomaterial")
+      end
+
+      it "sets error when no purpose is selected for standard purpose type" do
+        post(:update, params: select_purposes_params.merge(purposes_form: { "purpose_type": "standard", "colorant": "0", "preservative": "0", "uv_filter": "0" }))
+        expect(assigns(:purposes_form).errors[:purposes]).to include("Select the purpose")
       end
     end
 

--- a/cosmetics-web/spec/features/notification_wizard/blocked_nano_spec.rb
+++ b/cosmetics-web/spec/features/notification_wizard/blocked_nano_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
 
     # Perform steps to block nano
     click_on "Nano one"
-    click_on "Save and continue" # Name page
     click_on "Continue" # Purpose page
+    click_on "Save and continue" # Name page
     answer_is_nanomaterial_listed_in_ec_regulation_with("No", nanomaterial_name: "Nano one")
     click_link "the task list page"
 

--- a/cosmetics-web/spec/features/notification_wizard/correct_status_spec.rb
+++ b/cosmetics-web/spec/features/notification_wizard/correct_status_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
 
     expect_multi_item_kit_task_completed
 
-    # Does not create the nanomaterial until the name is added.
+    # Does not create the nanomaterial until the purposes are choosen.
     click_on "Add another nanomaterial"
     click_link "Back"
     expect(page).to have_current_path(/\/draft/)
@@ -393,19 +393,19 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
     expect_multi_item_kit_task_completed
 
     click_on "Add another nanomaterial"
-    answer_inci_name_with "Nano four"
+    answer_what_is_purpose_of_nanomaterial_with(%w[Preservative])
     click_link "Back"
-    expect(page).to have_current_path(/\/add_nanomaterial_name/)
+    expect(page).to have_current_path(/\/select_purposes/)
 
     click_link "Back"
     expect(page).to have_current_path(/\/draft/)
-    expect_task_not_started "Nano four"
+    expect_task_not_started "Nanomaterial #4"
     expect_multi_item_kit_task_blocked
 
     expect_task_blocked "Item #1"
     expect_task_blocked "Item #2"
 
-    complete_nano_material_wizard("Nano four", purposes: %w[Preservative])
+    complete_nano_material_wizard("Nano four", nano_material_number: 4, purposes: %w[Preservative])
 
     expect_multi_item_kit_task_completed
 

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurposesForm do
+  let(:predefined_type) { described_class::PREDEFINED_TYPE }
+  let(:other_type) { described_class::OTHER_TYPE }
+  let(:allowed_purposes) { described_class::ALLOWED_PURPOSES }
+  let(:predefined_purposes) { allowed_purposes - [other_type]}
+
+  describe "#initialize" do
+    it "sets the given purposes" do
+      purposes = allowed_purposes.sample(2)
+      form = described_class.new(purposes:)
+      expect(form.purposes).to eq(purposes)
+    end
+
+    it "sets the given purpose_type" do
+      form = described_class.new(purpose_type: predefined_type)
+      expect(form.purpose_type).to eq(predefined_type)
+    end
+
+    it "defaults the purpose_type to 'nil' if no purpose_type is given" do
+      form = described_class.new
+      expect(form.purpose_type).to be_nil
+    end
+
+    it "defaults the purposes to '[]' if no purposes are given" do
+      form = described_class.new
+      expect(form.purposes).to eq([])
+    end
+
+    it "does not accept other attributes" do
+      expect { described_class.new(foo: "bar") }.to raise_error(ArgumentError)
+    end
+
+    it "defaults the purpose_type to 'other' if the given purposes include 'other'" do
+      form = described_class.new(purposes: [other_type])
+      expect(form.purpose_type).to eq(other_type)
+    end
+
+    it "defaults the purpose_type to 'predefined' if the given purposes do not include 'other'" do
+      form = described_class.new(purposes: [predefined_purposes.sample])
+      expect(form.purpose_type).to eq(predefined_type)
+    end
+
+    context "when the provided purpose_type is 'other'" do
+      let(:purpose_type) { other_type }
+
+      it "defaults the purposes to 'other'" do
+        form = described_class.new(purpose_type:)
+        expect(form.purposes).to eq([other_type])
+      end
+
+      it "overrides any predefined purposes with 'other'" do
+        form = described_class.new(purpose_type:, purposes: predefined_purposes)
+        expect(form.purposes).to eq([other_type])
+      end
+    end
+  end
+
+  describe "validations" do
+    let(:purpose_type) { predefined_type }
+    let(:purposes) { predefined_purposes }
+
+    it "is valid with a predefined purpose type and a single predefined purpose" do
+      form = described_class.new(purpose_type:, purposes: [purposes.first])
+      expect(form).to be_valid
+    end
+
+    it "is valid with a predefined purpose type and multiple predefined purposes" do
+      form = described_class.new(purpose_type:, purposes:)
+      expect(form).to be_valid
+    end
+
+    it "is valid with other purpose type and no predefined purposes" do
+      form = described_class.new(purpose_type: "other", purposes: [])
+      expect(form).to be_valid
+    end
+
+    it "does not allow an invalid purpose type" do
+      form = described_class.new(purpose_type: "fooType", purposes:)
+      expect(form).not_to be_valid
+      expect(form.errors[:purpose_type]).to include("fooType is not a valid purpose type")
+    end
+
+    it "does not need a purpose type when purposes are present" do
+      form = described_class.new(purpose_type: nil, purposes:)
+      expect(form).to be_valid
+    end
+
+    it "requires a purpose type when no purposes are present" do
+      form = described_class.new(purpose_type: nil, purposes: [])
+      expect(form).not_to be_valid
+      expect(form.errors[:purpose_type]).to include("Select either the predefined or another purposes")
+    end
+
+    it "requires a purpose if the purpose type is predefined" do
+      form = described_class.new(purpose_type:, purposes: [])
+      expect(form).not_to be_valid
+      expect(form.errors[:purposes]).to include("Select one or more purposes")
+    end
+
+    it "does not allow invalid purposes" do
+      form = described_class.new(purpose_type:, purposes: purposes + %w[fooPurpose barPurpose])
+      expect(form).not_to be_valid
+      expect(form.errors[:purposes]).to eq(["fooPurpose is not a valid purpose", "barPurpose is not a valid purpose"])
+    end
+
+    it "does not allow to combine both predefined and other purposes" do
+      form = described_class.new(purpose_type:, purposes: [purposes.first, other_type])
+      expect(form).not_to be_valid
+      expect(form.errors[:purposes]).to eq(["Select either any predefined or 'other' as purposes"])
+    end
+  end
+end

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
@@ -90,13 +90,13 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurp
     it "requires a purpose type when no purposes are present" do
       form = described_class.new(purpose_type: nil, purposes: [])
       expect(form).not_to be_valid
-      expect(form.errors[:purpose_type]).to include("Select either the standard or another purposes")
+      expect(form.errors[:purpose_type]).to include("Select the purpose of this nanomaterial")
     end
 
     it "requires a purpose if the purpose type is standard" do
       form = described_class.new(purpose_type:, purposes: [])
       expect(form).not_to be_valid
-      expect(form.errors[:purposes]).to include("Select one or more purposes")
+      expect(form.errors[:purposes]).to include("Select the purpose")
     end
 
     it "does not allow invalid purposes" do

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurposesForm do
-  let(:predefined_type) { described_class::PREDEFINED_TYPE }
+  let(:standard_type) { described_class::STANDARD_TYPE }
   let(:other_type) { described_class::OTHER_TYPE }
   let(:allowed_purposes) { described_class::ALLOWED_PURPOSES }
-  let(:predefined_purposes) { allowed_purposes - [other_type]}
+  let(:standard_purposes) { allowed_purposes - [other_type]}
 
   describe "#initialize" do
     it "sets the given purposes" do
@@ -14,8 +14,8 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurp
     end
 
     it "sets the given purpose_type" do
-      form = described_class.new(purpose_type: predefined_type)
-      expect(form.purpose_type).to eq(predefined_type)
+      form = described_class.new(purpose_type: standard_type)
+      expect(form.purpose_type).to eq(standard_type)
     end
 
     it "defaults the purpose_type to 'nil' if no purpose_type is given" do
@@ -37,9 +37,9 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurp
       expect(form.purpose_type).to eq(other_type)
     end
 
-    it "defaults the purpose_type to 'predefined' if the given purposes do not include 'other'" do
-      form = described_class.new(purposes: [predefined_purposes.sample])
-      expect(form.purpose_type).to eq(predefined_type)
+    it "defaults the purpose_type to 'standard' if the given purposes do not include 'other'" do
+      form = described_class.new(purposes: [standard_purposes.sample])
+      expect(form.purpose_type).to eq(standard_type)
     end
 
     context "when the provided purpose_type is 'other'" do
@@ -50,28 +50,28 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurp
         expect(form.purposes).to eq([other_type])
       end
 
-      it "overrides any predefined purposes with 'other'" do
-        form = described_class.new(purpose_type:, purposes: predefined_purposes)
+      it "overrides any standard purposes with 'other'" do
+        form = described_class.new(purpose_type:, purposes: standard_purposes)
         expect(form.purposes).to eq([other_type])
       end
     end
   end
 
   describe "validations" do
-    let(:purpose_type) { predefined_type }
-    let(:purposes) { predefined_purposes }
+    let(:purpose_type) { standard_type }
+    let(:purposes) { standard_purposes }
 
-    it "is valid with a predefined purpose type and a single predefined purpose" do
+    it "is valid with a standard purpose type and a single standard purpose" do
       form = described_class.new(purpose_type:, purposes: [purposes.first])
       expect(form).to be_valid
     end
 
-    it "is valid with a predefined purpose type and multiple predefined purposes" do
+    it "is valid with a standard purpose type and multiple standard purposes" do
       form = described_class.new(purpose_type:, purposes:)
       expect(form).to be_valid
     end
 
-    it "is valid with other purpose type and no predefined purposes" do
+    it "is valid with other purpose type and no standard purposes" do
       form = described_class.new(purpose_type: "other", purposes: [])
       expect(form).to be_valid
     end
@@ -90,10 +90,10 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurp
     it "requires a purpose type when no purposes are present" do
       form = described_class.new(purpose_type: nil, purposes: [])
       expect(form).not_to be_valid
-      expect(form.errors[:purpose_type]).to include("Select either the predefined or another purposes")
+      expect(form.errors[:purpose_type]).to include("Select either the standard or another purposes")
     end
 
-    it "requires a purpose if the purpose type is predefined" do
+    it "requires a purpose if the purpose type is standard" do
       form = described_class.new(purpose_type:, purposes: [])
       expect(form).not_to be_valid
       expect(form.errors[:purposes]).to include("Select one or more purposes")
@@ -105,10 +105,10 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurp
       expect(form.errors[:purposes]).to eq(["fooPurpose is not a valid purpose", "barPurpose is not a valid purpose"])
     end
 
-    it "does not allow to combine both predefined and other purposes" do
+    it "does not allow to combine both standard and other purposes" do
       form = described_class.new(purpose_type:, purposes: [purposes.first, other_type])
       expect(form).not_to be_valid
-      expect(form.errors[:purposes]).to eq(["Select either any predefined or 'other' as purposes"])
+      expect(form.errors[:purposes]).to eq(["Select either any standard or 'other' as purposes"])
     end
   end
 end

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/nanomaterials/nano_element_purposes_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ResponsiblePersons::Notifications::Nanomaterials::NanoElementPurp
   let(:standard_type) { described_class::STANDARD_TYPE }
   let(:other_type) { described_class::OTHER_TYPE }
   let(:allowed_purposes) { described_class::ALLOWED_PURPOSES }
-  let(:standard_purposes) { allowed_purposes - [other_type]}
+  let(:standard_purposes) { allowed_purposes - [other_type] }
 
   describe "#initialize" do
     it "sets the given purposes" do

--- a/cosmetics-web/spec/models/nano_element_purposes_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_purposes_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe NanoElementPurposes, type: :model do
     end
   end
 
-  describe ".predefined" do
-    it "returns all the predefined purposes" do
-      expect(described_class.predefined.map(&:name)).to eq(%w[colorant preservative uv_filter])
+  describe ".standard" do
+    it "returns all the standard purposes" do
+      expect(described_class.standard.map(&:name)).to eq(%w[colorant preservative uv_filter])
     end
   end
 

--- a/cosmetics-web/spec/models/nano_element_purposes_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_purposes_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe NanoElementPurposes, type: :model do
+  describe ".all" do
+    it "returns all the purposes" do
+      expect(described_class.all.map(&:name)).to eq(%w[colorant preservative uv_filter other])
+    end
+  end
+
+  describe ".predefined" do
+    it "returns all the predefined purposes" do
+      expect(described_class.predefined.map(&:name)).to eq(%w[colorant preservative uv_filter])
+    end
+  end
+
+  describe ".find" do
+    it "returns the purpose with the given name" do
+      expect(described_class.find("colorant")).to have_attributes(
+        class: NanoElementPurposes::Purpose,
+        name: "colorant",
+      )
+    end
+
+    it "returns nil if the purpose name does not exist" do
+      expect(described_class.find("foo")).to be_nil
+    end
+  end
+
+  %i[colorant preservative uv_filter other].each do |purpose|
+    describe ".#{purpose}" do
+      it "returns '#{purpose}' purpose" do
+        expect(described_class.public_send(purpose)).to have_attributes(
+          class: NanoElementPurposes::Purpose,
+          name: purpose.to_s,
+        )
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/support/helpers/nano_material_wizard.rb
+++ b/cosmetics-web/spec/support/helpers/nano_material_wizard.rb
@@ -9,9 +9,9 @@ def complete_nano_material_wizard(name, nano_material_number: nil, purposes: %w[
     end
   end
 
+  answer_what_is_purpose_of_nanomaterial_with(purposes)
   answer_inci_name_with name
 
-  answer_what_is_purpose_of_nanomaterial_with(purposes, nanomaterial_name: name)
   answer_is_nanomaterial_listed_in_ec_regulation_with("Yes", nanomaterial_name: name)
   answer_does_nanomaterial_conform_to_restrictions_with("Yes", nanomaterial_name: name)
 
@@ -26,9 +26,10 @@ def answer_inci_name_with(name)
   click_button "Save and continue"
 end
 
-def answer_what_is_purpose_of_nanomaterial_with(purposes, nanomaterial_name:)
-  purposes.each do |purpose|
-    within_fieldset("What is the purpose of #{nanomaterial_name}?") do
+def answer_what_is_purpose_of_nanomaterial_with(purposes)
+  within_fieldset("What is the purpose of this nanomaterial?") do
+    page.choose "Colourant, Preservative or UV filter"
+    purposes.each do |purpose|
       page.check(purpose)
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket 1538](https://regulatorydelivery.atlassian.net/browse/COSBETA-1538)

This is the first nanomaterial journey changes ticket, belonging to the ["Improve nanomaterials addition/linking in product notifications" epic](https://regulatorydelivery.atlassian.net/browse/COSBETA-1560).

These changes focus on changing the nanomaterial journey to flip the order of the first two steps (from `add the name` -> `select the purposes` to `select the purposes` -> `add the name`), tweaking the forms and only requiring name for standard purposes nanomaterials.

## Description
When completing a nanomaterial from the notification draft, the first question will be about the nanomaterial's purposes.
 We have changed from a plain checklist with all the options to a radio button that asks the user to choose between standard or other purposes, and when choosing the standard option, displays checkboxes for all the standard purposes.
<!--- Describe your changes in detail -->
<img src="https://user-images.githubusercontent.com/1227578/189308667-82993c46-cee5-4115-8b9f-1acc2146cc54.png" width=50% height=50%>

The second step will be introducing the nanomaterial name.
This will only be displayed when the user has selected standard purposes in the previous step. Non-standard further changes will be covered in a [following ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1539).

Now there is a link pointing to the annex with the list of colourants to help users:
<img src="https://user-images.githubusercontent.com/1227578/189309480-6cc991c1-b6fa-4eb9-b277-9871261bd22a.png" width=50% height=50%>

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2587-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2587-search-web.london.cloudapps.digital/

