### PR TITLE
Fix margins from 'cannot remove an item' page

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/delete_items/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/delete_items/show.html.erb
@@ -6,12 +6,11 @@
   <%= govukBackLink text: "Back", href: responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>
 <% end %>
 
-<% if @notification.components.count > 2 %>
-  <% items = @notification.components.order(:created_at).each_with_index.map { |c, i| { text: (c.name.present? ? c.name : "Item ##{i+1}"), value: c.id } } %>
-
-  <%= form_with model: @form, url: responsible_person_notification_draft_delete_item_path(@notification.responsible_person, @notification), method: :delete do |form| %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @notification.components.count > 2 %>
+      <% items = @notification.components.order(:created_at).each_with_index.map { |c, i| { text: (c.name.present? ? c.name : "Item ##{i+1}"), value: c.id } } %>
+      <%= form_with model: @form, url: responsible_person_notification_draft_delete_item_path(@notification.responsible_person, @notification), method: :delete do |form| %>
         <%= error_summary_for(@form) %>
         <%= form.hidden_field :component_id %>
         <%= govukRadios(
@@ -26,23 +25,28 @@
 
           <a class="govuk-link govuk-link--no-visited-state" href="<%= responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>">Cancel</a>
         </div>
-      </div>
-    </div>
-  <% end %>
-<% else %>
-  <div class="govuk-grid-column-two-thirds">
-
-    <h1 class="govuk-heading-m govuk-!-margin-bottom-0">You cannot remove an item</h1>
-
-    <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-7">A multi-item kit product must include 2 or more items.</p>
-
-    <p class="govuk-body">This draft product notification has defined the product as being a multi-item kit and currently includes 2 items. A product containing only 1 item (or component) is a single item product and is not a multi-item kit product.</p>
-
-    <p class="govuk-body">To remove an item you must first add a new item. <span class="govuk-!-font-weight-bold">If the product is not a multi-item kit product</span>, you will need to <a href="<%= delete_responsible_person_delete_notification_path(@notification.responsible_person, @notification) %>" class="govuk-link govuk-link--no-visited-state">delete this draft</a>.</p>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-    <p class="govuk-body">Return to the <a href="<%= responsible_person_notification_draft_path(@notification.responsible_person, @notification) %>" class="govuk-link govuk-link--no-visited-state">tasks list page</a>.</p>
-
+      <% end %>
+    <% else %>
+      <h1 class="govuk-heading-m govuk-!-margin-bottom-0">You cannot remove an item</h1>
+      <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-7">A multi-item kit product must include 2 or more items.</p>
+      <p class="govuk-body">
+        This draft product notification has defined the product as being a multi-item kit and currently includes 2 items.
+        A product containing only 1 item (or component) is a single item product and is not a multi-item kit product.
+      </p>
+      <p class="govuk-body">
+        To remove an item you must first add a new item.
+        <span class="govuk-!-font-weight-bold">If the product is not a multi-item kit product</span>, you will need to
+        <%= link_to("delete this draft",
+                    delete_responsible_person_delete_notification_path(@notification.responsible_person, @notification),
+                    class: "govuk-link govuk-link--no-visited-state") %>.
+      </p>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <p class="govuk-body">
+        Return to the
+        <%= link_to("tasks list page",
+            responsible_person_notification_draft_path(@notification.responsible_person, @notification),
+            class: "govuk-link govuk-link--no-visited-state") %>.
+      </p>
+    <% end %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1403)

## Description
When a user attempts to delete an item from a multi-item notification draft, and the notification has 2 items, there are shown a page with a message about not being able to remove items.

The HTML div column element containing this message wasn't wrapped in an HTML div row, causing some redundant left margin to be applied.

Re-structured the page HTML always to have the same row/column structure, regardless of showing the deletion form or the error message.

Also broke the long paragraphs into more readable lines, and applied rails `link_to` helpers to the plain HTML links.

### Before
![image](https://user-images.githubusercontent.com/1227578/199245651-03ba8f63-29f6-49aa-a3c2-25436c067493.png)


### After (left margin from back link removed)
![image](https://user-images.githubusercontent.com/1227578/199245785-dc3b7237-56a0-4aaa-930e-32c47be7320a.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2664-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2664-search-web.london.cloudapps.digital/
