### PR TITLE
Changes on Cosmetic Search date filters for users navigating without JavaScript

### DIFF
--- a/cosmetics-web/app/views/poison_centres/ingredients_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients_search/_filters.html.erb
@@ -90,7 +90,7 @@
       <button type="submit" class="govuk-button" data-module="govuk-button">
         Apply
       </button>
-      <button type="reset" class="govuk-button govuk-!-font-size-16 opss-button-link" id="opss-reset">
+      <button type="reset" class="govuk-button govuk-!-font-size-16 opss-button-link opss-nojs-hide" id="opss-reset">
         Reset
       </button>
     </div>

--- a/cosmetics-web/app/views/poison_centres/ingredients_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients_search/_filters.html.erb
@@ -78,11 +78,11 @@
             From<span class="govuk-visually-hidden">:</span>
           </div>
 
-          <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_from, id: 'by-date-form-day', extra_classes: "opss-date-input--tight", search_type: "ingredient" } %>
+          <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_from, extra_classes: "opss-date-input--tight", search_type: "ingredient" } %>
           <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-4 govuk-!-margin-bottom-3">
             To<span class="govuk-visually-hidden">:</span>
           </div>
-          <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_to, id: 'by-date-to-day', extra_classes: "opss-date-input--tight", search_type: "ingredient" } %>
+          <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_to, extra_classes: "opss-date-input--tight", search_type: "ingredient" } %>
         </div>
       </fieldset>
     </div>

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_date_filter_input.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_date_filter_input.html.erb
@@ -3,26 +3,29 @@
     <span class="govuk-visually-hidden">Error:</span> <%= error %>
   </span>
 <% end %>
-<div class="govuk-date-input <%= extra_classes %>" id="<%= attribute %>">
+
+<% id = id.presence || attribute %>
+
+<div class="govuk-date-input <%= extra_classes %>" id="<%= id %>">
   <div class="govuk-date-input__item">
     <div class="govuk-form-group">
       <label class="govuk-label govuk-date-input__label" for="<%= attribute %>_day">
         Day
       </label>
-      <input class="govuk-input govuk-date-input__input govuk-input--width-2 <%= error_class(@search_form, attribute, :day) %>" id="<%= attribute %>_day" value="<%= @search_form.public_send(attribute)&.day %>" name="<%= search_type %>_search_form[<%= attribute %>][day]" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+      <input class="govuk-input govuk-date-input__input govuk-input--width-2 <%= error_class(@search_form, attribute, :day) %>" id="<%= id %>_day" value="<%= @search_form.public_send(attribute)&.day %>" name="<%= search_type %>_search_form[<%= attribute %>][day]" type="text" pattern="[0-9]*" inputmode="numeric"></div>
   </div>
   <div class="govuk-date-input__item">
     <div class="govuk-form-group">
       <label class="govuk-label govuk-date-input__label" for="<%= attribute %>_month">
         Month
       </label>
-      <input class="govuk-input govuk-date-input__input govuk-input--width-2 <%= error_class(@search_form, attribute, :month) %>" id="<%= attribute %>_month" value="<%= @search_form.public_send(attribute)&.month %>" name="<%= search_type %>_search_form[<%= attribute %>][month]" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+      <input class="govuk-input govuk-date-input__input govuk-input--width-2 <%= error_class(@search_form, attribute, :month) %>" id="<%= id %>_month" value="<%= @search_form.public_send(attribute)&.month %>" name="<%= search_type %>_search_form[<%= attribute %>][month]" type="text" pattern="[0-9]*" inputmode="numeric"></div>
   </div>
   <div class="govuk-date-input__item">
     <div class="govuk-form-group">
       <label class="govuk-label govuk-date-input__label" for="<%= attribute %>_year">
         Year
       </label>
-      <input class="govuk-input govuk-date-input__input govuk-input--width-4 <%= error_class(@search_form, attribute, :year) %>" id="<%= attribute %>_year" value="<%= @search_form.public_send(attribute)&.year %>" name="<%= search_type %>_search_form[<%= attribute %>][year]" type="text" pattern="[0-9]*" inputmode="numeric"></div>
+      <input class="govuk-input govuk-date-input__input govuk-input--width-4 <%= error_class(@search_form, attribute, :year) %>" id="<%= id %>_year" value="<%= @search_form.public_send(attribute)&.year %>" name="<%= search_type %>_search_form[<%= attribute %>][year]" type="text" pattern="[0-9]*" inputmode="numeric"></div>
   </div>
 </div>

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
@@ -49,7 +49,7 @@
                 For example, 14 08 2019.
               </div>
 
-              <%= render partial: 'date_filter_input', locals: { attribute: :date_exact, id: 'by-date', extra_classes: "", search_type: "notification" } %>
+              <%= render partial: 'date_filter_input', locals: { attribute: :date_exact, extra_classes: "", search_type: "notification" } %>
             </div>
           </div>
           <div class="govuk-radios__item">
@@ -69,11 +69,11 @@
                 From<span class="govuk-visually-hidden">:</span>
               </div>
 
-              <%= render partial: 'date_filter_input', locals: { attribute: :date_from, id: 'by-date-form-day', extra_classes: "", search_type: "notification" } %>
+              <%= render partial: 'date_filter_input', locals: { attribute: :date_from, extra_classes: "", search_type: "notification" } %>
               <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-4 govuk-!-margin-bottom-3">
                 To<span class="govuk-visually-hidden">:</span>
               </div>
-              <%= render partial: 'date_filter_input', locals: { attribute: :date_to, id: 'by-date-to-day', extra_classes: "", search_type: "notification" } %>
+              <%= render partial: 'date_filter_input', locals: { attribute: :date_to, extra_classes: "", search_type: "notification" } %>
 
             </div>
           </div>

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
@@ -33,7 +33,7 @@
           <%= form.hidden_field :search_fields, id: 'notification_search_form_search_fields_hidden' %>
           <%= form.hidden_field :match_similar, id: 'notification_search_form_match_similar_hidden' %>
         </div>
-        <div class="govuk-radios govuk-radios--small govuk-radios--conditional opss-radios--tight" data-module="govuk-radios">
+        <div class="govuk-radios govuk-radios--small govuk-radios--conditional opss-radios--tight opss-nojs-hide" data-module="govuk-radios">
 
           <div class="govuk-radios__item">
             <%= form.radio_button :date_filter, @search_form.class::FILTER_BY_DATE_EXACT, 'class' => "govuk-radios__input", 'id' => "by-date", 'aria-describedby' => "by-date-hint", 'aria-controls' => "conditional-date-block-1" %>

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
@@ -1,4 +1,4 @@
-<section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">
+<section class="govuk-grid-column-one-quarter govuk-!-padding-right-0 opss-full-height__col">
 
   <a href="#search-results-section" class="govuk-skip-link opss-skip-link">
     Skip to the main content

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
@@ -81,6 +81,8 @@
       </fieldset>
     </div>
 
+    <%= render "no_js_date_filters" %>
+
     <div class="govuk-button-group">
       <button type="submit" class="govuk-button" data-module="govuk-button">
         Apply

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_filters.html.erb
@@ -87,7 +87,7 @@
       <button type="submit" class="govuk-button" data-module="govuk-button">
         Apply
       </button>
-      <button type="reset" class="govuk-button govuk-!-font-size-16 opss-button-link" id="opss-reset">
+      <button type="reset" class="govuk-button govuk-!-font-size-16 opss-button-link opss-nojs-hide" id="opss-reset">
         Reset
       </button>
     </div>

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_no_js_date_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_no_js_date_filters.html.erb
@@ -1,0 +1,38 @@
+<noscript>
+  <div class="govuk-form-group govuk-!-margin-bottom-7">
+    <fieldset class="govuk-fieldset" aria-describedby="by-date-range-hint-2">
+
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-!-font-weight-regular">
+          Notified dates
+      </legend>
+
+      <div class="govuk-form-group">
+
+        <div id="by-date-range-hint-2" class="govuk-hint govuk-!-font-size-16">
+          Filter searches by notified dates within a date range. For example, from <span
+              class="opss-no-wrap">01 04 2020</span> to <span class="opss-no-wrap">30 09
+              2022</span>.
+        </div>
+        <div class="govuk-hint govuk-!-font-size-16">
+          From<span class="govuk-visually-hidden">:</span>
+        </div>
+
+        <%= render partial: 'date_filter_input',
+                   locals: { attribute: :date_from,
+                             id: 'date-from-no-script',
+                             extra_classes: "opss-date-input--tight",
+                             search_type: "notification" } %>
+
+        <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-4 govuk-!-margin-bottom-3">
+          To<span class="govuk-visually-hidden">:</span>
+        </div>
+
+        <%= render partial: 'date_filter_input',
+            locals: { attribute: :date_to,
+                      id: 'date-to-no-script',
+                      extra_classes: "opss-date-input--tight",
+                      search_type: "notification" } %>
+      </div>
+    </fieldset>
+  </div>
+</noscript>

--- a/cosmetics-web/app/views/responsible_persons/search_ingredients/_search_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/search_ingredients/_search_form.html.erb
@@ -32,7 +32,7 @@
                 <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1" id="from-hint">
                   For example, 27 9 2020
                 </div>
-                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_from, id: 'by-date-form-day', extra_classes: "", search_type: "ingredient" } %>
+                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_from, extra_classes: "", search_type: "ingredient" } %>
               </fieldset>
             </div>
 
@@ -44,7 +44,7 @@
                 <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1 govuk-visually-hidden" id="to-hint">
                   For example, 27 8 2022
                 </div>
-                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_to, id: 'by-date-to-day', extra_classes: "", search_type: "ingredient" } %>
+                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_to, extra_classes: "", search_type: "ingredient" } %>
               </fieldset>
             </div>
           </div>

--- a/cosmetics-web/app/views/responsible_persons/search_notifications/_search_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/search_notifications/_search_form.html.erb
@@ -33,7 +33,7 @@
                 <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1" id="from-hint">
                   For example, 27 9 2020
                 </div>
-                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_from, id: 'by-date-form-day', extra_classes: "", search_type: "notification" } %>
+                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_from, extra_classes: "", search_type: "notification" } %>
               </fieldset>
             </div>
 
@@ -45,7 +45,7 @@
                 <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1 govuk-visually-hidden" id="to-hint">
                   For example, 27 8 2022
                 </div>
-                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_to, id: 'by-date-to-day', extra_classes: "", search_type: "notification" } %>
+                <%= render partial: 'poison_centres/notifications_search/date_filter_input', locals: { attribute: :date_to, extra_classes: "", search_type: "notification" } %>
               </fieldset>
             </div>
           </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1670)



## Description
<!--- Describe your changes in detail -->

We are bringing changes to the Cosmetic Search portal to improve the search for users browsing without JavaScript:
- When searching for ingredients, the reset filter link will be hidden.
- When searching for notified products, instead of allowing users to filter either by an exact date or a date range, users will default to the date-range filters.


### Ingredients search without JS
![image](https://user-images.githubusercontent.com/1227578/204493242-9ffe02b6-0e0f-443b-87ea-44c3b6eee59e.png)

### Product search without JS
![image](https://user-images.githubusercontent.com/1227578/204493495-cb3d7441-f928-486b-a91b-1a60ff157a59.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2696-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2696-search-web.london.cloudapps.digital/


