### PR TITLE
Add banner on Submit about oncoming ingredients changes

### DIFF
--- a/cosmetics-web/app/views/layouts/application.html.erb
+++ b/cosmetics-web/app/views/layouts/application.html.erb
@@ -33,7 +33,8 @@
         <%= govukNotificationBanner(text: confirmation, type: "success") %>
       <% elsif submit_domain? %>
         <div class="govuk-!-margin-top-4"></div>
-        <%= govukNotificationBanner(text: "This service is updating on the 3 October 2022. PDF ingredient documents will be deleted from unsubmitted draft notifications.") %>
+        <%= govukNotificationBanner(text: "This service is updating on the 3 October 2022.<br class='opss-br-desktop'>" \
+                                          "PDF ingredient documents will be deleted from unsubmitted draft notifications.".html_safe) %>
       <% end %>
 
       <main id="main-content" class="govuk-main-wrapper app-main-class" role="main">

--- a/cosmetics-web/app/views/layouts/application.html.erb
+++ b/cosmetics-web/app/views/layouts/application.html.erb
@@ -31,6 +31,9 @@
       <% if confirmation %>
         <div class="govuk-!-margin-top-4"></div>
         <%= govukNotificationBanner(text: confirmation, type: "success") %>
+      <% elsif submit_domain? %>
+        <div class="govuk-!-margin-top-4"></div>
+        <%= govukNotificationBanner(text: "This service is updating on the 3 October 2022. PDF ingredient documents will be deleted from unsubmitted draft notifications.") %>
       <% end %>
 
       <main id="main-content" class="govuk-main-wrapper app-main-class" role="main">

--- a/cosmetics-web/app/views/layouts/application.html.erb
+++ b/cosmetics-web/app/views/layouts/application.html.erb
@@ -33,8 +33,8 @@
         <%= govukNotificationBanner(text: confirmation, type: "success") %>
       <% elsif submit_domain? %>
         <div class="govuk-!-margin-top-4"></div>
-        <%= govukNotificationBanner(text: "This service is updating on the 3 October 2022.<br class='opss-br-desktop'>" \
-                                          "PDF ingredient documents will be deleted from unsubmitted draft notifications.".html_safe) %>
+        <%= govukNotificationBanner(text: "This service is updating on the 3 October 2022. <br class='opss-br-desktop'> " \
+                                          "<abbr>PDF</abbr> ingredient documents will be deleted from unsubmitted draft notifications.".html_safe) %>
       <% end %>
 
       <main id="main-content" class="govuk-main-wrapper app-main-class" role="main">

--- a/cosmetics-web/app/views/submit/landing_page/index.html.erb
+++ b/cosmetics-web/app/views/submit/landing_page/index.html.erb
@@ -32,6 +32,10 @@
   <% if confirmation %>
     <div class="govuk-!-margin-top-4"></div>
     <%= govukNotificationBanner(text: confirmation, type: "success") %>
+  <% elsif submit_domain? %>
+    <div class="govuk-!-margin-top-4"></div>
+    <%= govukNotificationBanner(text: "This service is updating on the 3 October 2022. <br class='opss-br-desktop'> " \
+                                      "<abbr>PDF</abbr> ingredient documents will be deleted from unsubmitted draft notifications.".html_safe) %>
   <% end %>
 
   <main id="main-content" class="govuk-main-wrapper app-main-class" role="main">


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1582)

Add a banner on the submit service alerting users about the incoming ingredients changes on October 3rd.
Only display when there are no success banners for the page.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

![image](https://user-images.githubusercontent.com/1227578/191219257-edc8cafe-4018-48d3-9117-f45846f2ec5c.png)

### Not displayed when there is a success banner:
![image](https://user-images.githubusercontent.com/1227578/191224593-a41ff900-9f79-4b0f-b2fe-cd519e0894c5.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2596-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2596-search-web.london.cloudapps.digital/
