### PR TITLE
Allow to whitelist App OTP codes in review apps and staging

### DIFF
--- a/cosmetics-web/app/models/secondary_authentication/otp_whitelisting.rb
+++ b/cosmetics-web/app/models/secondary_authentication/otp_whitelisting.rb
@@ -1,0 +1,30 @@
+module SecondaryAuthentication
+  module OtpWhitelisting
+    def whitelisted_code_valid?(otp)
+      return unless otp_whitelisting_allowed?
+
+      if self.class::WHITELISTED_OTP_CODE.present?
+        code = self.class::WHITELISTED_OTP_CODE
+        code == otp
+      else
+        false
+      end
+    end
+
+    def otp_whitelisting_allowed?
+      return true if Rails.env.development?
+
+      uris = JSON(Rails.configuration.vcap_application)["application_uris"]
+      return false if uris.blank?
+      return false if uris.length > 2
+
+      uris.all? do |uri|
+        Rails.application.config.domains_allowing_otp_whitelisting["domains-regexps"].any? do |domain_regexp|
+          uri =~ domain_regexp
+        end
+      end
+    rescue StandardError
+      false
+    end
+  end
+end

--- a/cosmetics-web/config/application.rb
+++ b/cosmetics-web/config/application.rb
@@ -49,6 +49,7 @@ module Cosmetics
     config.secondary_authentication_enabled = ENV.fetch("TWO_FACTOR_AUTHENTICATION_ENABLED", "true") == "true"
     config.two_factor_attempts = 10
     config.whitelisted_direct_otp_code = ENV["WHITELISTED_DIRECT_OTP_CODE"]
+    config.whitelisted_time_otp_code = ENV["WHITELISTED_TIME_OTP_CODE"]
     config.vcap_application = ENV["VCAP_APPLICATION"]
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 

--- a/cosmetics-web/config/application.rb
+++ b/cosmetics-web/config/application.rb
@@ -48,7 +48,7 @@ module Cosmetics
     config.submit_notify_api_key = ENV.fetch("NOTIFY_API_KEY", "")
     config.secondary_authentication_enabled = ENV.fetch("TWO_FACTOR_AUTHENTICATION_ENABLED", "true") == "true"
     config.two_factor_attempts = 10
-    config.whitelisted_2fa_code = ENV["WHITELISTED_2FA_CODE"]
+    config.whitelisted_direct_otp_code = ENV["WHITELISTED_DIRECT_OTP_CODE"]
     config.vcap_application = ENV["VCAP_APPLICATION"]
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 

--- a/cosmetics-web/spec/models/secondary_authentication/direct_otp_spec.rb
+++ b/cosmetics-web/spec/models/secondary_authentication/direct_otp_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe SecondaryAuthentication::DirectOtp do
   let(:secondary_authentication) { described_class.new(user) }
 
   describe "#valid_otp?" do
+    include_examples "whitelisted OTP tests" do
+      let(:whitelisted_otp) { "12345" }
+    end
+
     it "increase attempts when checking code" do
       expect {
         secondary_authentication.valid_otp? "123"
@@ -58,105 +62,6 @@ RSpec.describe SecondaryAuthentication::DirectOtp do
 
           expect(user.reload.second_factor_attempts_locked_at).to eq(nil)
         end
-      end
-    end
-
-    context "when using WHITELISTED_OTP_CODE env" do
-      shared_examples_for "successful auth" do
-        specify do
-          expect(secondary_authentication).to be_valid_otp(whitelisted_otp)
-        end
-      end
-
-      shared_examples_for "failed auth" do
-        specify do
-          expect(secondary_authentication).not_to be_valid_otp(whitelisted_otp)
-        end
-      end
-
-      let(:whitelisted_otp) { "12345" }
-
-      let(:application_uris) { %w[foo] }
-
-      let(:vcap_application) do
-        { "application_uris" => application_uris }.to_json
-      end
-
-      before do
-        stub_const("#{described_class}::WHITELISTED_OTP_CODE", whitelisted_otp)
-        allow(Rails.configuration).to receive(:vcap_application).and_return(vcap_application)
-      end
-
-      context "when ENV['VCAP_APPLICATION'] doesn't exist" do
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] is string" do
-        let(:vcap_application) { "foo" }
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] is empty hash" do
-        let(:vcap_application) do
-          {}.to_json
-        end
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] does not have application_uris key" do
-        let(:vcap_application) do
-          { "foo" => "bar" }.to_json
-        end
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] application_uris key is string" do
-        let(:application_uris) { "foo" }
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] application_uris key is empty array" do
-        let(:application_uris) { [] }
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] application_uris doesn't fit allowed url" do
-        let(:application_uris) { %w[foo] }
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] application_uris has more than 2 values" do
-        let(:application_uris) do
-          ["staging-submit.cosmetic-product-notifications.service.gov.uk",
-           "staging-submit2.cosmetic-product-notifications.service.gov.uk",
-           "staging-search.cosmetic-product-notifications.service.gov.uk"]
-        end
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] application_uris is production url" do
-        let(:application_uris) { ["submit.cosmetic-product-notifications.service.gov.uk"] }
-
-        it_behaves_like "failed auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] application_uris is staging url" do
-        let(:application_uris) { ["staging-submit.cosmetic-product-notifications.service.gov.uk"] }
-
-        it_behaves_like "successful auth"
-      end
-
-      context "when ENV['VCAP_APPLICATION'] application_uris is review app url" do
-        let(:application_uris) { ["cosmetics-pr-1730-submit-web.london.cloudapps.digital"] }
-
-        it_behaves_like "successful auth"
       end
     end
   end

--- a/cosmetics-web/spec/models/secondary_authentication/direct_otp_spec.rb
+++ b/cosmetics-web/spec/models/secondary_authentication/direct_otp_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SecondaryAuthentication::DirectOtp do
       end
     end
 
-    context "when using WHITELISTED_2FA_CODE env" do
+    context "when using WHITELISTED_OTP_CODE env" do
       shared_examples_for "successful auth" do
         specify do
           expect(secondary_authentication).to be_valid_otp(whitelisted_otp)
@@ -83,7 +83,7 @@ RSpec.describe SecondaryAuthentication::DirectOtp do
       end
 
       before do
-        allow(Rails.configuration).to receive(:whitelisted_2fa_code).and_return(whitelisted_otp)
+        stub_const("#{described_class}::WHITELISTED_OTP_CODE", whitelisted_otp)
         allow(Rails.configuration).to receive(:vcap_application).and_return(vcap_application)
       end
 

--- a/cosmetics-web/spec/models/secondary_authentication/time_otp_spec.rb
+++ b/cosmetics-web/spec/models/secondary_authentication/time_otp_spec.rb
@@ -1,46 +1,50 @@
 require "rails_helper"
 
 RSpec.describe SecondaryAuthentication::TimeOtp do
-  describe "#valid_otp?", :with_2fa_app do
-    subject(:totp) { described_class.new(user, user.totp_secret_key) }
+  subject(:secondary_authentication) { described_class.new(user, user.totp_secret_key) }
 
-    let(:user) { build_stubbed(:submit_user, :with_app_secondary_authentication) }
+  let(:user) { build_stubbed(:submit_user, :with_app_secondary_authentication) }
+
+  describe "#valid_otp?", :with_2fa_app do
+    include_examples "whitelisted OTP tests" do
+      let(:whitelisted_otp) { "123123" }
+    end
 
     it "is valid when matches the time otp for the user" do
-      expect(totp.valid_otp?(correct_app_code)).to eq true
+      expect(secondary_authentication).to be_valid_otp(correct_app_code)
     end
 
     it "is false when does not match the time otp for the user" do
-      expect(totp.valid_otp?(correct_app_code.reverse)).to eq false
+      expect(secondary_authentication).not_to be_valid_otp(correct_app_code.reverse)
     end
 
     it "is false when no code is provided" do
-      expect(totp.valid_otp?("")).to eq false
+      expect(secondary_authentication.valid_otp?("")).to eq false
     end
   end
 
   describe "#qr_code" do
-    subject(:totp) { described_class.new(user, user.totp_secret_key) }
+    subject(:secondary_authentication) { described_class.new(user, user.totp_secret_key) }
 
     let(:user) { build_stubbed(:submit_user, :with_app_secondary_authentication) }
 
     it "generates a png image" do
-      expect(totp.qr_code).to start_with "data:image/png;base64,"
+      expect(secondary_authentication.qr_code).to start_with "data:image/png;base64,"
     end
 
     it "multiple calls with the same user generate the same qr code image" do
-      first_image = totp.qr_code
-      expect(totp.qr_code).to eq first_image
+      first_image = secondary_authentication.qr_code
+      expect(secondary_authentication.qr_code).to eq first_image
     end
 
     it "generates a different qr code if the user changes its email" do
-      first_image = totp.qr_code
+      first_image = secondary_authentication.qr_code
       user.email = "newemailfortotptest@example.com"
       expect(described_class.new(user, user.totp_secret_key).qr_code).not_to eq first_image
     end
 
     it "generates a different qr code when given a different totp secret key" do
-      first_image = totp.qr_code
+      first_image = secondary_authentication.qr_code
       expect(described_class.new(user, ROTP::Base32.random).qr_code).not_to eq first_image
     end
   end

--- a/cosmetics-web/spec/support/shared_examples/whitelisted_otp_tests.rb
+++ b/cosmetics-web/spec/support/shared_examples/whitelisted_otp_tests.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.shared_examples "whitelisted OTP tests" do
+  shared_examples_for "successful auth" do
+    specify do
+      expect(secondary_authentication).to be_valid_otp(whitelisted_otp)
+    end
+  end
+
+  shared_examples_for "failed auth" do
+    specify do
+      expect(secondary_authentication).not_to be_valid_otp(whitelisted_otp)
+    end
+  end
+
+  let(:application_uris) { %w[foo] }
+
+  let(:vcap_application) do
+    { "application_uris" => application_uris }.to_json
+  end
+
+  before do
+    stub_const("#{described_class}::WHITELISTED_OTP_CODE", whitelisted_otp)
+    allow(Rails.configuration).to receive(:vcap_application).and_return(vcap_application)
+  end
+
+  context "when ENV['VCAP_APPLICATION'] doesn't exist" do
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] is string" do
+    let(:vcap_application) { "foo" }
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] is empty hash" do
+    let(:vcap_application) do
+      {}.to_json
+    end
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] does not have application_uris key" do
+    let(:vcap_application) do
+      { "foo" => "bar" }.to_json
+    end
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] application_uris key is string" do
+    let(:application_uris) { "foo" }
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] application_uris key is empty array" do
+    let(:application_uris) { [] }
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] application_uris doesn't fit allowed url" do
+    let(:application_uris) { %w[foo] }
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] application_uris has more than 2 values" do
+    let(:application_uris) do
+      ["staging-submit.cosmetic-product-notifications.service.gov.uk",
+       "staging-submit2.cosmetic-product-notifications.service.gov.uk",
+       "staging-search.cosmetic-product-notifications.service.gov.uk"]
+    end
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] application_uris is production url" do
+    let(:application_uris) { ["submit.cosmetic-product-notifications.service.gov.uk"] }
+
+    it_behaves_like "failed auth"
+  end
+
+  context "when ENV['VCAP_APPLICATION'] application_uris is staging url" do
+    let(:application_uris) { ["staging-submit.cosmetic-product-notifications.service.gov.uk"] }
+
+    it_behaves_like "successful auth"
+
+    it "fails using a non whitelisted OTP" do
+      expect(secondary_authentication).not_to be_valid_otp(whitelisted_otp.reverse)
+    end
+  end
+
+  context "when ENV['VCAP_APPLICATION'] application_uris is review app url" do
+    let(:application_uris) { ["cosmetics-pr-1730-submit-web.london.cloudapps.digital"] }
+
+    it_behaves_like "successful auth"
+
+    it "fails using a non whitelisted OTP" do
+      expect(secondary_authentication).not_to be_valid_otp(whitelisted_otp.reverse)
+    end
+  end
+end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1631)

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
As review apps use an enhanced copy of staging DB, we do not use a fake phone number with SMS 2FA by default for all the review app users anymore.
Now, some users have App Authentication.

And for those users, we do not have an easy way to bypass the 2FA APP Code requests.

This PR resolves that by bringing the possibility of using a whitelisted code from Direct OTP codes into Time OTP codes.

From now on, the whitelisted codes will need to be defined in the environment as:
- `WHITELISTED_DIRECT_OTP_CODE` for the SMS 2FA (5 digits)
-  `WHITELISTED_TIME_OTP_CODE` for the APP 2FA (6 digits)

## Review apps

Note: Tested it in the review app after setting a `WHITELISTED_TIME_OTP_CODE` value in the environment. It did work,

<!--- Edit links after PR is created -->
https://cosmetics-pr-2625-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2625-search-web.london.cloudapps.digital/
