### PR TITLE
Add nanomaterials rake maintenance tasks

### DIFF
--- a/cosmetics-web/.rubocop.yml
+++ b/cosmetics-web/.rubocop.yml
@@ -105,6 +105,7 @@ RSpec/DescribeClass:
   Exclude:
     - spec/requests/*
     - spec/search/*
+    - spec/tasks/*
 
 RSpec/FilePath:
   Exclude:

--- a/cosmetics-web/lib/tasks/nanomaterials.rake
+++ b/cosmetics-web/lib/tasks/nanomaterials.rake
@@ -30,4 +30,15 @@ namespace :nanomaterials do
     puts "To download the file, execute in YOUR COMPUTER shell:"
     puts "cf ssh APPNAME -c 'cat ~/app/tmp/nanomaterial_notifications.zip' > nanomaterial_notifications.zip"
   end
+
+  # TODO: Remove this task once the NanoMaterial and NanoElement models are merged.
+  desc "Delete nanomaterials without associated nanoelements"
+  task delete_nanomaterials_without_nanoelements: :environment do
+    nanomaterials_without_nanoelements = NanoMaterial.left_joins(:nano_elements).where(nano_elements: { id: nil })
+    affected_count = nanomaterials_without_nanoelements.count
+    puts "Found #{affected_count} nanomaterials without any associated nanoelement"
+    puts "Deleting them..."
+    nanomaterials_without_nanoelements.delete_all # Dont delete associated objects
+    puts "#{affected_count} nanomaterials without nanoelements deleted"
+  end
 end

--- a/cosmetics-web/lib/tasks/nanomaterials.rake
+++ b/cosmetics-web/lib/tasks/nanomaterials.rake
@@ -41,4 +41,17 @@ namespace :nanomaterials do
     nanomaterials_without_nanoelements.delete_all # Dont delete associated objects
     puts "#{affected_count} nanomaterials without nanoelements deleted"
   end
+
+  # TODO: Remove this task once the NanoMaterial and NanoElement models are merged.
+  desc "Delete NanoMaterial and their nanoelements without any associated component or notification"
+  task delete_orphan_nanomaterials: :environment do
+    orphan_nanomaterials = NanoMaterial.left_joins(:component_nano_materials)
+                                       .where(component_nano_materials: { nano_material_id: nil },
+                                              nano_materials: { component_id: nil, notification_id: nil })
+    affected_count = orphan_nanomaterials.count
+    puts "Found #{affected_count} orphan nanomaterials without any associated components or notifications"
+    puts "Deleting them..."
+    orphan_nanomaterials.destroy_all # Also destroy associated Nano Elements.
+    puts "#{affected_count} orphan nanomaterials deleted"
+  end
 end

--- a/cosmetics-web/spec/factories/nano_material.rb
+++ b/cosmetics-web/spec/factories/nano_material.rb
@@ -2,4 +2,8 @@ FactoryBot.define do
   factory :nano_material do
     notification
   end
+
+  trait :skip_validations do
+    to_create { |instance| instance.save(validate: false) }
+  end
 end

--- a/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
+++ b/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
@@ -7,6 +7,10 @@ describe "nanomaterials.rake" do
     allow($stdout).to receive(:puts) # Silence console output while testing tasks
   end
 
+  after do
+    task&.reenable # Reenable task so it can be invoked again in another test
+  end
+
   describe ":delete_nanomaterials_without_nanoelements" do
     subject(:task) { Rake::Task["nanomaterials:delete_nanomaterials_without_nanoelements"] }
 
@@ -18,7 +22,7 @@ describe "nanomaterials.rake" do
       expect(NanoMaterial.all).to include(nano_with_element)
     end
 
-    it "does not delet nano materials with associated nano elements" do
+    it "does not delete nano materials with associated nano elements" do
       nano = create(:nano_element).nano_material
 
       expect { task.invoke }.not_to change(NanoMaterial, :count)

--- a/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
+++ b/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+Rails.application.load_tasks
+
+describe "nanomaterials.rake" do
+  before do
+    allow($stdout).to receive(:puts) # Silence console output while testing tasks
+  end
+
+  describe ":delete_nanomaterials_without_nanoelements" do
+    subject(:task) { Rake::Task["nanomaterials:delete_nanomaterials_without_nanoelements"] }
+
+    it "deletes any nano material without an associated nano element" do
+      create_list(:nano_material, 2)
+      nano_with_element = create(:nano_element).nano_material
+
+      expect { task.invoke }.to change(NanoMaterial, :count).by(-2)
+      expect(NanoMaterial.all).to include(nano_with_element)
+    end
+
+    it "does not delet nano materials with associated nano elements" do
+      nano = create(:nano_element).nano_material
+
+      expect { task.invoke }.not_to change(NanoMaterial, :count)
+      expect(NanoMaterial.all).to eq [nano]
+    end
+  end
+
+  describe ":delete_orphan_nanomaterials" do
+    subject(:task) { Rake::Task["nanomaterials:delete_orphan_nanomaterials"] }
+
+    it "deletes any nano materials without an associated component or notification" do
+      create_list(:nano_material, 2, :skip_validations, component_id: nil, notification_id: nil)
+
+      expect { task.invoke }.to change(NanoMaterial, :count).by(-2)
+    end
+
+    it "does not delete nanomaterials with an associated notification" do
+      nano = create(:nano_material, component_id: nil)
+
+      expect { task.invoke }.not_to change(NanoMaterial, :count)
+      expect(NanoMaterial.all).to eq [nano]
+    end
+
+    it "does not delete nanomaterials with a deprecated reference to component id" do
+      component = create(:component)
+      nano = create(:nano_material, :skip_validations, notification_id: nil, component_id: component.id)
+
+      expect { task.invoke }.not_to change(NanoMaterial, :count)
+      expect(NanoMaterial.all).to eq [nano]
+    end
+
+    it "does not delete nanomaterials with an associated component" do
+      nano = create(:nano_material, :skip_validations, notification_id: nil, component_id: nil)
+      nano.components << create(:component)
+
+      expect { task.invoke }.not_to change(NanoMaterial, :count)
+      expect(NanoMaterial.all).to eq [nano]
+    end
+  end
+end

--- a/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
+++ b/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
@@ -4,7 +4,7 @@ Rails.application.load_tasks
 
 describe "nanomaterials.rake" do
   before do
-    allow($stdout).to receive(:puts) # Silence console output while testing tasks
+    allow(Rails.logger).to receive(:info) # Silence logging while testing tasks
   end
 
   after do

--- a/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
+++ b/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
@@ -62,4 +62,59 @@ describe "nanomaterials.rake" do
       expect(NanoMaterial.all).to eq [nano]
     end
   end
+
+  describe ":single_nanoelement_per_nanomaterial" do
+    subject(:task) { Rake::Task["nanomaterials:single_nanoelement_per_nanomaterial"] }
+
+    context "when a single nanomaterial has multiple nanoelements" do
+      let(:nano_material) { create(:nano_material) }
+      let(:component) { create(:component, notification: nano_material.notification) }
+      let(:nano_element1) { create(:nano_element, nano_material:) }
+      let(:nano_element2) { create(:nano_element, nano_material:) }
+
+      before do
+        travel_to 1.month.ago do
+          nano_material
+          nano_material.components << component
+          nano_element1
+          nano_element2
+        end
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it "creates a new nanomaterial with the same values as the original" do
+        expect { task.invoke }.to change(NanoMaterial, :count).by(1)
+        new_nano_material = NanoMaterial.last
+        expect(new_nano_material).to have_attributes(
+          exposure_condition: nano_material.exposure_condition,
+          exposure_routes: nano_material.exposure_routes,
+          component_id: nano_material.component_id,
+          notification_id: nano_material.notification_id,
+          created_at: nano_material.created_at,
+          updated_at: nano_material.updated_at,
+        )
+      end
+      # rubocop:enable RSpec/ExampleLength
+
+      it "associates the new nanomaterial with the same components as the original" do
+        expect { task.invoke }.to change(ComponentNanoMaterial, :count).by(1)
+        expect(ComponentNanoMaterial.last).to have_attributes(component:, nano_material: NanoMaterial.last)
+      end
+
+      it "keeps the original association of the first nanoelement" do
+        expect {
+          task.invoke
+          nano_material.reload
+        }.to change(nano_material, :nano_elements).from([nano_element1, nano_element2]).to([nano_element1])
+        expect(nano_element1.nano_material).to eq(nano_material)
+      end
+
+      it "associates the second nanoelement with the new nanomaterial" do
+        task.invoke
+        new_nanomaterial = NanoMaterial.last
+        expect(new_nanomaterial).not_to eq nano_material
+        expect(nano_element2.reload.nano_material).to eq(new_nanomaterial)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1587)
## Description
<!--- Describe your changes in detail -->
We have identified over 209k nanomaterials in production not associated with any nanoelement (hence not even having a name or being displayed anywhere) and 28k orphan nanomaterials without any association to components or notifications.

We're introducing 2 rake tasks to remove them from our DB.

### Nanomaterials without nanoelements removal
Any nanomaterial with no associated nanoelement is invalid and should be deleted from our DB.

Even when they belong to a submitted notification, we only display nanoelement names and info in the notification info.
It is safe to delete nanomaterials with no nanoelement and consequently no name.

### Orphan nnomaterials removal
Between Jan and October 2021 28.5k nanomaterials were created without being associated with any notification or component.

This seems to be caused by some bug/error when importing zip notifications. Either caused by the importing task or by the imported data itself.

Whatever the reason, these nanomaterials are not associated with any notification, so they should be deleted together with any nanoelement they may contain.

### Fix data for nanomaterials with multiple nanoelements
There are 37 nanomaterials in production DB that contain more than 1 nanoelement (they all have 2 nanoelements).
The relationship between nanomaterials and nanoelements should be `1 to 1`. We resolve this by duplicating the nanomaterial and associating the new nanomaterial with the same component/notification as the original one while assigning the second nanoelement to this new nanomaterial.
This way we will move from 1 nanomaterial with 2 nanoelements for the notification/component to 2 nanomaterials with an individual nanoelement each.