### PR TITLE
Default to date descending sort for notifications search

### DIFF
--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -553,6 +553,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/cosmetics-web/app/controllers/poison_centres/ingredients_search_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/ingredients_search_controller.rb
@@ -27,7 +27,7 @@ private
     # instead of defaulting to OpenSearch returning the first 10 hits.
     search_result = Notification.full_search(query).page(params[:page]).per(PER_PAGE)
 
-    SearchHistory.create(query: @search_form.q, results: search_result.results.total)
+    SearchHistory.create(query: @search_form.q, sort_by: @search_form.sort_by, results: search_result.results.total)
 
     search_result
   end

--- a/cosmetics-web/app/controllers/poison_centres/notifications_search_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/notifications_search_controller.rb
@@ -27,7 +27,7 @@ private
     # instead of defaulting to OpenSearch returning the first 10 hits.
     search_result = Notification.full_search(query).page(params[:page]).per(PER_PAGE)
 
-    SearchHistory.create(query: @search_form.q, results: search_result.results.total)
+    SearchHistory.create(query: @search_form.q, sort_by: @search_form.sort_by, results: search_result.results.total)
 
     search_result
   end

--- a/cosmetics-web/app/controllers/responsible_persons/search_ingredients_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/search_ingredients_controller.rb
@@ -51,7 +51,7 @@ private
     # instead of defaulting to OpenSearch returning the first 10 hits.
     search_result = Notification.full_search(query).page(params[:page]).per(PER_PAGE)
 
-    SearchHistory.create(query: @search_form.q, results: search_result.results.total)
+    SearchHistory.create(query: @search_form.q, sort_by: @search_form.sort_by, results: search_result.results.total)
 
     search_result
   end

--- a/cosmetics-web/app/controllers/responsible_persons/search_notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/search_notifications_controller.rb
@@ -5,7 +5,6 @@ class ResponsiblePersons::SearchNotificationsController < SubmitApplicationContr
 
   def show
     @search_form = NotificationSearchForm.new(search_params)
-    @search_form.sort_by = OpenSearchQuery::Notification::SCORE_SORTING
     @search_params = search_params
 
     if search_params.present? && params["edit"].nil?
@@ -51,7 +50,7 @@ private
     # instead of defaulting to OpenSearch returning the first 10 hits.
     search_result = Notification.full_search(query).page(params[:page]).per(PER_PAGE)
 
-    SearchHistory.create(query: @search_form.q, results: search_result.results.total)
+    SearchHistory.create(query: @search_form.q, sort_by: @search_form.sort_by, results: search_result.results.total)
 
     search_result
   end

--- a/cosmetics-web/db/migrate/20230125101611_add_sort_by_to_search_histories.rb
+++ b/cosmetics-web/db/migrate/20230125101611_add_sort_by_to_search_histories.rb
@@ -1,0 +1,5 @@
+class AddSortByToSearchHistories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :search_histories, :sort_by, :string
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_23_161737) do
+ActiveRecord::Schema.define(version: 2023_01_25_101611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -285,6 +285,7 @@ ActiveRecord::Schema.define(version: 2022_11_23_161737) do
     t.integer "results"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sort_by"
   end
 
   create_table "trigger_question_elements", force: :cascade do |t|


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1698

## Description

Change default notifications search sort order to date descending. Also adds sort order to search history to be able to monitor how often users change the default sort order.

## Review apps

https://cosmetics-pr-2747-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2747-search-web.london.cloudapps.digital/