### PR TITLE
Fix exposure routes empty submission

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -181,7 +181,7 @@ private
   end
 
   def update_add_exposure_routes
-    exposure_routes = params[:component].select { |_key, value| value == "1" }.keys
+    exposure_routes = params.fetch(:component, {}).select { |_key, value| value == "1" }.keys
     if @component.update_with_context({ exposure_routes: }, step)
       render_next_step @component
     else

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_exposure_routes.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_exposure_routes.html.erb
@@ -15,7 +15,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <% if @component.errors.messages.include?(:exposure_routes) %>
-        <%= govukErrorSummary(titleText: "There is a problem", errorList: [{text: @component.errors.messages[:exposure_routes][0], href: "#nano_material_dermal"}] ) %>
+        <%= govukErrorSummary(titleText: "There is a problem", errorList: [{text: @component.errors.messages[:exposure_routes][0], href: "#component_dermal"}] ) %>
       <% end %>
       <%= govukCheckboxes(form: form,
                           key: :exposure_routes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1590)

Fixing a server error when the user does not select any of the exposure routes options and submits the form.

### Before
![Screenshot from 2022-09-16 12-34-12](https://user-images.githubusercontent.com/1227578/190640242-3283a83b-9320-4e2b-a8d2-7ef3a9e93f29.png)
![Screenshot from 2022-09-16 12-38-28](https://user-images.githubusercontent.com/1227578/190640267-26ad3625-b470-4641-96e1-86c3e7bb568d.png)


### After 
![Screenshot from 2022-09-16 13-35-49](https://user-images.githubusercontent.com/1227578/190640290-5bf92fcd-6e68-4930-9ac0-9371273de953.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
