### PR TITLE
Fix flaky test on notification bulk deletion

### DIFF
--- a/cosmetics-web/app/services/one_off/notification_bulk_deleter.rb
+++ b/cosmetics-web/app/services/one_off/notification_bulk_deleter.rb
@@ -25,7 +25,7 @@ module OneOff
     end
 
     def notifications_to_delete
-      @notifications_to_delete ||= Notification.where(reference_number: references_to_delete)
+      @notifications_to_delete ||= Notification.where(reference_number: references_to_delete).order(:reference_number)
     end
 
     def references_to_delete

--- a/cosmetics-web/spec/services/one_off/notification_bulk_deleter_spec.rb
+++ b/cosmetics-web/spec/services/one_off/notification_bulk_deleter_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe OneOff::NotificationBulkDeleter do
     it "logs the references for the deleted notifications" do
       bulk_deleter.call
       expect(Rails.logger).to have_received(:info)
-        .with(/Deleted notifications: \["11039162", "49508706", "16335561", "58914669", "4970943"\]/)
+        .with(/Deleted notifications: \["4970943", "11039162", "16335561", "49508706", "58914669"\]/)
     end
   end
 end


### PR DESCRIPTION
Ensuring the notifications are retrieved ordered by reference so the logs will always be presented in the same way.
