### PR TITLE
Move ingredients search date text

### DIFF
--- a/cosmetics-web/app/assets/application/stylesheets/opss/_opss-msa.scss
+++ b/cosmetics-web/app/assets/application/stylesheets/opss/_opss-msa.scss
@@ -179,6 +179,15 @@ header.govuk-header + .opss-std-row.opss-std-row--borders {
     }
 }
 
+.opss-font-size--reduced-s { /* inherited size - small amount reduced size*/
+    font-size: 92% !important;
+}
+
+a.govuk-link.opss-link--no-hover:hover {
+    text-decoration: none !important;
+    color: $govuk-link-colour !important;
+}
+
 /*.opss-list--borders {
     li {
         padding: govuk-spacing(4) 0 govuk-spacing(2) 0;
@@ -395,9 +404,10 @@ tbody.opss-table-grouped-by--2 + tbody.opss-table-grouped-by--none {
     }
 }
 
-/* check if this code BELOW is still required? .... */
+/*.opss-text-align-right > form > select {min-width: none; }*/
+select {min-width: 11.5em} /*localhost version not styling like new gds v?*/
 
-/* used on the search page - starts */
+/* used on the search page - starts.  (Required for filters in left col on search pgs) */
 body.js-enabled .govuk-radios__conditional--hidden.opss-nojs-hide {
     height: 0; overflow: hidden; float: left; margin: 0;
 }
@@ -408,3 +418,10 @@ body.js-enabled .govuk-radios__conditional.opss-nojs-hide {
     display: block;
 }
 /* used on the search page - ends */
+
+div[class*="radios--small"],
+div[class*="checkboxes--small"] {
+    label[class*="font-size-16"] {
+        line-height: 1.5 !important
+    }
+}

--- a/cosmetics-web/app/assets/application/stylesheets/opss/_opss-shared.scss
+++ b/cosmetics-web/app/assets/application/stylesheets/opss/_opss-shared.scss
@@ -524,9 +524,17 @@ ul.opss-left-nav {
     }
 
 }
-
+.opss-test-text {
+    color: $govuk-text-colour;
+}
+.opss-primary-text {
+    color: $govuk-text-colour;
+}
 .opss-secondary-text {
     color: $govuk-secondary-text-colour;
+}
+a[class*="link--no-underline"] sup {
+    color: $govuk-text-colour;
 }
 
 .opss-border-top, .opss-border-bottom, .opss-border-left, .opss-border-right, .opss-border-all {

--- a/cosmetics-web/app/assets/application/stylesheets/opss/_opss-shared.scss
+++ b/cosmetics-web/app/assets/application/stylesheets/opss/_opss-shared.scss
@@ -29,9 +29,9 @@ form.opss-cookie-form {/*for the cookie banner*/
 input[type="checkbox"]:disabled + label {opacity: 1 !important; }*/
 
 /* not normalised by gds library - starts */
-figure, 
+figure,
 figcaption {
-    margin: 0; padding: 0; display: block; 
+    margin: 0; padding: 0; display: block;
 }
 /* not normalised by gds library - ends */
 
@@ -88,6 +88,10 @@ h1.govuk-label-wrapper label.govuk-label--l {
         font-weight: 400;
     }
 }*/
+main a.govuk-link:hover {/*recreate new hover styles of latest gds*/
+    //text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+    text-decoration-skip-ink: none;
+}
 .opss-no-wrap {
   white-space: nowrap;
 }
@@ -117,21 +121,21 @@ body.js-enabled .opss-nojs-hide {
 }
 
 .opss-hidden-desktop {
-    visibility: visible; 
+    visibility: visible;
 
     @include govuk-media-query($from: desktop) {
         visibility: hidden;
-    }    
+    }
 }
 
 .opss-float-left {
     float: left;
 }
 .opss-float-right {
-    float: right; 
+    float: right;
 
     & + .opss-float-right {
-        clear: right; 
+        clear: right;
     }
 }
 
@@ -143,8 +147,8 @@ body.js-enabled .opss-nojs-hide {
         float: right;
 
         & + .opss-float-right-desktop {
-            clear: right; 
-        }        
+            clear: right;
+        }
     }
 }
 
@@ -268,11 +272,11 @@ body.js-enabled .opss-nojs-hide {
 
 .opss-warning-text--s {/* make warning text smaller and allow several in succession */
     strong {
-        @include opss-font-size($s: 16px, $l: 1.3); 
+        @include opss-font-size($s: 16px, $l: 1.3);
     }
 
     & + .opss-warning-text--s > span {
-        display: none; 
+        display: none;
     }
 }
 
@@ -288,7 +292,7 @@ abbr[title]{
     }
 }
 
-kbd, 
+kbd,
 samp {
     font-family: inherit;
     font-weight: inherit;
@@ -297,6 +301,9 @@ samp {
 .opss-text-align-center {
     text-align: center;
 }
+*[class^="govuk-heading"].opss-text-align-center {
+    width: 100%;
+}
 
 @include govuk-media-query($from: tablet) {
     .opss-max-width-two-thirds {
@@ -304,7 +311,7 @@ samp {
     }
     .opss-text-align-right {/*this opss style is prefered to govuk-!-text-align-right because it is resolution sensitive*/
         text-align: right; display: inline-block; width: 100%;
-    }    
+    }
 }
 
 .opss-text-underline-offset {
@@ -340,14 +347,20 @@ samp {
 
 @include govuk-media-query($from: desktop) {
     .opss-desktop-min-height--xs {
-        min-height: 130px; 
-    }    
+        min-height: 130px;
+    }
     .opss-desktop-min-height--s {
-        min-height: 180px; 
+        min-height: 180px;
+    }
+    .opss-desktop-min-height--s2 {
+        min-height: 230px;
+    }
+    .opss-desktop-min-height--s3 {
+        min-height: 275px;
     }
     .opss-desktop-min-height--m {
-        min-height: 300px; 
-    }    
+        min-height: 300px;
+    }
     .opss-desktop-padding-0 {
         padding: 0 !important ;
     }
@@ -449,17 +462,18 @@ ul.opss-left-nav {
     padding: 0;
 
     ul.govuk-list {
-        margin-top: 0; 
+        margin-top: 0;
     }
 
     & > li.opss-left-nav__active {
         @include menu-inset-anchors;
-    }    
+    }
 
     li {
         margin-bottom: 0;
         padding: 8px 0 5px 0;
         @include opss-font-size($s: 17px, $l: 1.2);
+        @include word-wrap;
 
             ul {
                 padding-left: govuk-spacing(4);
@@ -468,21 +482,17 @@ ul.opss-left-nav {
 
             ul li.opss-left-nav__active {/* 3rd nested ULs */
                 @include menu-inset-anchors;
-            }        
+            }
 
             a {
                 text-decoration: none !important;
                 text-underline-offset: 0.1em;
 
-                &:hover {
-                    text-decoration: underline !important;
-                    text-decoration-thickness: 0.2em !important;
-                    text-decoration-thickness: 3px !important;
-                    -webkit-text-decoration-skip-ink: none;
-                    text-decoration-skip-ink: none;
-                    -webkit-text-decoration-skip: none;
-                    text-decoration-skip: none; 
-                }
+                /*&:hover {//styles supersede by gds upgrade to 4.2
+                    text-decoration: underline !important; text-decoration-thickness: 0.2em !important;
+                    text-decoration-thickness: 3px !important; -webkit-text-decoration-skip-ink: none;
+                    text-decoration-skip-ink: none; -webkit-text-decoration-skip: none; text-decoration-skip: none;
+                }*/
 
                 span {
                     font-size: 90%;
@@ -490,9 +500,9 @@ ul.opss-left-nav {
             }
     }
 
-    /*& > li > ul.govuk-list { // 2nd nested ULs 
-        padding-top: govuk-spacing(1); margin: govuk-spacing(4) 0 govuk-spacing(2) 0; 
-    } */    
+    /*& > li > ul.govuk-list { // 2nd nested ULs
+        padding-top: govuk-spacing(1); margin: govuk-spacing(4) 0 govuk-spacing(2) 0;
+    } */
 
     & > li:first-child {
         padding-top: 5px;
@@ -512,7 +522,7 @@ ul.opss-left-nav {
         margin-left: - govuk-spacing(2) - 4;
         border-left: 4px solid $govuk-brand-colour;
     }
-   
+
 }
 
 .opss-secondary-text {
@@ -535,7 +545,12 @@ ul.opss-left-nav {
     .opss-border-all {border-width: 1px; }
     /*.opss-border-all--padding-sm {padding: govuk-spacing(1); }
     a.opss-border-all--padding-sm {padding: 7px 13px 8px 11px; }*/
+
+    a[class*="font-size-14"].opss-border-all {
+        line-height: 1.2 !important;
+    }
 }
+
 .opss-details--sm {
     @include govuk-media-query($from: desktop) {
         summary {
@@ -590,7 +605,7 @@ ul.opss-left-nav {
 }
 
 .opss-button-refresh {
-    padding-left: 40px; 
+    padding-left: 40px;
     background-image: url("data:image/webp;base64,UklGRrABAABXRUJQVlA4TKQBAAAvGAAGELXIkiTJkSoOodXEfnP/G3bPLkdIZKATnpZmCNq2ba5X3TOYgbRtQ82u4XBt2zb27N+2/z+2k9JprSdw0tm2n8C2bVa22dm2JyBTwHq2XwyOl/8AJAbqpuCSsIUqGEAUtMMCrMM0VIMPiAHqiucDQf0F3uF/DheQDDR14gIEZ7jstjADmupEcIevtoUX2IJ5OISftoUDUF8BPbgr/BWuIRa0gLwBQAcrKILf/ipMAQngAB39VVgBHefgAo9tIWQCdk8tnHxTk2WDCl5t/wPT/YQEStpCoJpRhYa24OTvBPZbOAO+JokjOLSFbFV4b2FUMwESGII+aIM1PLTQD+p/wOBPW2he2zRAeuED3n618PsXvuAZ/OC9hZE1hcKu3goHLZwAT4eDe6iQPwNfhbK2t2qSfFP/DS8qOMJvC0egUPcSknxT/7UvaoTu/iosgLpjcvKCCvkQrCaC4VtbOIdwUC0QhhzcQ3XZYBIFb/ht2zfYAachpwmqGWgQPOAG/kfwn2zrAgQdaISvtrc7RRVMIRH6YBe8dotTIP64giROdwA=");
     background-position-x: 8px;
     background-position-y: center;
@@ -607,15 +622,15 @@ ul.opss-left-nav {
     }
 
     &.opss-details-img--thumbnail + .opss-img-caption {
-        max-width: 174px; 
+        max-width: 174px;
         white-space: nowrap;
         overflow: hidden;
-        text-overflow: ellipsis; 
+        text-overflow: ellipsis;
     }
 }
 
 .opss-img-caption {
-    font-family: $std-font-family; 
+    font-family: $std-font-family;
     @include opss-font-size($s: 14px, $l: 1.25);
 }
 
@@ -709,13 +724,18 @@ dl.opss-summary-list-aside {
             word-break: break-all;
             word-break: break-word; /*no adding hypens*/
         }
+
+        dd[class*="summary-list__actions"] a { /*don't wrap the short "edit" type action links*/
+            white-space: nowrap;
+        }
+
         & > span.govuk-summary-list__actions {display: none !important; }/* 2. protects against rogue legacy psd invalid html */
     }
 
     @include govuk-media-query($from: desktop) {
         &.opss-summary-list-mixed--narrow-dt + .opss-text-align-right {
             position: relative;
-            top: - govuk-spacing(4);  
+            top: - govuk-spacing(4);
         }
 
         &.opss-summary-list-mixed--narrow-dt > div {
@@ -725,46 +745,56 @@ dl.opss-summary-list-aside {
             dt + dd {
                 min-width: 50%;
             }
-        }        
+        }
 
         &.opss-summary-list-mixed--narrow-actions > div {
             dd[class$="__actions"] {
                 width: 10%;
-            } 
+            }
         }
 
         &.opss-summary-list-mixed--compact > div {
             dt, dd {
-                margin-top: 0; 
-                margin-bottom: 0; 
-                padding-top: 0; 
-                padding-bottom: govuk-spacing(1);  
-                @include opss-font-size($s: 16px, $l: 1.2); 
+                margin-top: 0;
+                margin-bottom: 0;
+                padding-top: 0;
+                padding-bottom: govuk-spacing(1);
+                @include opss-font-size($s: 16px, $l: 1.2);
                 color: $govuk-secondary-text-colour;
             }
         }
     }
 
-    &.opss-summary-list-mixed--image > div:first-child dt {
-        vertical-align: bottom;
-    
-        & + dd {
-            padding-right: govuk-spacing(0); 
+    &.opss-summary-list-mixed--image {
+        margin-bottom: govuk-spacing(8);
+        border-bottom: 1px solid $govuk-input-border-colour;
 
-            figure {
-                img {
-                    max-width: 100%;
-                } 
+        .opss-tabs li:last-child & {
+            margin-bottom: govuk-spacing(0);
+            border-bottom: none 0;
+        }
 
-                a { 
-                    display: block; 
-                    margin-top: - govuk-spacing(5); 
-                    margin-bottom: govuk-spacing(1); 
+        & > div:first-child dt {
+            vertical-align: bottom;
 
+            & + dd {
+                padding-right: govuk-spacing(0);
+
+                figure {
                     img {
-                        margin-top: -2px;
-                        margin-bottom: -2px; 
-                        border: 0;
+                        max-width: 100%;
+                    }
+
+                    a {
+                        display: block;
+                        margin-top: - govuk-spacing(5);
+                        margin-bottom: govuk-spacing(1);
+
+                        img {
+                            margin-top: -2px;
+                            margin-bottom: -2px;
+                            border: 0;
+                        }
                     }
                 }
             }
@@ -787,8 +817,8 @@ dl.opss-summary-list-aside {
         &.opss-summary-list-mixed--narrow-actions > div {/*firefox only: col flow bug */
             dd[class$="__actions"] {
                 width: auto;
-            } 
-        }        
+            }
+        }
     }
 }
 
@@ -807,8 +837,8 @@ dl.opss-summary-list-aside {
 
         dt, dd {
             @include opss-font-size($s: 16px, $l: 1.2);
-            padding-top: govuk-spacing(1);         
-            padding-bottom: govuk-spacing(1);            
+            padding-top: govuk-spacing(1);
+            padding-bottom: govuk-spacing(1);
         }
 
         .govuk-accordion__section-content & {
@@ -817,7 +847,7 @@ dl.opss-summary-list-aside {
             div:last-child {
                 dt, dd {
                     border-bottom: none;
-                } 
+                }
             }
         }
     }
@@ -825,7 +855,7 @@ dl.opss-summary-list-aside {
         div {
             dt,  dd {
                 width: 33%;
-            }  
+            }
         }
     }
     .opss-summary-list-mixed.opss-summary-list--equal-last-2-wide {
@@ -835,37 +865,37 @@ dl.opss-summary-list-aside {
             }
             dd {
                 width: 40%;
-            }  
+            }
         }
-    }    
+    }
 }
 
 /* bespoke styles for Cases accordian section on a product page ... starts */
 .opss-summary-list-mixed.opss-summary-list-mixed--4-cols dt {width: 35%; }
-.opss-summary-list-mixed.opss-summary-list-mixed--4-cols dd, 
+.opss-summary-list-mixed.opss-summary-list-mixed--4-cols dd,
 .opss-summary-list-mixed.opss-summary-list-mixed--4-cols dd + dd {width: 25%; }
 .opss-summary-list-mixed.opss-summary-list-mixed--4-cols dd:last-of-type {width: 15%; }
 /* bespoke styles for Cases accordian section on a product page ... ends */
 
 dd dl.opss-nested-definition-list {
-    margin: 0; 
+    margin: 0;
     @include opss-font-size($s: 16px, $l: 1.6);
 
     & > div {
-        width: 100%; 
+        width: 100%;
     }
 
     dt {
-        font-weight: bold; 
-        display: inline-block; 
-        margin: 0 govuk-spacing(2) 0 0; 
+        font-weight: bold;
+        display: inline-block;
+        margin: 0 govuk-spacing(2) 0 0;
         width: 45%;
     }
 
     dd {
-        display: inline-block; 
-        padding-right: 0; 
-        margin-left: 0; 
+        display: inline-block;
+        padding-right: 0;
+        margin-left: 0;
     }
 }
 
@@ -884,9 +914,9 @@ dd dl.opss-nested-definition-list {
 
     @include govuk-media-query($from: desktop) {
         & > div {
-            display: inline-block; 
-            width: 100%; 
-        }        
+            display: inline-block;
+            width: 100%;
+        }
     }
 
     dt {
@@ -902,7 +932,7 @@ dd dl.opss-nested-definition-list {
         /* not all style options to match GDS styles are added - you may need to add more when required: e.g, opss-grouping__legend--l */
         .opss-grouping__heading-l,
         .opss-grouping__heading-m,
-        .opss-grouping__heading-s, 
+        .opss-grouping__heading-s,
         .opss-grouping__legend--s {
             background-color: govuk-colour("white");
             display: inline-block;
@@ -920,8 +950,8 @@ dd dl.opss-nested-definition-list {
         }
         .opss-grouping__legend--s {
             top: govuk-spacing(0);
-            padding-right: 0; 
-        }        
+            padding-right: 0;
+        }
         .opss-grouping__heading--norm {
             font-weight: normal;
         }
@@ -936,9 +966,7 @@ dd dl.opss-nested-definition-list {
         }
 
         & > dl > div:last-child {
-            dt, dd {
-                border-bottom: none;
-            }
+            border-bottom: none;
         }
     }
 
@@ -1026,15 +1054,15 @@ dd dl.opss-nested-definition-list {
 .opss-table--2-row-groups {
     tbody tr:first-child {
         & > * {
-            border-bottom: none 0; 
+            border-bottom: none 0;
         }
         & + tr > * {
             border-bottom: 1px solid $govuk-border-colour;
         }
     }
-    tbody:last-of-type tr > th, 
+    tbody:last-of-type tr > th,
     tbody:last-of-type tr > td {
-        border-bottom: none 0; 
+        border-bottom: none 0;
     }
 }
 
@@ -1106,9 +1134,9 @@ dd dl.opss-nested-definition-list {
         tbody tr {
             th, td {
                 border-bottom: 1px solid $govuk-border-colour;
-                padding-top: govuk-spacing(2); 
-                padding-bottom: govuk-spacing(2); 
-                vertical-align: middle; 
+                padding-top: govuk-spacing(2);
+                padding-bottom: govuk-spacing(2);
+                vertical-align: middle;
             }
         }
     }
@@ -1140,10 +1168,10 @@ dd dl.opss-nested-definition-list {
         @include govuk-media-query($from: tablet) {
             thead th:nth-child(1) {width: 50%; }
         }
-    }    
+    }
 }
 
-.opss-table, 
+.opss-table,
 .opss-table-items {
     tbody td {
         span > em,
@@ -1162,7 +1190,7 @@ dd dl.opss-nested-definition-list {
             border-top: 1px solid govuk-colour("light-grey");
         }
     }
-    tbody tr:first-child, 
+    tbody tr:first-child,
     tbody tr:last-child {
         th, td {
             border-bottom: none;
@@ -1172,8 +1200,8 @@ dd dl.opss-nested-definition-list {
     &.opss-table-items--sm {
         tbody tr {
             th, td {
-                padding-top: govuk-spacing(2); 
-                padding-bottom: govuk-spacing(2); 
+                padding-top: govuk-spacing(2);
+                padding-bottom: govuk-spacing(2);
             }
         }
     }
@@ -1187,7 +1215,7 @@ dd dl.opss-nested-definition-list {
         position: sticky;
         top: 20px;
     }
-    
+
     .opss-desktop-padding-left-0 {
         padding-left: 0;
     }
@@ -1229,6 +1257,3 @@ dd dl.opss-nested-definition-list {
         margin-right: govuk-spacing(1) - 2;
     }
 }
-
-
-

--- a/cosmetics-web/app/views/poison_centres/ingredients_search/_results.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients_search/_results.html.erb
@@ -10,7 +10,9 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <p class="govuk-body-s"><%= pluralize(search_response.results.total, 'notification') %> <%= display_keywords %> <%= display_filters_informations %> <%= search_response.results.total == 1 ? "was found." : "were found." %></p>
+      <p class="govuk-body-s">
+        <%= pluralize(search_response.results.total, 'notification') %> <%= display_keywords %> <%= display_filters_informations %> (submitted after 2 October 2022) <%= search_response.results.total == 1 ? "was found." : "were found." %>
+      </p>
     </div>
   </div>
 

--- a/cosmetics-web/app/views/poison_centres/ingredients_search/show.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients_search/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Ingredients search" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full opss-desktop-min-height--s">
+  <div class="govuk-grid-column-full opss-desktop-min-height--s2">
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       Ingredients search
@@ -9,6 +9,10 @@
 
     <p class="govuk-body opss-secondary-text">
       Search cosmetic product notifications for notifications which include a specific ingredient.
+      <br class="opss-br-desktop">
+      <span class="govuk-!-font-weight-bold opss-primary-text">
+        Only products notified after 2 October 2022 are searchable for ingredients.
+      </span>
     </p>
 
     <details class="govuk-details govuk-!-width-two-thirds opss-details--sm" data-module="govuk-details">
@@ -18,11 +22,6 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-
-        <p class="govuk-body-s govuk-!-margin-bottom-4">
-        <span class="govuk-!-font-weight-bold">Currently, only products notified after [dd month year] are searchable for ingredients.</span>
-        </p>
-
         <p class="govuk-body-s govuk-!-margin-bottom-4">
         <span id="search-hint">For best results, search for an individual ingredient.</span> This will search cosmetic product notifications for products which use it.
         </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1612)

## Description
<!--- Describe your changes in detail -->
Include the date from when notifications with ingredients can be searched by ingredients.

We are adding it in both the subtext of the ingredients search page and the wording for the number of results found.

### Before
![Screenshot from 2022-10-04 11-41-55](https://user-images.githubusercontent.com/1227578/193820612-4f2ad915-4f07-45b6-b012-d3cf86796dba.png)

### After

![Screenshot from 2022-10-04 13-33-24](https://user-images.githubusercontent.com/1227578/193820790-05378ff2-8d29-44b3-a522-e8aead633757.png)



## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2617-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2617-search-web.london.cloudapps.digital/


