### PR TITLE
Do not allow to introduce long ingredient names

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
@@ -18,7 +18,7 @@ module ResponsiblePersons::Notifications
     validates :component, presence: true
     validates :type, inclusion: { in: [EXACT, RANGE] }
     validates :poisonous, inclusion: { in: [true, false] }, if: :range?
-    validates :name, presence: true, ingredient_name_format: { message: :invalid }
+    validates :name, presence: true, length: { maximum: 100 }, ingredient_name_format: { message: :invalid }
     validate :unique_name
     validates :exact_concentration,
               presence: true,

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
@@ -149,6 +149,12 @@ RSpec.describe ResponsiblePersons::Notifications::IngredientConcentrationForm do
       expect(form.errors[:name]).to eq ["Enter a valid ingredient name"]
     end
 
+    it "is invalid with a name containing over 100 characters" do
+      form.name = "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      expect(form).not_to be_valid
+      expect(form.errors[:name]).to eq ["Name is too long (maximum is 100 characters)"]
+    end
+
     it "is valid when cas number is not present" do
       form.cas_number = nil
       expect(form).to be_valid


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1661)

## Description
<!--- Describe your changes in detail -->
We are introducing a form validation to avoid very long text introduced as an ingredient name when creating an ingredient.

Since we moved from PDF formulations to requiring RP users to introduce their product ingredients manually, some users used the lack of length restriction on the name to paste the whole product formulation (sometimes thousands of characters) as an ingredient.

This validation will avoid that for future ingredients. What to do with the current ingredients/products violating this will be decided in the future. At the moment those product notifications should pass validations, hence not introducing a model validation together with the form one.

![image](https://user-images.githubusercontent.com/1227578/201153180-18451ee2-eec0-4c27-b1ef-91d6e6093b5b.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2674-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2674-search-web.london.cloudapps.digital/
