### PR TITLE
Preselect poisonous info answer on cloned notifications

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/contains_ingredients_npis_needs_to_know.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/contains_ingredients_npis_needs_to_know.html.erb
@@ -34,8 +34,8 @@
         <%= govukRadios(
               form: form,
               key: :contains_ingredients_npis_needs_to_know,
-              items: [{ text: "Yes", value: "true" },
-                      { text: "No", value: "false" }],
+              items: [{ text: "Yes", value: "true", checked: @component.contains_poisonous_ingredients },
+                      { text: "No", value: "false", checked: @component.contains_poisonous_ingredients == false }], # Don't pre-select it when nil, only when explicitly false.
             ) %>
 
       </fieldset>


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1668)

When a frame formulation notification containing poisonous ingredients is cloned, and going through the cloned steps, we want to have pre-selected the original notification answer on whether the notification contains poisonous ingredients or not.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2725-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2725-search-web.london.cloudapps.digital/
