### PR TITLE
Changes on "no submitted any notification" text

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
@@ -30,12 +30,10 @@
 <% if @registered_notifications.total_count.zero? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-    <p class="govuk-body">
-      <%= @responsible_person.name %> has not submitted any cosmetic product notifications in <abbr>GB</abbr>.
-    </p>
-    <p class="govuk-body">
-      All cosmetic products sold or given away in <abbr>GB</abbr> must be notified in <abbr>GB</abbr>.
-    </p>
+      <p class="govuk-body govuk-!-margin-bottom-7">
+        <%= @responsible_person.name %> has not submitted any cosmetic product notifications in Great Britain (<abbr>GB</abbr>).
+        All cosmetic products sold or given away in <abbr>GB</abbr> must be notified in <abbr>GB</abbr>.
+      </p>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1241)

The Submit cosmetics products notifications list page shows some specific text when the user Responsible Person has no submitted notifications in the service.

We are changing the wording and paragraphing of this message.

### Before
![image](https://user-images.githubusercontent.com/1227578/198025460-1d71e29e-05c7-4017-84f2-ce368fdf5d34.png)

### After
![image](https://user-images.githubusercontent.com/1227578/198025372-601371b5-e240-4bca-afdb-120b14c9f3bd.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr2656-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2656-search-web.london.cloudapps.digital/
