### PR TITLE
Allow only one reindexing operation

### DIFF
--- a/cosmetics-web/app/jobs/reindex_opensearch_job.rb
+++ b/cosmetics-web/app/jobs/reindex_opensearch_job.rb
@@ -1,17 +1,26 @@
 class ReindexOpensearchJob < ApplicationJob
   def perform
-    total = 0
-    ActiveRecord::Base.descendants.each do |model|
-      next unless model.respond_to?(:__elasticsearch__) && !model.superclass.respond_to?(:__elasticsearch__)
+    ActiveRecord::Base.transaction do
+      # tries to aquire lock. Wont block, and we need to return in case lock exist
+      lock = ActiveRecord::Base.connection.execute("SELECT pg_try_advisory_xact_lock(#{AdvisoryLock::NAMESPACES[AdvisoryLock::SEARCH]}, #{AdvisoryLock::OPERATIONS[AdvisoryLock::REINDEX_NOTIFICATIONS]})")
+      # lock.result returns such array: [[true]] or [[false]]
+      # when false, lock exists and we don't want to proceed
+      # when true, we aquired the lock and we can perform operation in current transaction
+      return unless lock.values.first.first
 
-      total += 1
-      if model.respond_to?(:opensearch)
-        model.opensearch.import force: true
-      else
-        model.import force: true
+      total = 0
+      ActiveRecord::Base.descendants.each do |model|
+        next unless model.respond_to?(:__elasticsearch__) && !model.superclass.respond_to?(:__elasticsearch__)
+
+        total += 1
+        if model.respond_to?(:opensearch)
+          model.opensearch.import force: true
+        else
+          model.import force: true
+        end
       end
-    end
 
-    Sidekiq.logger.info "Imported #{total} records to Opensearch"
+      Sidekiq.logger.info "Imported #{total} records to Opensearch"
+    end
   end
 end

--- a/cosmetics-web/config/initializers/advisory_lock_constants.rb
+++ b/cosmetics-web/config/initializers/advisory_lock_constants.rb
@@ -1,0 +1,15 @@
+# Advisory locks accept 2 int argumests. First is commonly used as namespaced, second as 'operation'
+
+module AdvisoryLock
+  SEARCH = "search".freeze
+
+  REINDEX_NOTIFICATIONS = "reindex_notifications".freeze
+
+  NAMESPACES = {
+    SEARCH => 0,
+  }.freeze
+
+  OPERATIONS = {
+    REINDEX_NOTIFICATIONS => 0,
+  }.freeze
+end


### PR DESCRIPTION
Looks like sidekiq cron is being scheduled on each of the nodes, limit search reindexing to only one operation.