### PR TITLE
Change wording on Contact Person edit form buttons

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/contact_persons/_edit_field.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/contact_persons/_edit_field.html.erb
@@ -15,7 +15,7 @@
       <%= yield form %>
 
       <div class="govuk-form-group">
-        <%= govukButton text: "Continue" %>
+        <%= govukButton text: "Save and continue" %>
       </div>
     </div>
   </div>

--- a/cosmetics-web/spec/features/submit/responsible_person/contact_person_details_edition_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/contact_person_details_edition_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
 
     # First attempts with validation error
     fill_in "Full name", with: ""
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect(page).to have_h1("Edit the assigned contact name")
     expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
@@ -36,7 +36,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
     expect(page).to have_css("p#contact_person_name-error", text: "Name can not be blank")
 
     fill_in "Full name", with: "Foo Bar www.example.org"
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect(page).to have_h1("Edit the assigned contact name")
     expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
@@ -45,7 +45,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
 
     # Successful attempt
     fill_in "Full name", with: "Mr Foo Bar"
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect_to_be_on__responsible_person_page
     expect(page).to have_text("The assigned contact name was changed")
@@ -65,7 +65,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
 
     # First attempt with validation error
     fill_in "Email address", with: "mrFooBar"
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect(page).to have_h1("Edit the assigned contact email address")
     expected_error = "Enter an email address in the correct format, like name@example.com"
@@ -75,7 +75,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
 
     # Successful attempt
     fill_in "Email address", with: "mrFooBar@example.com"
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect_to_be_on__responsible_person_page
     expect(page).to have_text("The assigned contact email address was changed")
@@ -94,7 +94,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
 
     # First attempt with validation error
     fill_in "Telephone number", with: "000"
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect(page).to have_h1("Edit the assigned contact telephone number")
     expected_error = "Enter a valid telephone number, like 0344 411 1444 or +44 7700 900 982"
@@ -104,7 +104,7 @@ RSpec.describe "Editing responsible person contact person details", type: :featu
 
     # Successful attempt
     fill_in "Telephone number", with: "+44(7123456789)"
-    click_button "Continue"
+    click_button "Save and continue"
 
     expect_to_be_on__responsible_person_page
     expect(page).to have_text("The assigned contact telephone number was changed")


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1424)

Use "Save and continue" instead of "Continue"

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
![image](https://user-images.githubusercontent.com/1227578/201707747-195e3dd1-940a-4a76-97b9-15cff0ef5f63.png)

![image](https://user-images.githubusercontent.com/1227578/201707836-23ca9f6e-410d-46b3-912d-7f3f905a630f.png)

![image](https://user-images.githubusercontent.com/1227578/201707877-6f08290a-b521-4c1d-a4bf-83904e450f87.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2677-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2677-search-web.london.cloudapps.digital/
