### PR TITLE
Change wording on check your email page

### DIFF
--- a/cosmetics-web/app/controllers/registration/new_accounts_controller.rb
+++ b/cosmetics-web/app/controllers/registration/new_accounts_controller.rb
@@ -11,7 +11,7 @@ module Registration
 
     def create
       if new_account_form.save
-        render "users/check_your_email/show"
+        render "users/check_your_email/show", locals: { email: new_account_form.email }
       else
         render :new
       end

--- a/cosmetics-web/app/views/users/check_your_email/show.html.erb
+++ b/cosmetics-web/app/views/users/check_your_email/show.html.erb
@@ -7,6 +7,12 @@
     <h1 class="govuk-heading-l"><%= title %></h1>
 
     <p class="govuk-body">
+      <% if local_assigns[:email] %>
+        <%= I18n.t("users.check_your_email.message_sent.with_email", email: local_assigns[:email]) %>
+      <% else %>
+        <%= I18n.t("users.check_your_email.message_sent.generic") %>
+      <% end %>
+      <br>
       <%= I18n.t("users.check_your_email.follow_link") %>
       <br>
       <%= I18n.t("users.check_your_email.check_spam") %>

--- a/cosmetics-web/app/views/users/check_your_email/show.html.erb
+++ b/cosmetics-web/app/views/users/check_your_email/show.html.erb
@@ -6,7 +6,11 @@
 
     <h1 class="govuk-heading-l"><%= title %></h1>
 
-    <p class="govuk-body"><%= I18n.t("users.check_your_email.body") %></p>
+    <p class="govuk-body">
+      <%= I18n.t("users.check_your_email.follow_link") %>
+      <br>
+      <%= I18n.t("users.check_your_email.check_spam") %>
+    </p>
 
   </div>
 </div>

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -415,7 +415,8 @@ en:
     blank: "Password can not be blank"
   users:
     check_your_email:
-      body: A message with a confirmation link has been sent to your email address. Please follow the link to continue.
+      follow_link: A message with a confirmation link has been sent to your email address. Please follow the link to continue.
+      check_spam: If you cannot find the email, check inside your email spam folder.
   sign_user_in:
     email:
       wrong_email_or_password: "Enter correct email address and password"

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -415,7 +415,10 @@ en:
     blank: "Password can not be blank"
   users:
     check_your_email:
-      follow_link: A message with a confirmation link has been sent to your email address. Please follow the link to continue.
+      message_sent:
+        with_email: A message with a confirmation link has been sent to %{email}.
+        generic: A message with a confirmation link has been sent to your email address.
+      follow_link: Please follow the link to continue.
       check_spam: If you cannot find the email, check inside your email spam folder.
   sign_user_in:
     email:

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
 
-    expect_to_be_on_check_your_email_page
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
     email = delivered_emails.last
     expect(email.recipient).to eq "signing_up@example.com"
@@ -104,7 +104,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
 
-    expect_to_be_on_check_your_email_page
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
     email = delivered_emails.last
     expect(email.recipient).to eq "signing_up@example.com"
@@ -131,7 +131,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
 
-    expect_to_be_on_check_your_email_page
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
     email = delivered_emails.last
     expect(email.recipient).to eq "signing_up@example.com"
@@ -191,7 +191,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
 
-    expect_to_be_on_check_your_email_page
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
     email = delivered_emails.last
     expect(email.recipient).to eq "signing_up@example.com"
@@ -218,7 +218,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
 
-    expect_to_be_on_check_your_email_page
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
     travel_to(3.days.from_now)
     email = delivered_emails.last
@@ -264,7 +264,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
       fill_in "Email address", with: user.email.upcase
       click_button "Continue"
 
-      expect_to_be_on_check_your_email_page
+      expect_to_be_on_check_your_email_page(user.email.upcase)
 
       email = delivered_emails.last
       expect(email.recipient).to eq user.email
@@ -294,7 +294,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
         fill_in "Email address", with: user.email
         click_button "Continue"
 
-        expect_to_be_on_check_your_email_page
+        expect_to_be_on_check_your_email_page(user.email)
 
         expect(delivered_emails.count).to eq(2)
         email = delivered_emails.last
@@ -354,7 +354,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
           responsible_person: responsible_person.name,
           invite_sender: invitation.inviting_user.name,
         )
-        expect_to_be_on_check_your_email_page
+        expect_to_be_on_check_your_email_page("inviteduser@example.com")
 
         # Invitation link takes the user to the account completion page
         visit invitation_path
@@ -374,7 +374,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
 
-    expect_to_be_on_check_your_email_page
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
     email = delivered_emails.last
     expect(email.recipient).to eq "signing_up@example.com"
@@ -410,7 +410,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     fill_in "Email address", with: "signing_up@example.com"
     click_button "Continue"
 
-    expect_to_be_on_check_your_email_page
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
     email = delivered_emails.last
     expect(email.recipient).to eq "signing_up@example.com"
@@ -456,9 +456,9 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect(page).to have_css("p#full_name-error", text: "Enter a valid name")
   end
 
-  def expect_to_be_on_check_your_email_page
+  def expect_to_be_on_check_your_email_page(email)
     expect(page).to have_css("h1", text: "Check your email")
-    expect(page).to have_css(".govuk-body", text: "A message with a confirmation link has been sent to your email address.")
+    expect(page).to have_css(".govuk-body", text: "A message with a confirmation link has been sent to #{email}.")
   end
 
   def user(email = nil)

--- a/cosmetics-web/spec/features/submit/responsible_person/user_account_creation_with_pending_responsible_person_invitations_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/user_account_creation_with_pending_responsible_person_invitations_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Creating an account when having pending responsible person invit
     click_button "Continue"
 
     expect(page).to have_css("h1", text: "Check your email")
-    expect(page).to have_css(".govuk-body", text: "A message with a confirmation link has been sent to your email address.")
+    expect(page).to have_css(".govuk-body", text: "A message with a confirmation link has been sent to #{invited_user_email}.")
 
     email = delivered_emails.last
     expect(email.recipient).to eq invited_user_email


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-670)

## Description
<!--- Describe your changes in detail -->

When users initiate their registration, they are redirected to a "check your email" static page.

On that page:
- We included the email address where the registration email has been sent.
- We included a message to check the spam folder if no email arrived in the inbox.

![image](https://user-images.githubusercontent.com/1227578/210592832-d3460ca4-cac9-4178-a0e2-14a4c944cf62.png)

## Review apps




<!--- Edit links after PR is created -->
https://cosmetics-pr-2724-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2724-search-web.london.cloudapps.digital/
