### PR TITLE
Only reset radio selection if field has no errors

### DIFF
--- a/cosmetics-web/app/assets/application/javascripts/notification_search.js
+++ b/cosmetics-web/app/assets/application/javascripts/notification_search.js
@@ -10,7 +10,6 @@ $(function () {
 
   const filterForm = document.getElementById('new_notification_search_form_filters')
   if (filterForm !== null) {
-    const groupErrors = filterForm.querySelectorAll('.govuk-form-group--error')
     const radioConditionalElements = filterForm.querySelectorAll('.govuk-radios__conditional')
     const radioInputs = filterForm.querySelectorAll('.govuk-radios__input')
     const checkboxes = filterForm.querySelectorAll('.govuk-checkboxes__input')
@@ -29,6 +28,8 @@ $(function () {
       radioConditionalElements.forEach(function (element) {
         element.classList.add('govuk-radios__conditional--hidden')
       })
+
+      const groupErrors = filterForm.querySelectorAll('.govuk-form-group--error')
       if (groupErrors.length <= 0) { // there are no errors in the form
         radioInputs.forEach(function (element) {
           element.setAttribute('aria-expanded', true)

--- a/cosmetics-web/app/assets/application/javascripts/notification_search.js
+++ b/cosmetics-web/app/assets/application/javascripts/notification_search.js
@@ -10,6 +10,7 @@ $(function () {
 
   const filterForm = document.getElementById('new_notification_search_form_filters')
   if (filterForm !== null) {
+    const groupErrors = filterForm.querySelectorAll('.govuk-form-group--error')
     const radioConditionalElements = filterForm.querySelectorAll('.govuk-radios__conditional')
     const radioInputs = filterForm.querySelectorAll('.govuk-radios__input')
     const checkboxes = filterForm.querySelectorAll('.govuk-checkboxes__input')
@@ -28,10 +29,12 @@ $(function () {
       radioConditionalElements.forEach(function (element) {
         element.classList.add('govuk-radios__conditional--hidden')
       })
-      radioInputs.forEach(function (element) {
-        element.setAttribute('aria-expanded', false)
-        element.removeAttribute('checked')
-      })
+      if (groupErrors.length <= 0) { // there are no errors in the form
+        radioInputs.forEach(function (element) {
+          element.setAttribute('aria-expanded', true)
+          element.removeAttribute('checked')
+        })
+      }
       checkboxes.forEach(function (element) {
         element.removeAttribute('checked')
       })


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1671)

When there is a validation error on the Cosmetics Product Search date filter inputs, we don't want the "Reset" link to remove the date radio selection.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
On these product search filters
![image](https://user-images.githubusercontent.com/1227578/211523291-3d721032-e9c3-4f8c-b774-54034d4515cc.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2729-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2729-search-web.london.cloudapps.digital/
