### PR TITLE
Improve colour contrast ratio on main pages for 'Search' and 'Submit'

### DIFF
--- a/cosmetics-web/app/views/search/landing_page/index.html.erb
+++ b/cosmetics-web/app/views/search/landing_page/index.html.erb
@@ -5,11 +5,11 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-6">
+        <h1 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-6">
           Cosmetic products search
         </h1>
-        <p class="masthead-account-links govuk-!-padding-top-2 govuk-!-margin-bottom-5">
-          <%= link_to "sign in", new_search_user_session_path, class: "govuk-link govuk-link--no-visited-state" %>
+        <p class="govuk-body-l govuk-body--inverse govuk-!-margin-bottom-7">
+          <%= link_to "Sign in", new_search_user_session_path, class: "govuk-link govuk-link--no-visited-state" %>
         </p>
       </div>
     </div>

--- a/cosmetics-web/app/views/submit/landing_page/index.html.erb
+++ b/cosmetics-web/app/views/submit/landing_page/index.html.erb
@@ -5,22 +5,20 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-6">
+        <h1 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-6">
           Submit cosmetic product notifications
         </h1>
-        <p class="masthead-account-links govuk-!-padding-top-2 govuk-!-margin-bottom-5">
+        <p class="govuk-body-l govuk-body--inverse govuk-!-margin-bottom-7">
           <% if @responsible_person.present? %>
-            <a class="govuk-button govuk-!-font-weight-bold" role="button" draggable="false"
+            Go to your
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--inverse govuk-!-display-inline-block" role="button" draggable="false"
               href="<%= responsible_person_notifications_path(@responsible_person) %>">
-              Your cosmetic products
-              <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false"><path fill="#1d70b8" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+              cosmetic products page
+              <svg class="govuk-button__start-icon govuk-!-margin-left-1" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false"><path fill="#ffffff" d="M0 0h13l20 20-20 20H0l20-20z"></path>
               </svg>
             </a>
           <% else %>
-            <%= govukButton text: "Create an account", href: registration_new_submit_user_path, classes: "govuk-!-font-weight-bold" %>
-            or
-            <%= link_to "sign in", new_submit_user_session_path, class: "govuk-link govuk-link--no-visited-state" %>
-            if you have used this service before
+            <%= link_to "Create an account", registration_new_submit_user_path, class: "govuk-link govuk-link--no-visited-state govuk-link--inverse" %>
           <% end %>
         </p>
       </div>

--- a/cosmetics-web/spec/features/account/creating_a_search_account_from_an_invitation_spec.rb
+++ b/cosmetics-web/spec/features/account/creating_a_search_account_from_an_invitation_spec.rb
@@ -52,7 +52,9 @@ RSpec.feature "Creating a Search account from an invitation", :with_stubbed_mail
 
     expect_to_be_on_the_search_homepage
 
-    click_link "Sign in"
+    within("div.govuk-header__content") do
+      click_link "Sign in"
+    end
 
     fill_in "Email address", with: invited_user.email
     fill_in "Password", with: "testpassword123@"
@@ -145,7 +147,9 @@ RSpec.feature "Creating a Search account from an invitation", :with_stubbed_mail
 
     expect_to_be_on_the_search_homepage
 
-    click_link "Sign in"
+    within("div.govuk-header__content") do
+      click_link "Sign in"
+    end
 
     fill_in "Email address", with: invited_user.email
     fill_in "Password", with: "testpassword123@"

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -427,7 +427,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect(page).to have_css("h1", text: "You are already signed in")
     click_link "Continue as #{second_user.name}"
     expect(page).to have_css("h1", text: "Submit cosmetic product notifications")
-    click_link "Your cosmetic products"
+    click_link "cosmetic products page"
     expect(page).to have_css("h1", text: "Cosmetic products")
   end
 

--- a/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
+++ b/cosmetics-web/spec/features/multiple_responsible_person_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
   scenario "Changing responsible person" do
     visit "/"
 
-    click_on "Your cosmetic products"
+    click_on "cosmetic products page"
 
     expect_to_be_on_responsible_person_notifications_page(responsible_person_1)
     click_on "Responsible Person"
@@ -54,7 +54,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
   scenario "Adding new responsible person" do
     visit "/"
 
-    click_on "Your cosmetic products"
+    click_on "cosmetic products page"
 
     expect_to_be_on_responsible_person_notifications_page(responsible_person_1)
     click_on "Responsible Person"
@@ -76,7 +76,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
   scenario "Adding new responsible person - cant ommit contact details" do
     visit "/"
 
-    click_on "Your cosmetic products"
+    click_on "cosmetic products page"
 
     expect_to_be_on_responsible_person_notifications_page(responsible_person_1)
     click_on "Responsible Person"
@@ -97,7 +97,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
 
   scenario "Landing page redirects to correct responsible person" do
     visit "/"
-    click_on "Your cosmetic products"
+    click_on "cosmetic products page"
     expect_to_be_on_responsible_person_notifications_page(responsible_person_1)
 
     visit "/responsible_persons/select"
@@ -106,7 +106,7 @@ RSpec.describe "Submit user belongs to multiple responsible persons", :with_2fa,
     click_on "Save and continue"
 
     visit "/"
-    click_on "Your cosmetic products"
+    click_on "cosmetic products page"
     expect_to_be_on_responsible_person_notifications_page(responsible_person_2)
   end
 

--- a/cosmetics-web/spec/features/responsible_person_spec.rb
+++ b/cosmetics-web/spec/features/responsible_person_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Creating multiple responsible persons from the same user", type:
 
     expect(page).not_to have_text("Responsible Person was changed")
     visit "/"
-    click_on "Your cosmetic products"
+    click_on "cosmetic products page"
     click_link "Responsible Person"
     expect(page).to have_css("dd", text: "First RP")
     click_link "Change the Responsible Person"

--- a/cosmetics-web/spec/requests/submit/landing_page_spec.rb
+++ b/cosmetics-web/spec/requests/submit/landing_page_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Landing page", :with_2fa, type: :request do
       it "loads the landing page with a link to the user notifications" do
         get submit_root_path
         expect(response).to render_template(:index)
-        expect(response.body).to include("Your cosmetic products")
+        expect(response.body).to include("cosmetic products page")
       end
     end
 


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1238

## Description
Updated CSS classes on page headers
<img width="1010" alt="Screenshot 2022-10-21 at 09 49 51" src="https://user-images.githubusercontent.com/7682746/197155086-ed0953d7-39de-47c8-a18d-22d17eb258c9.png">
<img width="1023" alt="Screenshot 2022-10-21 at 09 49 14" src="https://user-images.githubusercontent.com/7682746/197155102-8ee2bac9-ee05-4017-8efb-e58e26d81632.png">
<img width="1071" alt="Screenshot 2022-10-21 at 09 48 59" src="https://user-images.githubusercontent.com/7682746/197155106-8ba7ed8b-c561-4d65-a977-68542e183bb8.png">

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2645-submit-web.london.cloudapps.digital/

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
