### PR TITLE
Enable manual smoke test runs

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -2,6 +2,8 @@ name: Smoke test
 on:
   schedule:
     - cron: "5 * * * *"
+  workflow_dispatch:
+
 env:
   SEARCH_HOST: search
   SUBMIT_HOST: submit


### PR DESCRIPTION
Adding this trigger will allow us to manually run the smoke tests (including modified versions from specific branches) from Github actions page.

