### PR TITLE
Fix error display on search pages

### DIFF
--- a/cosmetics-web/app/views/poison_centres/ingredients_search/_filters.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients_search/_filters.html.erb
@@ -61,7 +61,7 @@
             ],
           ) %>
     </div>
-    <div class="govuk-form-group govuk-!-margin-bottom-7">
+    <div class="govuk-form-group govuk-!-margin-bottom-7 <%= search_date_filter_group_error_class(:date_from, :date_to) %>">
       <fieldset class="govuk-fieldset" aria-describedby="by-date-range-hint">
 
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-!-font-weight-regular">

--- a/cosmetics-web/app/views/poison_centres/ingredients_search/show.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients_search/show.html.erb
@@ -3,6 +3,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full opss-desktop-min-height--s2">
 
+    <%= error_summary(@search_form.errors) %>
+
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
       Ingredients search
     </h1>
@@ -36,8 +38,6 @@
 
       </div>
     </details>
-
-    <%= error_summary(@search_form.errors) %>
   </div>
 </div>
 

--- a/cosmetics-web/app/views/poison_centres/notifications_search/show.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/show.html.erb
@@ -1,9 +1,8 @@
 <% content_for :page_title, "Search cosmetic products" %>
 
 <div class="govuk-grid-row">
-  <%= render 'search_box' %>
-
   <%= error_summary(@search_form.errors) %>
+  <%= render 'search_box' %>
 </div>
 
 <div class="govuk-grid-row opss-full-height">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1669)

## Description
<!--- Describe your changes in detail -->

Resolving the following issues when displaying errors in the Cosmetics Search portal:

## On product search 
### Error summary box wrapping the search form. It should be displayed between the "beta" message and the search title/form.
![image](https://user-images.githubusercontent.com/1227578/210405836-8bd7598b-ef4d-49f6-b5ff-a162e0dd4ebb.png)

## On Ingredients search:
### Error summary box below the search form. It should be displayed between the "beta" message and the search title/form.
![image](https://user-images.githubusercontent.com/1227578/210405878-f9ffdbf3-4cd3-431f-ba55-317c75775ca8.png)

### All the date fields should be highlighted with a vertical red bar when there is an error in any of the individual fields.
![image](https://user-images.githubusercontent.com/1227578/210405912-28411e5f-c60e-4a22-9fa1-25353c419487.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2723-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2723-search-web.london.cloudapps.digital/
