### PR TITLE
Dont recreate index

### DIFF
--- a/cosmetics-web/app/jobs/reindex_opensearch_job.rb
+++ b/cosmetics-web/app/jobs/reindex_opensearch_job.rb
@@ -12,11 +12,13 @@ class ReindexOpensearchJob < ApplicationJob
       ActiveRecord::Base.descendants.each do |model|
         next unless model.respond_to?(:__elasticsearch__) && !model.superclass.respond_to?(:__elasticsearch__)
 
+        model.__elasticsearch__.create_index! unless model.__elasticsearch__.index_exists?
+
         total += 1
         if model.respond_to?(:opensearch)
-          model.opensearch.import force: true
+          model.opensearch.import
         else
-          model.import force: true
+          model.import
         end
       end
 


### PR DESCRIPTION
We were removing index on every reindexing job. When they were failing, this was causing lack of searchable notifications in the index. Now, index is created only when it does not exists - it will be used mostly by review apps.