### PR TITLE
Fix ingredients list on notification page

### DIFF
--- a/cosmetics-web/app/views/notifications/_frame_formulation_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_frame_formulation_details.html.erb
@@ -1,14 +1,18 @@
-<h2 class="govuk-heading-m">Frame formulations</h2>
+<% if notification.components.any?(&:frame_formulation) %>
+  <h2 class="govuk-heading-m">Frame formulations</h2>
 
-<table class="govuk-table">
-  <% notification.components.each do |component| %>
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-!-width-one-half" scope="row">
-        <%= component.name %>
-      </th>
-      <td class="govuk-table__cell">
-        <%= get_frame_formulation_name(component.frame_formulation) %>
-      </td>
-    </tr>
-  <% end %>
-</table>
+  <table class="govuk-table">
+    <% notification.components.each do |component| %>
+      <% if component.frame_formulation.present? %>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header govuk-!-width-one-half" scope="row">
+            <%= component.name %>
+          </th>
+          <td class="govuk-table__cell">
+            <%= get_frame_formulation_name(component.frame_formulation) %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </table>
+<% end %>

--- a/cosmetics-web/app/views/notifications/_ingredient_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_ingredient_details.html.erb
@@ -1,29 +1,26 @@
 <h2 class="govuk-heading-l poison-centre__table-heading">Ingredients</h2>
 
 <% notification.components.each do |component| %>
-  <table class="govuk-table">
-    <% if component.name.present? %>
-      <caption class="govuk-table__caption govuk-heading-m"><%= component.name %></caption>
-    <% end %>
-
-    <% if component.ingredients.exact.any? %>
-      <%= render "formulation_table", entities_list: component.ingredients.exact,
-              key_name: :inci_name, value_name: :exact_concentration %>
-    <% end %>
-    <% if component.ingredients.range.any? %>
-      <%= render "formulation_table", entities_list: component.ingredients.range,
-              key_name: :inci_name, value_name: :range_concentration %>
-    <% end %>
-    <% if component.formulation_file.attached? %>
-      <% if component.formulation_file.metadata["safe"] %>
-        <%= link_to component.formulation_file.filename, url_for(component.formulation_file) %>
-        <%= render("shared/pdf_size", file: component.formulation_file) %>
+  <% if component.ingredients.any? || component.formulation_file.attached? %>
+    <table class="govuk-table">
+      <% if component.name.present? %>
+        <caption class="govuk-table__caption govuk-heading-m"><%= component.name %></caption>
       <% end %>
-    <% end %>
-    <% if component.ingredients.none? && !component.formulation_file.attached? %>
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-!-width-one-half" scope="row">No ingredients data</th>
-      </tr>
-    <% end %>
-  </table>
+  
+      <% if component.ingredients.exact.any? %>
+        <%= render "formulation_table", entities_list: component.ingredients.exact,
+                key_name: :inci_name, value_name: :exact_concentration %>
+      <% end %>
+      <% if component.ingredients.range.any? %>
+        <%= render "formulation_table", entities_list: component.ingredients.range,
+                key_name: :inci_name, value_name: :range_concentration %>
+      <% end %>
+      <% if component.formulation_file.attached? %>
+        <% if component.formulation_file.metadata["safe"] %>
+          <%= link_to component.formulation_file.filename, url_for(component.formulation_file) %>
+          <%= render("shared/pdf_size", file: component.formulation_file) %>
+        <% end %>
+      <% end %>
+    </table>
+  <% end %>
 <% end %>


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1711

## Description

Makes two fixes to the list of ingredients on the notifications page:

* Removes the frame formulations section if there are none for any of the components of a product (i.e. only exact or range ingredients have been provided)
* Removes individual components from the ingredients list if they don’t have any ingredients listed (mainly if the product has multiple components which have a mix of frame formulations and exact/range ingredients along with NPIS-notifiable ingredients; in this case, components with frame formulations but no NPIS-notifiable ingredients would show as “no ingredients data”)

## Review apps

https://cosmetics-pr-2754-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2754-search-web.london.cloudapps.digital/