### PR TITLE
Remove invalid delegation from nano to component

### DIFF
--- a/cosmetics-web/app/models/nano_material.rb
+++ b/cosmetics-web/app/models/nano_material.rb
@@ -9,8 +9,6 @@ class NanoMaterial < ApplicationRecord
   has_many :component_nano_materials, dependent: :destroy
   has_many :components, through: :component_nano_materials
 
-  delegate :component_name, to: :component
-
   validates :inci_name, presence: true, on: :add_nanomaterial_name
   validate :unique_name_per_product_notification, on: :add_nanomaterial_name
   validate :nanomaterial_notification_association


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1438)

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
The relationship between nanomaterial to component used to be "one component to many nanomaterials". That enabled delegating methods from the component into the nanomaterial.

Since this has been moved to a many-to-many relationship, this delegation is no longer valid, as one nanomaterial will have many components.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
