### PR TITLE
Bring ph range size validation to mixed multi-item

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -281,7 +281,7 @@ private
 
   def difference_between_maximum_and_minimum_ph
     if (maximum_ph - minimum_ph).round(2) > 1.0
-      errors.add(:maximum_ph, "The maximum pH cannot be more than 1 higher than the minimum pH")
+      errors.add(:maximum_ph, "The maximum pH cannot be greater than 1 above the minimum pH")
     end
   end
 

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -357,7 +357,7 @@ private
     return unless ph_min_value.present? && ph_max_value.present?
 
     if (ph_max_value - ph_min_value).round(2) > 1.0
-      errors.add(:ph_max_value, "The maximum pH cannot be more than 1 higher than the minimum pH")
+      errors.add(:ph_max_value, "The maximum pH cannot be greater than 1 above the minimum pH")
     end
   end
 

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -87,7 +87,7 @@ class Notification < ApplicationRecord
   validates :ph_min_value, :ph_max_value, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 14 }, allow_nil: true
 
   validate :max_ph_is_greater_than_min_ph
-  validate :difference_between_maximum_and_minimum_ph
+  validate :difference_between_maximum_and_minimum_ph, on: :ph_range
 
   validate :product_name_uniqueness, on: :cloning
 

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -87,6 +87,7 @@ class Notification < ApplicationRecord
   validates :ph_min_value, :ph_max_value, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 14 }, allow_nil: true
 
   validate :max_ph_is_greater_than_min_ph
+  validate :difference_between_maximum_and_minimum_ph
 
   validate :product_name_uniqueness, on: :cloning
 
@@ -349,6 +350,14 @@ private
   def max_ph_is_greater_than_min_ph
     if ph_min_value.present? && ph_max_value.present? && ph_min_value > ph_max_value
       errors.add :ph_range, "The minimum pH must be lower than the maximum pH"
+    end
+  end
+
+  def difference_between_maximum_and_minimum_ph
+    return unless ph_min_value.present? && ph_max_value.present?
+
+    if (ph_max_value - ph_min_value).round(2) > 1.0
+      errors.add(:ph_max_value, "The maximum pH cannot be more than 1 higher than the minimum pH")
     end
   end
 

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     end
 
     trait :ph_values do
-      ph_min_value { 4 }
+      ph_min_value { 7 }
       ph_max_value { 8 }
     end
 

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Component, type: :model do
       predefined_component.maximum_ph = 3.01
 
       expect(predefined_component).not_to be_valid(:ph_range)
-      expect(predefined_component.errors[:maximum_ph]).to include("The maximum pH cannot be more than 1 higher than the minimum pH")
+      expect(predefined_component.errors[:maximum_ph]).to include("The maximum pH cannot be greater than 1 above the minimum pH")
     end
 
     context "when changing the pH answer after giving an explicit range" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1686)

## Description
<!--- Describe your changes in detail -->

This validation was already present on the PH range manual values for single-item or non-mixed multi-item notifications.

Bringing the same validation to the multi-item mixed notifications.

![image](https://user-images.githubusercontent.com/1227578/212062309-123a39c9-d943-45df-bcef-76cc38a78038.png)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2734-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2734-search-web.london.cloudapps.digital/
