### PR TITLE
Add details info on nano notifications list page

### DIFF
--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -27,15 +27,40 @@
   </div>
 </div>
 
-<% if @nanomaterial_notifications.present? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govukDetails(summaryHtml: "When can you place products containing nanomaterials on the market".html_safe, classes: "opss-details--m govuk-!-margin-bottom-0") do %>
+      <p class="govuk-body-s">
+          Products containing a nanomaterial notified in the <abbr>EU</abbr> before 1 July 2020 and placed on the market
+          before 1 January 2021 can remain on the market if you submit a product notification before 31 March 2021.
+      </p>
+      <p class="govuk-body-s">
+        Products containing nanomaterials notified in the <abbr>EU</abbr> after 1 July 2020, but before 1 January 2021 can
+        be placed on the <abbr>GB</abbr> market 7 months after first being notified in the <abbr>EU</abbr>. As the cosmetic
+        product has not been on the <abbr>GB</abbr> market prior to 1 January 2021, the product must be notified before
+        being placed on the <abbr>GB</abbr> market.
+      </p>
+      <p class="govuk-body-s">
+        Products containing nanomaterials notified in <abbr>GB</abbr> after 1 January 2021 can be placed on the market 6
+        months after the nanomaterial has first been notified.
+      </p>
+      <p class="govuk-body-s govuk-!-font-weight-bold">
+        Note that you cannot use a nanomaterial as a preservative, <abbr>UV</abbr>-filter or colourant that is not listed
+        in the Annexes.
+      </p>
+    <% end %>
+  </div>
+
+  <% if @nanomaterial_notifications.present? %>
+    <div class="govuk-grid-column-one-third">
       <a href="<%= responsible_person_nanomaterials_path(@responsible_person, :csv) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-14 opss-text-align-right" download="download">
         <span class="opss-download-link-sm"></span>Download a <abbr title="Comma-Separated Values">CSV</abbr> file of notified nanomaterials
       </a>
     </div>
-  </div>
+  <% end %>
+</div>
 
+<% if @nanomaterial_notifications.present? %>
   <div class="govuk-grid-row">
     <section class="govuk-grid-column-full">
       <table id="table-items" class="govuk-table opss-table-items govuk-!-margin-top-5">

--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full govuk-!-margin-top-4">
+  <div class="govuk-grid-column-full govuk-!-margin-top-4 govuk-!-margin-bottom-6">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-2" aria-describedby="nanomaterial-notifications-hint">

--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -22,26 +22,33 @@
         <p  id="nanomaterial-notifications-hint" class="govuk-hint govuk-!-width-two-thirds">
           These are your notified nanomaterials.
         </p>
-        <%= govukDetails(summaryHtml: "Help with nanomaterials and market dates".html_safe, classes: "opss-details--sm") do %>
-          <p class="govuk-body-s">
-              Products containing a nanomaterial notified in the <abbr>EU</abbr> before 1 July 2020 and placed on the market
-              before 1 January 2021 can remain on the market if you submit a product notification before 31 March 2021.
-          </p>
-          <p class="govuk-body-s">
-            Products containing nanomaterials notified in the <abbr>EU</abbr> after 1 July 2020, but before 1 January 2021 can
-            be placed on the <abbr>GB</abbr> market 7 months after first being notified in the <abbr>EU</abbr>. As the cosmetic
-            product has not been on the <abbr>GB</abbr> market prior to 1 January 2021, the product must be notified before
-            being placed on the <abbr>GB</abbr> market.
-          </p>
-          <p class="govuk-body-s">
-            Products containing nanomaterials notified in <abbr>GB</abbr> after 1 January 2021 can be placed on the market 6
-            months after the nanomaterial has first been notified.
-          </p>
-          <p class="govuk-body-s govuk-!-font-weight-bold">
-            Note that you cannot use a nanomaterial as a preservative, <abbr>UV</abbr>-filter or colourant that is not listed
-            in the Annexes.
-          </p>
-        <% end %>
+        <details class="govuk-details opss-details--sm" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Help with nanomaterials and market dates
+            </span>
+          </summary>
+          <div class="govuk-details__text govuk-!-width-three-quarters">
+            <p class="govuk-body-s">
+                Products containing a nanomaterial notified in the <abbr>EU</abbr> before 1 July 2020 and placed on the market
+                before 1 January 2021 can remain on the market if you submit a product notification before 31 March 2021.
+            </p>
+            <p class="govuk-body-s">
+              Products containing nanomaterials notified in the <abbr>EU</abbr> after 1 July 2020, but before 1 January 2021 can
+              be placed on the <abbr>GB</abbr> market 7 months after first being notified in the <abbr>EU</abbr>. As the cosmetic
+              product has not been on the <abbr>GB</abbr> market prior to 1 January 2021, the product must be notified before
+              being placed on the <abbr>GB</abbr> market.
+            </p>
+            <p class="govuk-body-s">
+              Products containing nanomaterials notified in <abbr>GB</abbr> after 1 January 2021 can be placed on the market 6
+              months after the nanomaterial has first been notified.
+            </p>
+            <p class="govuk-body-s govuk-!-font-weight-bold">
+              Note that you cannot use a nanomaterial as a preservative, <abbr>UV</abbr>-filter or colourant that is not listed
+              in the Annexes.
+            </p>
+          </div>
+        </details>
       </div>
     </div>
   </div>

--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -29,7 +29,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govukDetails(summaryHtml: "When can you place products containing nanomaterials on the market".html_safe, classes: "opss-details--m govuk-!-margin-bottom-0") do %>
+    <%= govukDetails(summaryHtml: "Help with nanomaterials and market dates".html_safe, classes: "opss-details--m govuk-!-margin-bottom-0") do %>
       <p class="govuk-body-s">
           Products containing a nanomaterial notified in the <abbr>EU</abbr> before 1 July 2020 and placed on the market
           before 1 January 2021 can remain on the market if you submit a product notification before 31 March 2021.

--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -22,42 +22,29 @@
         <p  id="nanomaterial-notifications-hint" class="govuk-hint govuk-!-width-two-thirds">
           These are your notified nanomaterials.
         </p>
+        <%= govukDetails(summaryHtml: "Help with nanomaterials and market dates".html_safe, classes: "opss-details--sm") do %>
+          <p class="govuk-body-s">
+              Products containing a nanomaterial notified in the <abbr>EU</abbr> before 1 July 2020 and placed on the market
+              before 1 January 2021 can remain on the market if you submit a product notification before 31 March 2021.
+          </p>
+          <p class="govuk-body-s">
+            Products containing nanomaterials notified in the <abbr>EU</abbr> after 1 July 2020, but before 1 January 2021 can
+            be placed on the <abbr>GB</abbr> market 7 months after first being notified in the <abbr>EU</abbr>. As the cosmetic
+            product has not been on the <abbr>GB</abbr> market prior to 1 January 2021, the product must be notified before
+            being placed on the <abbr>GB</abbr> market.
+          </p>
+          <p class="govuk-body-s">
+            Products containing nanomaterials notified in <abbr>GB</abbr> after 1 January 2021 can be placed on the market 6
+            months after the nanomaterial has first been notified.
+          </p>
+          <p class="govuk-body-s govuk-!-font-weight-bold">
+            Note that you cannot use a nanomaterial as a preservative, <abbr>UV</abbr>-filter or colourant that is not listed
+            in the Annexes.
+          </p>
+        <% end %>
       </div>
     </div>
   </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= govukDetails(summaryHtml: "Help with nanomaterials and market dates".html_safe, classes: "opss-details--m govuk-!-margin-bottom-0") do %>
-      <p class="govuk-body-s">
-          Products containing a nanomaterial notified in the <abbr>EU</abbr> before 1 July 2020 and placed on the market
-          before 1 January 2021 can remain on the market if you submit a product notification before 31 March 2021.
-      </p>
-      <p class="govuk-body-s">
-        Products containing nanomaterials notified in the <abbr>EU</abbr> after 1 July 2020, but before 1 January 2021 can
-        be placed on the <abbr>GB</abbr> market 7 months after first being notified in the <abbr>EU</abbr>. As the cosmetic
-        product has not been on the <abbr>GB</abbr> market prior to 1 January 2021, the product must be notified before
-        being placed on the <abbr>GB</abbr> market.
-      </p>
-      <p class="govuk-body-s">
-        Products containing nanomaterials notified in <abbr>GB</abbr> after 1 January 2021 can be placed on the market 6
-        months after the nanomaterial has first been notified.
-      </p>
-      <p class="govuk-body-s govuk-!-font-weight-bold">
-        Note that you cannot use a nanomaterial as a preservative, <abbr>UV</abbr>-filter or colourant that is not listed
-        in the Annexes.
-      </p>
-    <% end %>
-  </div>
-
-  <% if @nanomaterial_notifications.present? %>
-    <div class="govuk-grid-column-one-third">
-      <a href="<%= responsible_person_nanomaterials_path(@responsible_person, :csv) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-14 opss-text-align-right" download="download">
-        <span class="opss-download-link-sm"></span>Download a <abbr title="Comma-Separated Values">CSV</abbr> file of notified nanomaterials
-      </a>
-    </div>
-  <% end %>
 </div>
 
 <% if @nanomaterial_notifications.present? %>
@@ -129,6 +116,15 @@
       </table>
       <%= paginate @nanomaterial_notifications, views_prefix: "pagination", nav_class: "opss-pagination-link--no-top-border" %>
     </section>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <a href="<%= responsible_person_nanomaterials_path(@responsible_person, :csv) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-14 govuk-!-margin-top-3 opss-text-align-right" download="download">
+        <span class="opss-download-link-sm"></span>Download a <abbr title="Comma-Separated Values">CSV</abbr> file of notified nanomaterials
+      </a>
+    </div>
   </div>
 <% else %>
   <div class="govuk-grid-row">

--- a/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/index.html.erb
@@ -119,6 +119,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      &nbsp;
     </div>
     <div class="govuk-grid-column-one-third">
       <a href="<%= responsible_person_nanomaterials_path(@responsible_person, :csv) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-14 govuk-!-margin-top-3 opss-text-align-right" download="download">


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1551)

When users reach their list of Nanomaterial Notifications for their Responsible Person, they will have a link containing expandable details with guidance on when users can place products containing nanomaterials on the market.

### Top changes
![image](https://user-images.githubusercontent.com/1227578/195879261-3274dbac-ab19-4b1d-8d6d-286bac41c8cd.png)

-----
### Bottom changes
![image](https://user-images.githubusercontent.com/1227578/195879608-0ad9dbc6-7f46-4fab-89d4-0b64694e0294.png)


<!--- Edit links after PR is created -->
https://cosmetics-pr-2623-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2623-search-web.london.cloudapps.digital/
