### PR TITLE
Show improved cosmetic search to all users

### DIFF
--- a/cosmetics-web/app/views/poison_centres/notifications_search/_search_box.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_search_box.html.erb
@@ -17,7 +17,6 @@
               <span class="govuk-visually-hidden">Search</span>
             </button>
           </div>
-          <% if PoisonCentres::NotificationsSearchController::ADVANCED_SEARCH_USER_ROLES.include? current_user.role %>
             <%= govukRadios(
               form: form,
               key: :search_fields,
@@ -49,7 +48,6 @@
               classes: "govuk-checkboxes--small",
               items: [{ key: 'match_similar', text: 'Include similar words', disable_ghost: true, label: { classes: 'govuk-!-font-size-16' } }],
             ) %>
-          <% end %>
           <%= form.hidden_field :category, id: 'notification_search_form_category_hidden' %>
           <%= render partial: 'hidden_date_fields', locals: { attribute: :date_exact, id: :keyword_form, search_type: 'notification' } %>
           <%= render partial: 'hidden_date_fields', locals: { attribute: :date_from, id: :keyword_form, search_type: 'notification' } %>


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1630

## Description
This was to remove the logic around the search to show to all users

## Review apps

<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about. Changes in notification wizard should always be included.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
