### PR TITLE
Reword ingredient name validation to GDS standards

### DIFF
--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -290,6 +290,7 @@ en:
               blank: "Enter a name"
               invalid: "Enter a valid ingredient name"
               taken: "Enter a name which is unique to this %{entity}"
+              too_long: "Ingredient name must be 100 characters or less"
             poisonous:
               inclusion: "Select yes if the ingredient is poisonous"
             range_concentration:

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe ResponsiblePersons::Notifications::IngredientConcentrationForm do
     it "is invalid with a name containing over 100 characters" do
       form.name = "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ"
       expect(form).not_to be_valid
-      expect(form.errors[:name]).to eq ["Name is too long (maximum is 100 characters)"]
+      expect(form.errors[:name]).to eq ["Ingredient name must be 100 characters or less"]
     end
 
     it "is valid when cas number is not present" do


### PR DESCRIPTION
Just a rewording, moving away from the default rails length error message to match the [GDS standards](https://design-system.service.gov.uk/components/error-message/)