### PR TITLE
Remove component id from nanomaterials

### DIFF
--- a/cosmetics-web/db/migrate/20220920110832_remove_component_id_from_nano_materials.rb
+++ b/cosmetics-web/db/migrate/20220920110832_remove_component_id_from_nano_materials.rb
@@ -1,0 +1,7 @@
+class RemoveComponentIdFromNanoMaterials < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      remove_column :nano_materials, :component_id, :bigint
+    end
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_09_124102) do
+ActiveRecord::Schema.define(version: 2022_09_20_110832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -169,10 +169,8 @@ ActiveRecord::Schema.define(version: 2022_09_09_124102) do
     t.string "exposure_condition"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "component_id"
     t.string "exposure_routes", array: true
     t.integer "notification_id"
-    t.index ["component_id"], name: "index_nano_materials_on_component_id"
     t.index ["notification_id"], name: "index_nano_materials_on_notification_id"
   end
 
@@ -377,7 +375,6 @@ ActiveRecord::Schema.define(version: 2022_09_09_124102) do
   add_foreign_key "exact_formulas", "components"
   add_foreign_key "image_uploads", "notifications"
   add_foreign_key "nano_elements", "nano_materials"
-  add_foreign_key "nano_materials", "components"
   add_foreign_key "nanomaterial_notifications", "responsible_persons"
   add_foreign_key "notifications", "responsible_persons"
   add_foreign_key "pending_responsible_person_users", "responsible_persons"

--- a/cosmetics-web/lib/tasks/draft_notifications.rake
+++ b/cosmetics-web/lib/tasks/draft_notifications.rake
@@ -1,17 +1,4 @@
 namespace :draft_notifications do
-  desc "Migrate notifications to use new task-based flow structure. This task is safe to run multiple times"
-
-  task migrate_data: :environment do
-    ActiveRecord::Base.transaction do
-      # need to be first as is using existing nano_material exposure info
-      DraftNotificationData.add_info_to_components
-
-      DraftNotificationData.add_nano_materials
-      DraftNotificationData.assign_nano_materials_to_notification
-      DraftNotificationData.add_component_nano_material_relation
-    end
-  end
-
   desc "Change state of notifications. This task can be run just once"
   task rewrite_state: :environment do
     ActiveRecord::Base.transaction do
@@ -22,76 +9,6 @@ end
 
 # Namespaced methods used in rake. It is safe to use each method mutiple times, it should not be necessary though.
 module DraftNotificationData
-  # each NanoElement should be given his own NanoMaterial
-  # previously NanoMaterial was containter for all NanoElements withinComponent,
-  # it has to change as we add nano materials before adding components
-  # and now one NanoMaterial can be used in multiple components in the same notification
-  #
-  # This method is not backwards compatibile.
-  def self.add_nano_materials
-    nano_materials.each do |nano_material|
-      nano_elements = NanoElement.where(nano_material_id: nano_material.id)
-
-      next if nano_elements.count < 2
-
-      component = Component.find_by(id: nano_material.component_id)
-      next if component.nil?
-
-      # create new nano material for next nano elements
-      nano_elements[1..].each do |nano_element|
-        new_nano_material = NanoMaterial.create!(notification: component.notification)
-        nano_element.update!(nano_material_id: new_nano_material.id)
-        # add component relation for new nanomaterial
-        ComponentNanoMaterial.create(nano_material: new_nano_material, component:)
-      end
-    end
-  end
-
-  # in new flow we add nanomaterial first so there is need to assign NanoMaterial
-  # to proper notification
-  def self.assign_nano_materials_to_notification
-    nano_materials.each do |nano_material|
-      component = Component.find_by(id: nano_material.component_id)
-      if component.nil?
-        log("NanoMaterial #{nano_material.id} has no component")
-        next
-      end
-
-      nano_material.notification_id = component.notification.id
-      nano_material.save
-    end
-  end
-
-  # In new datastructure, its component that holds information about exposure condition.
-  # TODO: should it be first?
-  def self.add_info_to_components
-    nano_materials.each do |nano_material|
-      component = Component.find_by(id: nano_material.component_id)
-      next if component.nil?
-
-      component.exposure_routes    = nano_material.exposure_routes
-      component.exposure_condition = nano_material.exposure_condition
-      next if component.save
-
-      log("Component #{component.id} could not be saved")
-      # Some early data issues were causing troubles, save anyway
-      component.save(validate: false)
-    end
-  end
-
-  # In new datastructure, given nano material can be assigned to multiple components
-  def self.add_component_nano_material_relation
-    nano_materials.each do |nano_material|
-      component = Component.find_by(id: nano_material.component_id)
-      next if component.nil?
-
-      # Ommit relations that already exist
-      next if ComponentNanoMaterial.find_by(nano_material:, component:)
-
-      ComponentNanoMaterial.create(nano_material:, component:)
-    end
-  end
-
   # TODO: check if new flow makes possible to create empty notification
   def self.rewrite_state
     # rubocop:disable Rails/UniqBeforePluck
@@ -126,10 +43,5 @@ module DraftNotificationData
 
   def self.log(msg)
     Rails.logger.info("[DRAFT_MIGRATION] #{msg}")
-  end
-
-  # we want only nanomaterials that has nano elements
-  def self.nano_materials
-    @nano_materials ||= NanoMaterial.joins("LEFT JOIN nano_elements on nano_elements.nano_material_id = nano_materials.id").where("nano_elements.id IS NOT null")
   end
 end

--- a/cosmetics-web/lib/tasks/nanomaterials.rake
+++ b/cosmetics-web/lib/tasks/nanomaterials.rake
@@ -49,7 +49,7 @@ namespace :nanomaterials do
     task_name = "[nanomaterials:delete_orphan_nanomaterials]"
     orphan_nanomaterials = NanoMaterial.left_joins(:component_nano_materials)
                                        .where(component_nano_materials: { nano_material_id: nil },
-                                              nano_materials: { component_id: nil, notification_id: nil })
+                                              nano_materials: { notification_id: nil })
     affected_count = orphan_nanomaterials.count
     Rails.logger.info "#{task_name} Found #{affected_count} orphan nanomaterials without any associated components or notifications"
     Rails.logger.info "#{task_name} Deleting them..."

--- a/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
+++ b/cosmetics-web/spec/tasks/nanomaterials_tasks_spec.rb
@@ -34,28 +34,20 @@ describe "nanomaterials.rake" do
     subject(:task) { Rake::Task["nanomaterials:delete_orphan_nanomaterials"] }
 
     it "deletes any nano materials without an associated component or notification" do
-      create_list(:nano_material, 2, :skip_validations, component_id: nil, notification_id: nil)
+      create_list(:nano_material, 2, :skip_validations, notification_id: nil)
 
       expect { task.invoke }.to change(NanoMaterial, :count).by(-2)
     end
 
     it "does not delete nanomaterials with an associated notification" do
-      nano = create(:nano_material, component_id: nil)
-
-      expect { task.invoke }.not_to change(NanoMaterial, :count)
-      expect(NanoMaterial.all).to eq [nano]
-    end
-
-    it "does not delete nanomaterials with a deprecated reference to component id" do
-      component = create(:component)
-      nano = create(:nano_material, :skip_validations, notification_id: nil, component_id: component.id)
+      nano = create(:nano_material)
 
       expect { task.invoke }.not_to change(NanoMaterial, :count)
       expect(NanoMaterial.all).to eq [nano]
     end
 
     it "does not delete nanomaterials with an associated component" do
-      nano = create(:nano_material, :skip_validations, notification_id: nil, component_id: nil)
+      nano = create(:nano_material, :skip_validations, notification_id: nil)
       nano.components << create(:component)
 
       expect { task.invoke }.not_to change(NanoMaterial, :count)
@@ -88,7 +80,6 @@ describe "nanomaterials.rake" do
         expect(new_nano_material).to have_attributes(
           exposure_condition: nano_material.exposure_condition,
           exposure_routes: nano_material.exposure_routes,
-          component_id: nano_material.component_id,
           notification_id: nano_material.notification_id,
           created_at: nano_material.created_at,
           updated_at: nano_material.updated_at,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1593)

## Description
<!--- Describe your changes in detail -->
Now the relationship between `NanoMaterial` and `Component` is a many-to-many through a `ComponentNanoMaterial` model/table. 