### PR TITLE
Fix follow team invite link with incomplete user

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -24,7 +24,7 @@ class ResponsiblePersons::TeamMembersController < SubmitApplicationController
       user.confirm_new_email! if user.new_email == invitation.email_address
       redirect_to responsible_person_notifications_path(responsible_person)
     else
-      login_user_from_invitation?(invitation, user)
+      login_user_from_invitation(invitation, user)
       redirect_to registration_new_account_security_path
     end
   rescue ActiveRecord::RecordNotFound
@@ -56,7 +56,7 @@ private
     set_current_responsible_person(responsible_person)
   end
 
-  def login_user_from_invitation?(invitation, user)
+  def login_user_from_invitation(invitation, user)
     # User will be already set at this point if was created but not completed security details
     user ||= SubmitUser.new(email: invitation.email_address, name: invitation.name).tap do |u|
       u.dont_send_confirmation_instructions!

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -62,7 +62,7 @@ private
       u.dont_send_confirmation_instructions!
       u.save(validate: false)
     end
-    bypass_sign_in(user)
+    sign_in(user)
     session[:registered_from_responsible_person_invitation_id] = invitation.id
   end
 

--- a/cosmetics-web/app/mailers/submit_notify_mailer.rb
+++ b/cosmetics-web/app/mailers/submit_notify_mailer.rb
@@ -43,7 +43,7 @@ class SubmitNotifyMailer < NotifyMailer
     set_personalisation(
       responsible_person: responsible_person.name,
       invite_sender: inviting_user_name,
-      invitation_url: join_responsible_person_team_members_url(responsible_person.id, invitation_token: invited_team_member.invitation_token),
+      invitation_url: join_responsible_person_team_members_url(responsible_person.id, invitation_token: invited_team_member.invitation_token, host: @host),
     )
     mail(to: invited_team_member.email_address)
     Sidekiq.logger.info "Responsible person invite email sent"

--- a/cosmetics-web/config/initializers/session_security.rb
+++ b/cosmetics-web/config/initializers/session_security.rb
@@ -4,6 +4,6 @@ Warden::Manager.before_logout do |record, warden, options|
       warden.authenticated?(options[:scope]) &&
       !record.skip_session_limitable?
     unique_session_id = Devise.friendly_token
-    record.update_unique_session_id!(unique_session_id) if record.has_completed_registration?
+    record.update_unique_session_id!(unique_session_id) if record.unique_session_id.present?
   end
 end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1175)

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
### ISSUE

**When:**
1. A team invited a non-registered user email.
2. The user registered themselves without following the link.
3. The user "signs out" from the account security page instead of completing their registration.
4. User follows up on the invitation link to register/join the team.

**Then:**
A sign-in page with a "Your login credentials were used in another browser." error. Instead of displaying the account security page and allowing the user to complete their registration while getting added to the Responsible Person that invited them.

### CAUSE

The method used for signing in a user from an invitation link called the `bypass_sign_in` Devise method. That method bypasses Warden callbacks and stores the user straight in session.
The problem with that is that one of those Warden callbacks sets the `warden.user.submit_user.session"=>{"unique_session_id"=>"value"}` in the user session. This value is used by Devise `SessionLimitable`
module to check what is the current session value against the unique session id stored in DB for the current user.

As it wasn't set on the session, but the user was marked as "signed in" in their session, the `SessionLimitable` module takes this as the user's current session not matching the unique session id in DB, and triggers the "Your login credentials were used in another browser" error.

### SOLUTION

Do a default Devise `sign_in`, including Warden callbacks,  when following the team invitation link. This sets the unique session id from the user DB into the session: `"unique_session_id"=>"value"`.

With this set, following the link passes the SessionLimitable check and the user ends in the account security form to complete their registration, as expected.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2673-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2673-search-web.london.cloudapps.digital/
