### PR TITLE
Fix display of fractional ing. concentration range

### DIFF
--- a/cosmetics-web/app/helpers/component_build_helper.rb
+++ b/cosmetics-web/app/helpers/component_build_helper.rb
@@ -12,7 +12,11 @@ module ComponentBuildHelper
       ingredient_range_concentration_item("10", "25"),
       ingredient_range_concentration_item("5", "10"),
       ingredient_range_concentration_item("1", "5"),
-      ingredient_range_concentration_item("01", "1"),
+      {
+        html: render("ingredient_range_concentration_option", above: "0.1", up_to: "1"),
+        value: "greater_than_01_less_than_1_percent",
+        id: "greater_than_01_less_than_1_percent",
+      },
       {
         html: "Up to and including <span class='govuk-!-font-weight-bold'>0.1%</span> <abbr class='govuk-!-font-size-16'>w/w</abbr>".html_safe,
         value: "less_than_01_percent",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1688)

## Description
<!--- Describe your changes in detail -->

When the ingredient range has a fractional value, display it properly. At the moment we are displaying "01", we want to display "0.1".

![image](https://user-images.githubusercontent.com/1227578/212095916-c9dd2bf6-fd9b-4478-8b44-9a96fb03274f.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2735-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2735-search-web.london.cloudapps.digital/
