### PR TITLE
Fix environment variables incorrectly configured in manifest files

### DIFF
--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -27,7 +27,7 @@ cp -a ./infrastructure/env/. ./cosmetics-web/env/
 export CF_STARTUP_TIMEOUT=25
 
 # Deploy the submit app and set the hostname
-cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-instances=$WEB_INSTANCES --var web-max-threads=$WEB_MAX_THREADS --var worker-instances=$WORKER_INSTANCES --var worker-max-threads=$WORKER_MAX_THREADS --var sentry-service-name=$SENTRY_SERVICE_NAME --strategy rolling
+cf push $APP_NAME -f $MANIFEST_FILE --app-start-timeout 180 --var app-name=$APP_NAME --var submit-host=$SUBMIT_HOST --var search-host=$SEARCH_HOST --var web-instances=$WEB_INSTANCES --var worker-instances=$WORKER_INSTANCES --var worker-max-threads=$WORKER_MAX_THREADS --var sentry-service-name=$SENTRY_SERVICE_NAME --strategy rolling
 
 # Remove the copied infrastructure env files to clean up
 rm -R cosmetics-web/env/

--- a/cosmetics-web/manifest.review.yml
+++ b/cosmetics-web/manifest.review.yml
@@ -13,6 +13,8 @@ applications:
     COSMETICS_HOST: ((cosmetics-host))
     OS_NAMESPACE: ((cosmetics-instance-name))
     SENTRY_CURRENT_ENV: ((sentry-current-env))
+    RAILS_MAX_THREADS: ((web-max-threads))
+    WEB_CONCURRENCY: ((web-concurrency))
   stack: cflinuxfs3
   services:
     - ((cosmetics-web-database))
@@ -31,17 +33,12 @@ applications:
     - cosmetics-seed-env
   processes:
     - type: web
-      env:
-        RAILS_MAX_THREADS: ((web-max-threads))
-        WEB_CONCURRENCY: ((web-concurrency))
-      command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate db:seed open_search:reindex && RAILS_MIN_THREADS=((web-max-threads)) RAILS_MAX_THREADS=((web-max-threads)) WEB_CONCURRENCY=((web-concurrency)) bundle exec puma -C config/puma.rb
+      command: export $(./env/get-env-from-vcap.sh) && bin/rake cf:on_first_instance db:migrate db:seed open_search:reindex && bundle exec puma -C config/puma.rb
       instances: 1
       memory: 1G
       disk-quota: 2G
     - type: worker
-      env:
-        RAILS_MAX_THREADS: ((worker-max-threads))
-      command: export $(./env/get-env-from-vcap.sh) && bin/yarn install && bin/sidekiq -C config/sidekiq.yml
+      command: export $(./env/get-env-from-vcap.sh) && bin/yarn install && RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: 1
       memory: 500M

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -29,15 +29,11 @@ applications:
   path: .
   processes:
     - type: web
-      env:
-        RAILS_MAX_THREADS: ((web-max-threads))
       command: export $(./env/get-env-from-vcap.sh) && STATEMENT_TIMEOUT=60s bin/rake cf:on_first_instance db:migrate && bundle exec puma
       instances: ((web-instances))
       memory: 4G
     - type: worker
-      env:
-        RAILS_MAX_THREADS: ((worker-max-threads))
-      command: export $(./env/get-env-from-vcap.sh) && bin/yarn install && bin/sidekiq -C config/sidekiq.yml
+      command: export $(./env/get-env-from-vcap.sh) && bin/yarn install && RAILS_MAX_THREADS=((worker-max-threads)) bin/sidekiq -C config/sidekiq.yml
       health-check-type: process
       instances: ((worker-instances))
       memory: 2G


### PR DESCRIPTION
The [CloudFoundry app manifest specification](https://v3-apidocs.cloudfoundry.org/version/3.76.0/index.html#the-app-manifest-specification) shows that there is no `env` section for `processes`, and therefore these were never being set in the applications.

Additionally, in production and staging (but not review apps) there is a user-provided service called `cosmetics-puma-env` which provides the `RAILS_MAX_THREADS`, `RAILS_MIN_THREADS` and `WEB_CONCURRENCY` environment variables. These would override the definition in the manifest which would cause confusion.

In the review apps manifest, the environment variables are overridden in the `command` definition which was overriding the `env` definition, which would similarly cause confusion.

I have also removed the increased `STATEMENT_TIMEOUT` on the review apps command which only applied to the database migration task, since this could provide a misleading indicator of behaviour when a migration is deployed to staging and production.

This change does not actually change the configuration of the application as the settings are configured the same as previously, but it should help with diagnosis and configuration in the future.