### PR TITLE
Fix h1 wording in Smoke tests

### DIFF
--- a/cosmetics-web/spec/smoke/search_smoke_test_spec.rb
+++ b/cosmetics-web/spec/smoke/search_smoke_test_spec.rb
@@ -20,13 +20,13 @@ RSpec.feature "Search smoke test" do
         code = get_code.scan(/\d{5}/).first
         smoke_complete_secondary_authentication_with(code, session)
         attempts += 1
-        break if session.has_css?("h1", text: "Search cosmetic products")
+        break if session.has_css?("h1", text: "Cosmetic products search")
         break if attempts > 3
 
         sleep attempts * 10
       end
 
-      expect(session).to have_css("h1", text: "Search cosmetic products")
+      expect(session).to have_css("h1", text: "Cosmetic products search")
       expect(session).to have_xpath("//input[contains(@id,'q')]")
 
       session.fill_in("notification_search_form_q", with: product_name)


### PR DESCRIPTION
The wording has been changed. We need to update the smoke test to assert against the new wording.
