### PR TITLE
Change success banners wording for Responsible Person & Contact Person details change

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/contact_persons_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/contact_persons_controller.rb
@@ -70,7 +70,7 @@ private
   def confirmation_message(field, changed)
     return unless changed # Don't set confirmation message when submitted value does not change the current value
 
-    "Contact person #{field.humanize(capitalize: false)} changed successfully"
+    "The assigned contact #{ContactPerson.human_attribute_name(field).downcase} was changed"
   end
 
   def create_successful_message

--- a/cosmetics-web/app/controllers/responsible_persons_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons_controller.rb
@@ -29,7 +29,7 @@ class ResponsiblePersonsController < SubmitApplicationController
                                                  user: current_user,
                                                  details: update_params.to_h)
     if result.success?
-      confirmation = "Responsible Person details changed successfully" if result.changed
+      confirmation = "The Responsible Person details were changed" if result.changed
       redirect_to(responsible_person_path(@responsible_person), confirmation:)
     else
       render :edit

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -32,6 +32,8 @@ en:
       cmr:
         cas_number: "CAS number"
         ec_number: "EC number"
+      contact_person:
+        phone_number: "Telephone number"
     errors:
       models:
         notification:

--- a/cosmetics-web/spec/features/submit/responsible_person/contact_person_details_edition_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/contact_person_details_edition_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
     click_button "Continue"
 
     expect_to_be_on__responsible_person_page
-    expect(page).to have_text("Contact person name changed successfully")
+    expect(page).to have_text("The assigned contact name was changed")
     contact_person_name_elem = page.find_all("dt", text: "Name", exact_text: true).last
     expect(contact_person_name_elem).to have_sibling("td, dd", text: "Mr Foo Bar", exact_text: true)
   end
@@ -78,7 +78,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
     click_button "Continue"
 
     expect_to_be_on__responsible_person_page
-    expect(page).to have_text("Contact person email address changed successfully")
+    expect(page).to have_text("The assigned contact email address was changed")
     expect(page).to have_summary_item(key: "Email", value: "mrFooBar@example.com")
   end
 
@@ -107,7 +107,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
     click_button "Continue"
 
     expect_to_be_on__responsible_person_page
-    expect(page).to have_text("Contact person phone number changed successfully")
+    expect(page).to have_text("The assigned contact telephone number was changed")
     expect(page).to have_summary_item(key: "Telephone", value: "+44(7123456789)")
   end
 end

--- a/cosmetics-web/spec/features/submit/responsible_person/details_edition_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/details_edition_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Editing responsible person details", :with_stubbed_mailer, type:
     click_button "Save and continue"
 
     expect_to_be_on__responsible_person_page
-    expect(page).to have_text("Responsible Person details changed successfully")
+    expect(page).to have_text("The Responsible Person details were changed")
     business_type_elem = page.find("dt", text: "Business type", exact_text: true)
     expect(business_type_elem).to have_sibling("td, dd",
                                                text: "Limited company or Limited Liability Partnership (LLP)",

--- a/cosmetics-web/spec/requests/contact_person_request_spec.rb
+++ b/cosmetics-web/spec/requests/contact_person_request_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "Contact person pages", :with_stubbed_mailer, type: :request do
 
         it "response includes a confirmation message" do
           follow_redirect!
-          expect(response.body).to include("Contact person name changed successfully")
+          expect(response.body).to include("The assigned contact name was changed")
         end
       end
 
@@ -244,7 +244,7 @@ RSpec.describe "Contact person pages", :with_stubbed_mailer, type: :request do
 
         it "response includes a confirmation message" do
           follow_redirect!
-          expect(response.body).to include("Contact person email address changed successfully")
+          expect(response.body).to include("The assigned contact email address was changed")
         end
       end
 
@@ -279,7 +279,7 @@ RSpec.describe "Contact person pages", :with_stubbed_mailer, type: :request do
 
         it "response includes a confirmation message" do
           follow_redirect!
-          expect(response.body).to include("Contact person phone number changed successfully")
+          expect(response.body).to include("The assigned contact telephone number was changed")
         end
       end
 

--- a/cosmetics-web/spec/requests/responsible_persons/edit_details_spec.rb
+++ b/cosmetics-web/spec/requests/responsible_persons/edit_details_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Edit Responsible Person Details", type: :request do
       it "response includes a confirmation message" do
         update_request
         follow_redirect!
-        expect(response.body).to include("Responsible Person details changed successfully")
+        expect(response.body).to include("The Responsible Person details were changed")
       end
 
       it "records the previous responsible person address into DB" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1561)

## Description
<!--- Describe your changes in detail -->
Changing the wording on the success banners that are displayed after updating either Contact Person or Responsible Person details.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2660-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2660-search-web.london.cloudapps.digital/
