### PR TITLE
Validate against URLs on Ingredient name

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
@@ -18,7 +18,7 @@ module ResponsiblePersons::Notifications
     validates :component, presence: true
     validates :type, inclusion: { in: [EXACT, RANGE] }
     validates :poisonous, inclusion: { in: [true, false] }, if: :range?
-    validates :name, presence: true
+    validates :name, presence: true, ingredient_name_format: { message: :invalid }
     validate :unique_name
     validates :exact_concentration,
               presence: true,

--- a/cosmetics-web/app/models/ingredient.rb
+++ b/cosmetics-web/app/models/ingredient.rb
@@ -33,7 +33,7 @@ class Ingredient < ApplicationRecord
 
   default_scope { order(created_at: :asc) }
 
-  validates :inci_name, presence: true
+  validates :inci_name, presence: true, ingredient_name_format: { message: :invalid }
   validates :inci_name, uniqueness: { scope: :component_id }, if: :validate_inci_name_uniqueness?
 
   # Exact and range concentration invalidate each other.

--- a/cosmetics-web/app/validators/ingredient_name_format_validator.rb
+++ b/cosmetics-web/app/validators/ingredient_name_format_validator.rb
@@ -1,3 +1,3 @@
 class IngredientNameFormatValidator < NameFormatValidator
-  BANNED_REGEXP = /www|http/
+  BANNED_REGEXP = /<\/|www|http/
 end

--- a/cosmetics-web/app/validators/ingredient_name_format_validator.rb
+++ b/cosmetics-web/app/validators/ingredient_name_format_validator.rb
@@ -1,0 +1,3 @@
+class IngredientNameFormatValidator < NameFormatValidator
+  BANNED_REGEXP = /www|http/
+end

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -166,6 +166,7 @@ en:
           attributes:
             inci_name:
               blank: "Enter a name"
+              invalid: "Enter a valid ingredient name"
               taken: "Ingredient name already exists in this component"
             exact_concentration:
               blank: "Enter the exact or range concentration"
@@ -285,6 +286,7 @@ en:
               not_a_number: "Enter a number for the concentration"
             name:
               blank: "Enter a name"
+              invalid: "Enter a valid ingredient name"
               taken: "Enter a name which is unique to this %{entity}"
             poisonous:
               inclusion: "Select yes if the ingredient is poisonous"

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
@@ -143,6 +143,12 @@ RSpec.describe ResponsiblePersons::Notifications::IngredientConcentrationForm do
       expect(form.errors[:name]).to eq ["Enter a valid ingredient name"]
     end
 
+    it "is invalid with a name containing '</'" do
+      form.name = "<script>Soap</script>"
+      expect(form).not_to be_valid
+      expect(form.errors[:name]).to eq ["Enter a valid ingredient name"]
+    end
+
     it "is valid when cas number is not present" do
       form.cas_number = nil
       expect(form).to be_valid

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe ResponsiblePersons::Notifications::IngredientConcentrationForm do
       expect(form.errors[:name]).to eq ["Enter a name"]
     end
 
+    it "is invalid with a name containing 'http'" do
+      form.name = "http://example.com"
+      expect(form).not_to be_valid
+      expect(form.errors[:name]).to eq ["Enter a valid ingredient name"]
+    end
+
+    it "is invalid with a name containing 'www'" do
+      form.name = "www.example.com"
+      expect(form).not_to be_valid
+      expect(form.errors[:name]).to eq ["Enter a valid ingredient name"]
+    end
+
     it "is valid when cas number is not present" do
       form.cas_number = nil
       expect(form).to be_valid

--- a/cosmetics-web/spec/models/ingredient_spec.rb
+++ b/cosmetics-web/spec/models/ingredient_spec.rb
@@ -85,6 +85,18 @@ RSpec.describe Ingredient, type: :model do
         expect(ingredient.errors[:inci_name]).to eq(["Enter a name"])
       end
 
+      it "is invalid when name includes 'http'" do
+        ingredient = build_stubbed(:exact_ingredient, inci_name: "Soap http://example.com")
+        expect(ingredient).not_to be_valid
+        expect(ingredient.errors[:inci_name]).to eq(["Enter a valid ingredient name"])
+      end
+
+      it "is invalid when name includes 'www'" do
+        ingredient = build_stubbed(:exact_ingredient, inci_name: "Soap www.example.com")
+        expect(ingredient).not_to be_valid
+        expect(ingredient.errors[:inci_name]).to eq(["Enter a valid ingredient name"])
+      end
+
       it "is invalid when an ingredient with the same name exists in the same component" do
         component = create(:ranges_component)
         create(:range_ingredient, inci_name: "A", component:)

--- a/cosmetics-web/spec/models/ingredient_spec.rb
+++ b/cosmetics-web/spec/models/ingredient_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe Ingredient, type: :model do
         expect(ingredient.errors[:inci_name]).to eq(["Enter a valid ingredient name"])
       end
 
+      it "is invalid when name includes '</'" do
+        ingredient = build_stubbed(:exact_ingredient, inci_name: "<script>Soap</script>")
+        expect(ingredient).not_to be_valid
+        expect(ingredient.errors[:inci_name]).to eq(["Enter a valid ingredient name"])
+      end
+
       it "is invalid when an ingredient with the same name exists in the same component" do
         component = create(:ranges_component)
         create(:range_ingredient, inci_name: "A", component:)


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1533)

We are banning `<\`, `www` and `http` from Ingredient names. Using the same pattern as on previous name validations.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
![image](https://user-images.githubusercontent.com/1227578/198318041-3b9a2f5c-9400-4549-b4b9-df00e253ec04.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2658-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2658-search-web.london.cloudapps.digital/
