### PR TITLE
Fix n+1 query on Ingredients search

### DIFF
--- a/cosmetics-web/app/controllers/poison_centres/ingredients_search_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/ingredients_search_controller.rb
@@ -13,7 +13,7 @@ class PoisonCentres::IngredientsSearchController < SearchApplicationController
     # Notifications are only listed in ElasticSearch index when completed, but if an indexed notification gets deleted,
     # it won't be removed from the index until the next reindex is run (once per day).
     # During that period, the result record will be a deleted notification with empty values. We don't want to show those.
-    @notifications = @search_response.records.completed
+    @notifications = @search_response.records.includes(:responsible_person).completed
   end
 
 private


### PR DESCRIPTION
I noticed that the Ingredients search is triggering n+1 queries to retrieve & display the Responsible Person name for each notification result.

Resolving it by preloading it.

Note: In the example, ActiveRecord/PG is managing to retrieve it from cache memory saving the DB hit as I only have 2 RPs locally, and the query is always the same, but you can get an idea about the volume of DB requests being triggered per search.

### Before
```
  Notification Load (0.3ms)  SELECT "notifications".* FROM "notifications" WHERE "notifications"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) AND "notifications"."state" = $21  [["id", 1], ["id", 4], ["id", 7], ["id", 10], ["id", 13], ["id", 16], ["id", 19], ["id", 22], ["id", 25], ["id", 28], ["id", 31], ["id", 34], ["id", 37], ["id", 40], ["id", 43], ["id", 46], ["id", 49], ["id", 52], ["id", 55], ["id", 58], ["state", "notification_complete"]]
  ↳ app/views/poison_centres/ingredients_search/_results.html.erb:22
  ResponsiblePerson Load (0.1ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.6ms | Allocations: 2249)
  ResponsiblePerson Load (0.1ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.2ms | Allocations: 2079)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1996)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.0ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.0ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.0ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.0ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.0ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.0ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.0ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ↳ app/views/poison_centres/ingredients_search/_result_row.html.erb:27
  Rendered poison_centres/ingredients_search/_result_row.html.erb (Duration: 1.1ms | Allocations: 1994)
  CACHE ResponsiblePerson Load (0.0ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
```

### After
```
  Notification Load (0.3ms)  SELECT "notifications".* FROM "notifications" WHERE "notifications"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) AND "notifications"."state" = $21  [["id", 1], ["id", 4], ["id", 7], ["id", 10], ["id", 13], ["id", 16], ["id", 19], ["id", 22], ["id", 25], ["id", 28], ["id", 31], ["id", 34], ["id", 37], ["id", 40], ["id", 43], ["id", 46], ["id", 49], ["id", 52], ["id", 55], ["id", 58], ["state", "notification_complete"]]
  ↳ app/views/poison_centres/ingredients_search/_results.html.erb:22
  ResponsiblePerson Load (0.2ms)  SELECT "responsible_persons".* FROM "responsible_persons" WHERE "responsible_persons"."id" IN ($1, $2)  [["id", 1], ["id", 2]]
```


