### PR TITLE
Add Coverband production code usage tool

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -53,6 +53,8 @@ gem "webpacker", "~> 5.0"
 gem "webrick", "~> 1.7"
 gem "wicked", "~> 1.3.4"
 
+gem "coverband"
+
 group :development do
   gem "rails-erd"
 end

--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -53,7 +53,7 @@ gem "webpacker", "~> 5.0"
 gem "webrick", "~> 1.7"
 gem "wicked", "~> 1.3.4"
 
-gem "coverband"
+gem "coverband", git: "https://github.com/OfficeForProductSafetyAndStandards/coverband.git"
 
 group :development do
   gem "rails-erd"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/OfficeForProductSafetyAndStandards/coverband.git
+  revision: 1a51d00a5f450d0f74209ccba6cf651f837c7fd0
+  specs:
+    coverband (5.2.6.rc.1)
+      redis (>= 3.0)
+
+GIT
   remote: https://github.com/zilkey/active_hash.git
   revision: 1c95f992af3ec94c07e19846f042e12bd0b11dd1
   ref: 1c95f99
@@ -128,8 +135,6 @@ GEM
       term-ansicolor (~> 1.6)
       thor (>= 0.20.3, < 2.0)
       tins (~> 1.16)
-    coverband (5.2.5)
-      redis (>= 3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -563,7 +568,7 @@ DEPENDENCIES
   capybara-screenshot
   cf-app-utils (~> 0.6)
   coveralls_reborn (~> 0.22.0)
-  coverband
+  coverband!
   devise
   devise-security
   dotenv-rails (~> 2.7.5)

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       term-ansicolor (~> 1.6)
       thor (>= 0.20.3, < 2.0)
       tins (~> 1.16)
+    coverband (5.2.5)
+      redis (>= 3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -561,6 +563,7 @@ DEPENDENCIES
   capybara-screenshot
   cf-app-utils (~> 0.6)
   coveralls_reborn (~> 0.22.0)
+  coverband
   devise
   devise-security
   dotenv-rails (~> 2.7.5)

--- a/cosmetics-web/config/coverband.rb
+++ b/cosmetics-web/config/coverband.rb
@@ -19,4 +19,16 @@ Coverband.configure do |config|
 
   # Password to access the web interface
   config.password = ENV["COVERBAND_PASS"]
+
+  # Files ignored in the coverage report
+  config.ignore +=  ["config/application.rb",
+                     "config/boot.rb",
+                     "config/coverband.rb",
+                     "config/environment.rb",
+                     "config/puma.rb",
+                     "config/schedule.rb",
+                     "bin/.*",
+                     "config/environments/.*",
+                     "lib/console.rb",
+                     "lib/tasks/.*"]
 end

--- a/cosmetics-web/config/coverband.rb
+++ b/cosmetics-web/config/coverband.rb
@@ -16,4 +16,7 @@ Coverband.configure do |config|
   # Does not track line-level usage, only indicates if an entire file
   # is used or not.
   config.track_views = true
+
+  # Password to access the web interface
+  config.password = ENV["COVERBAND_PASS"]
 end

--- a/cosmetics-web/config/coverband.rb
+++ b/cosmetics-web/config/coverband.rb
@@ -10,7 +10,7 @@ Coverband.configure do |config|
   config.verbose = false
 
   # default false. button at the top of the web interface which clears all data
-  config.web_enable_clear = true
+  config.web_enable_clear = false
 
   # default false. Experimental support for tracking view layer tracking.
   # Does not track line-level usage, only indicates if an entire file

--- a/cosmetics-web/config/coverband.rb
+++ b/cosmetics-web/config/coverband.rb
@@ -1,0 +1,19 @@
+# config/coverband.rb NOT in the initializers
+Coverband.configure do |config|
+  config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: Rails.application.config_for(:redis).fetch(:url)))
+  config.logger = Rails.logger
+
+  # config options false, true. (defaults to false)
+  # true and debug can give helpful and interesting code usage information
+  # and is safe to use if one is investigating issues in production, but it will slightly
+  # hit perf.
+  config.verbose = false
+
+  # default false. button at the top of the web interface which clears all data
+  config.web_enable_clear = true
+
+  # default false. Experimental support for tracking view layer tracking.
+  # Does not track line-level usage, only indicates if an entire file
+  # is used or not.
+  config.track_views = true
+end

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -40,9 +40,9 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
 
-  # if ENV["COVERBAND_PASSWORD"]
-  mount Coverband::Reporters::Web.new, at: "/coverage"
-  # end
+  if ENV["COVERBAND_PASS"]
+    mount Coverband::Reporters::Web.new, at: "/coverage"
+  end
 
   constraints DomainInclusionConstraint.new(ENV.fetch("SEARCH_HOST")) do
     devise_for :search_users,

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -40,6 +40,10 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
 
+  # if ENV["COVERBAND_PASSWORD"]
+  mount Coverband::Reporters::Web.new, at: "/coverage"
+  # end
+
   constraints DomainInclusionConstraint.new(ENV.fetch("SEARCH_HOST")) do
     devise_for :search_users,
                path: "",


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1746)

## Description
Sets Coverband to identify areas of code that don't get called in production.

The review app coverage can be accessed through:

https://cosmetics-pr-2751-submit-web.london.cloudapps.digital/coverage/

### Implementation notes
We had to[ fork & tweak the Coverband gem](https://github.com/danmayer/coverband/compare/main...OfficeForProductSafetyAndStandards:coverband:main) to be able to use it in our service.

The issue is within the Coverband Rack static middleware which, in its default state, triggers our Rails service Content Security Policies errors, blocking Coverband JS code and Coverband report page from loading.

Fortunately, someone else struggled with the same issue and [opened a PR with a fix](https://github.com/danmayer/coverband/pull/447) over the Coverband repo.
Sadly this is still unmerged and seems stalled.
That is why, for the time being, and in order to be able to use the tool, we forked and tweaked it.

## Report screenshot from the review app:
![image](https://user-images.githubusercontent.com/1227578/215176733-e300b4e7-112e-4b32-b2ce-08623ace7862.png)


## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2751-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2751-search-web.london.cloudapps.digital/
