### PR TITLE
Bugfix: Notifications missing deletion timestamps

### DIFF
--- a/cosmetics-web/app/models/concerns/notification_state_concern.rb
+++ b/cosmetics-web/app/models/concerns/notification_state_concern.rb
@@ -72,12 +72,6 @@ module NotificationStateConcern
           end
         end
       end
-
-      event :mark_as_deleted do
-        # Only call OpenSearch document deletion when deleting indexed(completed) notifications
-        transitions from: DISPLAYABLE_INCOMPLETE_STATES, to: DELETED
-        transitions from: NOTIFICATION_COMPLETE, to: DELETED, after: proc { delete_document_from_index }
-      end
     end
   end
 

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -266,7 +266,7 @@ class Notification < ApplicationRecord
   def soft_delete!
     return if deleted?
 
-    is_indexed = notification_complete?
+    needs_index_deletion = notification_complete?
     transaction do
       DeletedNotification.create!(attributes.slice(*DELETABLE_ATTRIBUTES).merge(notification: self, state:))
       DELETABLE_ATTRIBUTES.each do |field|
@@ -276,7 +276,7 @@ class Notification < ApplicationRecord
       self.state = DELETED
       save!(validate: false)
 
-      delete_document_from_index if is_indexed
+      delete_document_from_index if needs_index_deletion
     end
   end
 

--- a/cosmetics-web/lib/tasks/deleted_notifications.rake
+++ b/cosmetics-web/lib/tasks/deleted_notifications.rake
@@ -1,0 +1,10 @@
+namespace :deleted_notifications do
+  desc "Backfills the deleted_at column when missing for deleted notifications"
+  task backfill_missing_deletion_timestamp: :environment do
+    ActiveRecord::Base.transaction do
+      Notification.where(state: "deleted").where(deleted_at: nil).find_each do |notification|
+        notification.update_column(:deleted_at, notification.updated_at)
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/lib/tasks/deleted_notifications_spec.rb
+++ b/cosmetics-web/spec/lib/tasks/deleted_notifications_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+Rails.application.load_tasks
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "deleted_notifications.rake" do
+  describe "backfill_missing_deletion_timestamp" do
+    subject(:task) { Rake::Task["deleted_notifications:backfill_missing_deletion_timestamp"] }
+
+    let(:creation_time) { Time.zone.local(2022, 10, 30, 14) }
+    let(:deletion_time) { Time.zone.local(2022, 10, 30, 15) }
+
+    let!(:deleted_notification) do
+      create(:notification, :deleted, deleted_at: nil, updated_at: deletion_time, created_at: creation_time)
+    end
+
+    it "sets the deletion timestampt to the last time the notification got updated" do
+      expect { task.invoke }.to change { deleted_notification.reload.deleted_at }.from(nil).to(deletion_time)
+    end
+
+    it "does not update the updated_at time" do
+      expect { task.invoke }.not_to(change { deleted_notification.reload.updated_at })
+    end
+
+    it "does not change notifications that already have a deletion timestamp" do
+      deleted_notification.update!(deleted_at: creation_time + 1.hour)
+      expect { task.invoke }.not_to(change { deleted_notification.reload.deleted_at })
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1709)

Fix of a bug introduced by https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/pull/2692


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
