### PR TITLE
Check that the review app exists before deletion

### DIFF
--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -30,11 +30,13 @@ jobs:
         cf api api.london.cloud.service.gov.uk
         cf auth
         cf target -o 'beis-opss' -s $SPACE
-        cf stop cosmetics-pr-$PR_NUMBER
-        cf run-task cosmetics-pr-$PR_NUMBER --command "./env/delete-opensearch-indexes.sh" --name delete-opensearch-indexes
-        task_status=0; until [ $task_status = "SUCCEEDED" ]; do task_status="$(cf tasks cosmetics-pr-$PR_NUMBER | grep delete-opensearch-indexes | awk '{print $3}')" && if [ "$task_status" = "FAILED" ]; then break; else echo "waiting" && sleep 10; fi; done;
-        cf delete -f -r cosmetics-pr-$PR_NUMBER
-        cf delete-service -f cosmetics-review-redis-$PR_NUMBER
+        if [[ $(cf apps | grep cosmetics-pr-$PR_NUMBER) ]]; then
+          cf stop cosmetics-pr-$PR_NUMBER
+          cf run-task cosmetics-pr-$PR_NUMBER --command "./env/delete-opensearch-indexes.sh" --name delete-opensearch-indexes
+          task_status=0; until [ $task_status = "SUCCEEDED" ]; do task_status="$(cf tasks cosmetics-pr-$PR_NUMBER | grep delete-opensearch-indexes | awk '{print $3}')" && if [ "$task_status" = "FAILED" ]; then break; else echo "waiting" && sleep 10; fi; done;
+          cf delete -f -r cosmetics-pr-$PR_NUMBER
+          cf delete-service -f cosmetics-review-redis-$PR_NUMBER
+        fi
         cf logout
 
     - name: Checkout code to get deploy functions


### PR DESCRIPTION
Since Dependabot PRs are not creating review apps, the Github action for deleting the review app when deleting/closing a Dependabot PR is failing. ([Example](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/actions/runs/3693520501/jobs/6253600406))

Resolving it by checking the reviw app existence before attempting to stop/delete it.
