### PR TITLE
Add Responsible Persons and Notifications pages

### DIFF
--- a/cosmetics-web/app/controllers/concerns/responsible_person_query_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/responsible_person_query_concern.rb
@@ -1,0 +1,22 @@
+module ResponsiblePersonQueryConcern
+  extend ActiveSupport::Concern
+
+  def responsible_persons_by_notified_ingredient(ingredient_inci_name, sort_by:, page:, per_page:)
+    ResponsiblePerson
+      .joins(notifications: { components: :ingredients })
+      .where(notifications: { components: { ingredients: { inci_name: ingredient_inci_name } } })
+      .select("responsible_persons.id, responsible_persons.name, count(notifications.id) AS total_notifications")
+      .group("responsible_persons.id, responsible_persons.name")
+      .order(sort_by)
+      .page(page).per(per_page)
+  end
+
+  def notifications_by_notified_ingredient(ingredient_inci_name, responsible_person:, sort_by:, page:, per_page:)
+    Notification
+      .joins(:responsible_person, components: :ingredients)
+      .where(responsible_person:, components: { ingredients: { inci_name: ingredient_inci_name } })
+      .select("notifications.product_name, notifications.reference_number, notifications.cpnp_reference, notifications.notification_complete_at, notifications.responsible_person_id")
+      .order(sort_by)
+      .page(page).per(per_page)
+  end
+end

--- a/cosmetics-web/app/controllers/poison_centres/ingredients_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/ingredients_controller.rb
@@ -1,5 +1,5 @@
 class PoisonCentres::IngredientsController < SearchApplicationController
-  PER_PAGE = 200
+  include ResponsiblePersonQueryConcern
 
   def index
     return redirect_to root_path unless helpers.can_view_ingredients_list?
@@ -12,6 +12,39 @@ class PoisonCentres::IngredientsController < SearchApplicationController
                       else
                         Ingredient.unique_names.by_name_asc
                       end
-    @ingredients = ingredient_list.page(params[:page]).per(PER_PAGE)
+    @ingredients = ingredient_list.page(params[:page]).per(200)
+  end
+
+  def responsible_persons
+    return redirect_to root_path unless helpers.can_view_ingredients_list?
+    return redirect_to poison_centre_ingredients_path if params[:ingredient_inci_name].blank?
+
+    sort_by = case params[:sort_by]
+              when "most_notifications"
+                "total_notifications desc"
+              when "name_desc"
+                "responsible_persons.name desc"
+              else
+                "responsible_persons.name asc"
+              end
+
+    @responsible_persons = responsible_persons_by_notified_ingredient(params[:ingredient_inci_name], sort_by:, page: params[:page], per_page: 100)
+  end
+
+  def responsible_person_notifications
+    return redirect_to root_path unless helpers.can_view_ingredients_list?
+    return redirect_to poison_centre_ingredients_path if params[:ingredient_inci_name].blank?
+
+    sort_by = case params[:sort_by]
+              when "date"
+                "notifications.created_at desc"
+              when "name_desc"
+                "notifications.product_name desc"
+              else
+                "notifications.product_name asc"
+              end
+
+    @responsible_person = ResponsiblePerson.find(params[:responsible_person_id])
+    @notifications = notifications_by_notified_ingredient(params[:ingredient_inci_name], responsible_person: @responsible_person, sort_by:, page: params[:page], per_page: 20)
   end
 end

--- a/cosmetics-web/app/helpers/poison_centres_notifications_helper.rb
+++ b/cosmetics-web/app/helpers/poison_centres_notifications_helper.rb
@@ -1,6 +1,7 @@
 module PoisonCentresNotificationsHelper
   INGREDIENTS_SEARCH = "ingredients_search".freeze
   NOTIFICATIONS_SEARCH = "notifications_search".freeze
+  INGREDIENTS_LIST = "ingredients_list".freeze
 
   def search_date_filter_group_error_class(*fields)
     error_present = fields.any? do |field|
@@ -31,6 +32,10 @@ module PoisonCentresNotificationsHelper
     params[:back_to] == INGREDIENTS_SEARCH
   end
 
+  def back_to_ingredients_list?
+    params[:back_to] == INGREDIENTS_LIST
+  end
+
   def active_page_class(page)
     if is_current_page(page)
       "class='opss-left-nav__active'".html_safe
@@ -50,12 +55,21 @@ module PoisonCentresNotificationsHelper
     when :ingredients_search
       params[:controller] == "poison_centres/ingredients_search"
     when :ingredients_list
-      params[:controller] == "poison_centres/ingredients"
+      params[:controller] == "poison_centres/ingredients" && params[:action] == "index"
+    when :ingredients_list_responsible_persons
+      params[:controller] == "poison_centres/ingredients" && params[:action] == "responsible_persons"
+    when :ingredients_list_responsible_person_notifications
+      params[:controller] == "poison_centres/ingredients" && params[:action] == "responsible_person_notifications"
     end
   end
 
   def ingredient_search_option(label, value)
     selected = params[:group_by] == value ? "selected=\"selected\"" : ""
+    "<option value=\"#{value}\" #{selected}>#{label}</option>".html_safe
+  end
+
+  def responsible_person_search_option(label, value)
+    selected = params[:sort_by] == value ? "selected=\"selected\"" : ""
     "<option value=\"#{value}\" #{selected}>#{label}</option>".html_safe
   end
 

--- a/cosmetics-web/app/views/poison_centres/ingredients/responsible_person_notifications.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients/responsible_person_notifications.html.erb
@@ -1,0 +1,126 @@
+<% content_for :page_title, "Ingredients list" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full opss-desktop-min-height--s">
+
+	<h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+	  Ingredients list -
+	  <span class="govuk-!-font-weight-regular opss-font-size--reduced-s">Notifications</span>
+	</h1>
+
+	<p class="govuk-body opss-secondary-text">
+	  Notifications by <%= @responsible_person.name %> -
+	  <span class="govuk-!-font-weight-bold opss-primary-text">submitted after 2 October 2022</span><a href="#october" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"><sup class="govuk-!-font-size-14">&ast;</sup></a>
+	  - which include the ingredient <%= params[:ingredient_inci_name] %>.
+	</p>
+  </div>
+</div>
+
+<div class="govuk-grid-row opss-full-height">
+  <section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">
+	<a href="#notifications" class="govuk-skip-link opss-skip-link">
+	  Skip to the main content
+	</a>
+	<nav aria-label="Secondary">
+	  <%= render 'poison_centres/shared/secondary_navigation' %>
+	</nav>
+  </section>
+  <section class="govuk-grid-column-three-quarters" id="notifications">
+	<div class="govuk-grid-row">
+	  <div class="govuk-grid-column-one-third opss-text-align-right">
+		<div class="govuk-form-group opss-text-align-right">
+		  <form id="new_notification_search_form_sort" novalidate="novalidate" action="#" accept-charset="UTF-8" method="get">
+			<input type="hidden" name="ingredient_inci_name" value="<%= params[:ingredient_inci_name] %>">
+			<label class="govuk-label govuk-body-s" for="notification_search_form_sort_by">
+			  Order by
+			</label>
+
+			<select class="govuk-select govuk-!-margin-bottom-1" name="sort_by" id="notification_search_form_sort_by">
+			  <%= responsible_person_search_option("A - Z", "name_asc") %>
+			  <%= responsible_person_search_option("Z - A", "name_desc") %>
+			  <%= responsible_person_search_option("Newly added", "date") %>
+			</select>
+
+			<button class="govuk-button opss-js-enabled-hidden">
+			  Order
+			</button>
+		  </form>
+		</div>
+	  </div>
+	</div>
+	<div class="govuk-grid-row">
+	  <div class="govuk-grid-column-full">
+		<p class="govuk-body-s">
+		  There are currently <%= @notifications.total_count %> active notifications by <%= @responsible_person.name %> (submitted after 2 October 2022) which include the ingredient <%= params[:ingredient_inci_name] %>.
+		</p>
+	  </div>
+	</div>
+	<div class="govuk-grid-row">
+	  <div class="govuk-grid-column-full" role="region" aria-label="search-results-list" id="results-order" aria-live="polite">
+		<table id="table-items" class="govuk-table govuk-!-margin-top-5 opss-table-items opss-table-items--sm opss-table-items--first-col-33">
+		  <caption class="govuk-visually-hidden">
+			Search results. Each notification is described across 2 rows within its own table body.
+		  </caption>
+		  <thead class="govuk-table__head">
+			<tr class="govuk-table__row">
+			  <th class="govuk-visually-hidden">&nbsp;</th>
+			  <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
+			  <th scope="col" class="govuk-table__header"><abbr>UK</abbr> cosmetic product number</th>
+			  <th scope="col" class="govuk-table__header"><abbr>EU</abbr> reference number</th>
+			</tr>
+		  </thead>
+		  <%
+		  	@notifications.each.with_index(1) do |notification, index|
+		   	  cell_headers = "item-#{index} meta-#{index}"
+		  %>
+	  	  <tbody class="govuk-table__body">
+		    <tr class="govuk-table__row">
+		  	  <th class="govuk-visually-hidden">
+			    Name
+		  	  </th>
+		  	  <th id="item-<%= index %>" colspan="3" scope="colgroup" class="govuk-table__header">
+			    <%= link_to notification.product_name,
+				  poison_centre_notification_path(reference_number: notification.reference_number, ingredient_inci_name: params[:ingredient_inci_name], back_to: PoisonCentresNotificationsHelper::INGREDIENTS_LIST),
+				  class: "govuk-link govuk-link--no-visited-state" %>
+		  	  </th>
+			</tr>
+			<tr class="govuk-table__row">
+		  	  <th headers="item-<%= index %>" id="meta-<%= index %>" class="govuk-visually-hidden">
+			    Metadata
+		  	  </th>
+		  	  <td headers="uknotified <%= cell_headers %>" class="govuk-table__cell">
+			    <%= notification.notification_complete_at.present? ? display_full_month_date(notification.notification_complete_at) : "&nbsp;".html_safe %>
+		  	  </td>
+		  	  <td headers="ukcosprodnumber <%= cell_headers %>" class="govuk-table__cell">
+			    <%= notification.reference_number_for_display.presence || "&nbsp;".html_safe %>
+		  	  </td>
+		  	  <td headers="eurefnumber <%= cell_headers %>" class="govuk-table__cell">
+			    <%= notification.cpnp_reference %>
+		  	  </td>
+			</tr>
+	  	  </tbody>
+		  <% end %>
+		  <% if @notifications.size > 11 %>
+			<tfoot class="govuk-table__head">
+			  <tr class="govuk-table__row">
+				<th class="govuk-visually-hidden">&nbsp;</th>
+				<th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
+				<th scope="col" class="govuk-table__header"><abbr>UK</abbr> cosmetic product number</th>
+				<th scope="col" class="govuk-table__header"><abbr>EU</abbr> reference number</th>
+			  </tr>
+			</tfoot>
+		  <% end %>
+		</table>
+		<%= paginate @notifications, views_prefix: "pagination", nav_class: "opss-pagination-link--no-top-border" %>
+	  </div>
+	</div>
+	<div class="govuk-grid-row">
+	  <div class="govuk-grid-column-full">
+		<p id="october" class="govuk-body govuk-!-font-size-14 govuk-!-margin-top-9 govuk-!-margin-bottom-0 opss-secondary-text opss-text-align-right">
+		  <sup>&ast;</sup>Notifications submitted before 3 October 2022 are not searchable for ingredients.<br>
+		  The ingredient may also feature in older notifications.
+		</p>
+	  </div>
+	</div>
+  </section>
+</div>

--- a/cosmetics-web/app/views/poison_centres/ingredients/responsible_persons.html.erb
+++ b/cosmetics-web/app/views/poison_centres/ingredients/responsible_persons.html.erb
@@ -4,38 +4,41 @@
   <div class="govuk-grid-column-full opss-desktop-min-height--s">
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-      Ingredients list
+      Ingredients list -
+      <span class="govuk-!-font-weight-regular opss-font-size--reduced-s">Responsible Persons</span>
     </h1>
 
     <p class="govuk-body opss-secondary-text">
-      Ingredients listed in cosmetic product notifications
-      (<span class="govuk-!-font-weight-bold opss-primary-text">submitted after 2 October 2022</span>)<a href="#october" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"><sup class="govuk-!-font-size-14">&ast;</sup></a>.
+      Ingredient <%= params[:ingredient_inci_name] %> is included in notifications -
+      <span class="govuk-!-font-weight-bold opss-primary-text">submitted after 2 October 2022</span><a href="#october" class="govuk-link govuk-link--no-visited-state govuk-link--no-underline"><sup class="govuk-!-font-size-14">&ast;</sup></a>
+      - by these Responsible Persons. From here you can view the notifications for each Responsible Person.
     </p>
   </div>
 </div>
 
 <div class="govuk-grid-row opss-full-height">
   <section class="govuk-grid-column-one-quarter govuk-!-padding-right-1 opss-full-height__col">
-    <a href="#ingredients" class="govuk-skip-link opss-skip-link">
+    <a href="#responsible_persons" class="govuk-skip-link opss-skip-link">
       Skip to the main content
     </a>
     <nav aria-label="Secondary">
       <%= render 'poison_centres/shared/secondary_navigation' %>
     </nav>
   </section>
-  <section class="govuk-grid-column-three-quarters" id="ingredients">
+  <section class="govuk-grid-column-three-quarters" id="responsible_persons">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third opss-text-align-right">
         <div class="govuk-form-group opss-text-align-right">
           <form id="new_notification_search_form_sort" novalidate="novalidate" action="#" accept-charset="UTF-8" method="get">
+            <input type="hidden" name="ingredient_inci_name" value="<%= params[:ingredient_inci_name] %>">
             <label class="govuk-label govuk-body-s" for="notification_search_form_sort_by">
               Order by
             </label>
 
             <select class="govuk-select govuk-!-margin-bottom-1" name="sort_by" id="notification_search_form_sort_by">
-              <%= ingredient_search_option("A - Z", "name_asc") %>
-              <%= ingredient_search_option("Z - A", "name_desc") %>
-              <%= ingredient_search_option("Newly added", "date") %>
+              <%= responsible_person_search_option("A - Z", "name_asc") %>
+              <%= responsible_person_search_option("Z - A", "name_desc") %>
+              <%= responsible_person_search_option("Most notifications", "most_notifications") %>
             </select>
 
             <button class="govuk-button opss-js-enabled-hidden">
@@ -48,8 +51,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <p class="govuk-body-s">
-          There are currently <%= @ingredients.total_count %> different ingredients listed in cosmetic product notifications
-          <br class="opss-br-desktop">(submitted after 2 October 2022).
+          There are currently <%= @responsible_persons.total_count %> Responsible Persons with active notifications (submitted after 2 October 2022) which include the ingredient <%= params[:ingredient_inci_name] %>.
         </p>
       </div>
     </div>
@@ -57,22 +59,26 @@
       <div class="govuk-grid-column-full" role="region" aria-label="Search results">
         <div class="govuk-!-margin-top-5 opss-2-col-flow">
           <ul class="govuk-list govuk-list--bullet">
-            <% @ingredients.each_with_index do |ingredient, index| %>
+            <% @responsible_persons.each_with_index do |responsible_person, index| %>
               <li>
-                <%= link_to ingredient.inci_name,
-                  poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: ingredient.inci_name),
+                <%= link_to responsible_person.name,
+                  poison_centre_ingredients_responsible_person_notifications_path(
+                    responsible_person_id: responsible_person.id,
+                    ingredient_inci_name: params[:ingredient_inci_name],
+                  ),
                   class: "govuk-link govuk-link--no-visited-state" %>
               </li>
             <% end %>
           </ul>
         </div>
-        <%= paginate @ingredients, views_prefix: "pagination", nav_class: "opss-pagination-link--no-top-border" %>
+        <%= paginate @responsible_persons, views_prefix: "pagination", nav_class: "opss-pagination-link--no-top-border" %>
       </div>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <p id="october" class="govuk-body govuk-!-font-size-14 govuk-!-margin-top-9 govuk-!-margin-bottom-0 opss-secondary-text opss-text-align-right">
-          <sup>&ast;</sup>Notifications submitted before 3 October 2022 are not searchable for ingredients.
+          <sup>&ast;</sup>Notifications submitted before 3 October 2022 are not searchable for ingredients.<br>
+          The ingredient may also feature in older notifications.
         </p>
       </div>
     </div>

--- a/cosmetics-web/app/views/poison_centres/shared/_back_links.html.erb
+++ b/cosmetics-web/app/views/poison_centres/shared/_back_links.html.erb
@@ -1,5 +1,7 @@
 <% if back_to_ingredients? %>
   <%= govukBackLink text: "Back", href: poison_centre_ingredients_search_path(ingredient_search_form: search_params, page: params[:page]) %>
+<% elsif back_to_ingredients_list? %>
+  <%= govukBackLink text: "Back", href: poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: @notification.responsible_person.id, ingredient_inci_name: params[:ingredient_inci_name], page: params[:page]) %>
 <% else %>
   <%= govukBackLink text: "Back", href: poison_centre_notifications_search_path(notification_search_form: search_params, page: params[:page]) %>
 <% end %>

--- a/cosmetics-web/app/views/poison_centres/shared/_secondary_navigation.html.erb
+++ b/cosmetics-web/app/views/poison_centres/shared/_secondary_navigation.html.erb
@@ -10,10 +10,32 @@
     </a>
   </li>
   <% if can_view_ingredients_list? %>
-    <li <%= active_page_class(:ingredients_list) %>>
+    <li <%= active_page_class(:ingredients_list) || active_page_class(:ingredients_list_responsible_persons) || active_page_class(:ingredients_list_responsible_person_notifications) %>>
       <a href="<%= poison_centre_ingredients_path %>" class="govuk-link govuk-link--no-visited-state" <%= aria_active(:ingredients_list) %>>
         Ingredients list
       </a>
+      <% if active_page_class(:ingredients_list_responsible_persons) || active_page_class(:ingredients_list_responsible_person_notifications) %>
+        <ul class="govuk-list">
+          <li>
+            <a href="<%= poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: params[:ingredient_inci_name]) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold opss-link--no-hover" <%= aria_active(:ingredients_list_responsible_persons) %>>
+              Responsible Persons
+            </a>
+            <br>
+            <%= params[:ingredient_inci_name] %>
+            <% if active_page_class(:ingredients_list_responsible_person_notifications) %>
+              <ul class="govuk-list">
+                <li>
+                  <a href="<%= poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: params[:responsible_person_id], ingredient_inci_name: params[:ingredient_inci_name]) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold opss-link--no-hover" <%= aria_active(:ingredients_list_responsible_person_notifications) %>>
+                    Notifications
+                  </a>
+                  <br>
+                  <%= @responsible_person.name %>
+                </li>
+              </ul>
+            <% end %>
+          </li>
+        </ul>
+      <% end %>
     </li>
   <% end %>
 </ul>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
       resource :notifications_search, path: "/notifications", controller: "notifications_search", only: %i[show]
       resource :ingredients_search, path: "/ingredients", controller: "ingredients_search", only: %i[show]
       resources :ingredients, path: "/ingredients-list", controller: "ingredients", only: %i[index]
+      get "ingredients-list/responsible-persons", to: "ingredients#responsible_persons", as: :ingredients_responsible_persons
+      get "ingredients-list/responsible-persons/:responsible_person_id/notifications", to: "ingredients#responsible_person_notifications", as: :ingredients_responsible_person_notifications
     end
     resources :users, only: [:update] do
       member do

--- a/cosmetics-web/spec/controllers/concerns/responsible_person_query_concern_spec.rb
+++ b/cosmetics-web/spec/controllers/concerns/responsible_person_query_concern_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe ResponsiblePersonQueryConcern, type: :controller do
+  let(:dummy_class) do
+    Class.new(ApplicationController) do
+      include ResponsiblePersonQueryConcern
+
+      def self.name
+        "DummyClass"
+      end
+    end
+  end
+
+  let(:dummy) { dummy_class.new }
+
+  let(:ingredient1) { create(:exact_ingredient, inci_name: "NaCl", created_at: 2.days.ago) }
+  let(:ingredient2) { create(:exact_ingredient, inci_name: "Aqua", created_at: 1.week.ago) }
+  let(:ingredient3) { create(:exact_ingredient, inci_name: "Sodium", created_at: 2.weeks.ago) }
+  let(:ingredient4) { create(:exact_ingredient, inci_name: "Aqua", created_at: 3.weeks.ago) }
+  let(:notification5) { create(:notification, responsible_person: ingredient4.component.responsible_person) }
+  let(:component5) { create(:exact_component, notification: notification5) }
+  let(:ingredient5) { create(:exact_ingredient, inci_name: "Aqua", component: component5, created_at: 3.weeks.ago) }
+
+  before do
+    ingredient1
+    ingredient2
+    ingredient3
+    ingredient4
+    ingredient5
+  end
+
+  describe "#responsible_persons_by_notified_ingredient" do
+    context "when ordered by Responsible Person names in ascending order" do
+      it "returns a sorted array of Responsible Persons" do
+        result = dummy.responsible_persons_by_notified_ingredient("Aqua", sort_by: "responsible_persons.name asc", page: "1", per_page: 100)
+        expect(result).to eq([ingredient2.component.responsible_person, ingredient4.component.responsible_person])
+      end
+    end
+
+    context "when ordered by Responsible Person names in descending order" do
+      it "returns a sorted array of Responsible Persons" do
+        result = dummy.responsible_persons_by_notified_ingredient("Aqua", sort_by: "responsible_persons.name desc", page: "1", per_page: 100)
+        expect(result).to eq([ingredient4.component.responsible_person, ingredient2.component.responsible_person])
+      end
+    end
+
+    context "when ordered by most notifications per Responsible Person" do
+      it "returns a sorted array of Responsible Persons" do
+        result = dummy.responsible_persons_by_notified_ingredient("Aqua", sort_by: "total_notifications desc", page: "1", per_page: 100)
+        expect(result).to eq([ingredient4.component.responsible_person, ingredient2.component.responsible_person])
+      end
+    end
+  end
+
+  describe "#notifications_by_notified_ingredient" do
+    context "when ordered by product names in ascending order" do
+      it "returns a sorted array of notifications" do
+        result = dummy.notifications_by_notified_ingredient("Aqua", responsible_person: ingredient5.component.responsible_person, sort_by: "notifications.product_name asc", page: "1", per_page: 20)
+        # We need to check individual product names because the query does not return complete notifications
+        expect(result[0].product_name).to eq(ingredient4.component.notification.product_name)
+        expect(result[1].product_name).to eq(ingredient5.component.notification.product_name)
+      end
+    end
+
+    context "when ordered by product names in descending order" do
+      it "returns a sorted array of notifications" do
+        result = dummy.notifications_by_notified_ingredient("Aqua", responsible_person: ingredient5.component.responsible_person, sort_by: "notifications.product_name desc", page: "1", per_page: 20)
+        # We need to check individual product names because the query does not return complete notifications
+        expect(result[0].product_name).to eq(ingredient5.component.notification.product_name)
+        expect(result[1].product_name).to eq(ingredient4.component.notification.product_name)
+      end
+    end
+
+    context "when ordered by notification created date" do
+      it "returns a sorted array of notifications" do
+        result = dummy.notifications_by_notified_ingredient("Aqua", responsible_person: ingredient5.component.responsible_person, sort_by: "notifications.created_at desc", page: "1", per_page: 20)
+        # We need to check individual product names because the query does not return complete notifications
+        expect(result[0].product_name).to eq(ingredient5.component.notification.product_name)
+        expect(result[1].product_name).to eq(ingredient4.component.notification.product_name)
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/features/search/ingredients_list_spec.rb
+++ b/cosmetics-web/spec/features/search/ingredients_list_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "support/feature_helpers"
 
-RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :with_2fa_app, type: :feature do
+RSpec.feature "Ingredients list", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :with_2fa_app, type: :feature do
   let(:user) { create(:poison_centre_user, :with_sms_secondary_authentication) }
 
   let(:component1) { create(:component, :using_exact, with_ingredients: %w[aqua tin sodium]) }
@@ -13,7 +13,6 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
   let(:shower_bubbles) { create(:notification, :registered, responsible_person:, components: [component2], notification_complete_at: 3.days.ago, product_name: "Shower Bubbles") }
 
   before do
-    skip("Awaiting for ingredients list to be approved to go live")
     configure_requests_for_search_domain
 
     cream
@@ -34,6 +33,11 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     expect(page).to have_link("sodium")
 
     click_link "sodium"
+
+    expect(page).to have_link(cream.responsible_person.name)
+    expect(page).not_to have_link(responsible_person.name)
+
+    click_link cream.responsible_person.name
 
     expect(page).to have_link("Cream")
     expect(page).not_to have_link("Shower Bubbles")

--- a/cosmetics-web/spec/requests/ingredient_list_spec.rb
+++ b/cosmetics-web/spec/requests/ingredient_list_spec.rb
@@ -15,67 +15,273 @@ RSpec.describe "Ingredient list", type: :request do
     ingredient4
   end
 
-  describe "GET #index" do
+  context "when signed in as a Poison Centre user" do
     before do
       sign_in_as_poison_centre_user
     end
 
-    RSpec.shared_examples "unique ingredient names" do
-      it "returns unique ingredient names" do
-        within("ul.govuk-list--bullet li") do
-          expect(response.body).to have_tag("a.govuk-link", count: 3)
-                               .and have_tag("a.govuk-link", text: "Aqua", count: 1)
-                               .and have_tag("a.govuk-link", text: "Sodium", count: 1)
-                               .and have_tag("a.govuk-link", text: "NaCl", count: 1)
+    describe "GET #index" do
+      RSpec.shared_examples "unique ingredient names" do
+        it "returns unique ingredient names" do
+          within("ul.govuk-list--bullet li") do
+            expect(response.body).to have_tag("a.govuk-link", count: 3)
+                                 .and have_tag("a.govuk-link", text: "Aqua", count: 1)
+                                 .and have_tag("a.govuk-link", text: "Sodium", count: 1)
+                                 .and have_tag("a.govuk-link", text: "NaCl", count: 1)
+          end
+        end
+      end
+
+      context "when sorting by date" do
+        before do
+          get poison_centre_ingredients_path(sort_by: "date")
+        end
+
+        include_examples "unique ingredient names"
+
+        it "orders ingredients from last to first added" do
+          expect(response.body).to match(/NaCl.*Sodium.*Aqua/m)
+        end
+      end
+
+      context "when sorting by name_desc" do
+        before do
+          get poison_centre_ingredients_path(sort_by: "name_desc")
+        end
+
+        include_examples "unique ingredient names"
+
+        it "orders ingredients by name from last to first" do
+          expect(response.body).to match(/Sodium.*NaCl.*Aqua/m)
+        end
+      end
+
+      context "when sorting by name_asc" do
+        before do
+          get poison_centre_ingredients_path(sort_by: "name_asc")
+        end
+
+        include_examples "unique ingredient names"
+
+        it "orders ingredients by name from first to last" do
+          expect(response.body).to match(/Aqua.*NaCl.*Sodium/m)
+        end
+      end
+
+      context "without sorting parameter" do
+        before do
+          get poison_centre_ingredients_path
+        end
+
+        include_examples "unique ingredient names"
+
+        it "orders ingredients by name from first to last" do
+          expect(response.body).to match(/Aqua.*NaCl.*Sodium/m)
         end
       end
     end
 
-    context "when sorting by date" do
+    describe "GET #responsible_persons" do
+      let(:notification5) { create(:notification, responsible_person: ingredient4.component.responsible_person) }
+      let(:component5) { create(:exact_component, notification: notification5) }
+      let(:ingredient5) { create(:exact_ingredient, inci_name: "Aqua", component: component5, created_at: 3.weeks.ago) }
+
       before do
-        get poison_centre_ingredients_path(sort_by: "date")
+        ingredient5
       end
 
-      include_examples "unique ingredient names"
+      context "when sorting by most_notifications" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua", sort_by: "most_notifications")
+        end
 
-      it "orders ingredients from last to first added" do
-        expect(response.body).to match(/NaCl.*Sodium.*Aqua/m)
+        it "orders responsible persons from most to least notifications" do
+          expect(response.body).to match(/#{ingredient4.component.responsible_person.name}.*#{ingredient2.component.responsible_person.name}/m)
+        end
+      end
+
+      context "when sorting by name_desc" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua", sort_by: "name_desc")
+        end
+
+        it "orders responsible persons by name from last to first" do
+          expect(response.body).to match(/#{ingredient4.component.responsible_person.name}.*#{ingredient2.component.responsible_person.name}/m)
+        end
+      end
+
+      context "when sorting by name_asc" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua", sort_by: "name_asc")
+        end
+
+        it "orders responsible persons by name from first to last" do
+          expect(response.body).to match(/#{ingredient2.component.responsible_person.name}.*#{ingredient4.component.responsible_person.name}/m)
+        end
+      end
+
+      context "without sorting parameter" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua")
+        end
+
+        it "orders responsible persons by name from first to last" do
+          expect(response.body).to match(/#{ingredient2.component.responsible_person.name}.*#{ingredient4.component.responsible_person.name}/m)
+        end
+      end
+
+      context "without ingredient name" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "")
+        end
+
+        it "redirects to the ingredients list page" do
+          expect(response).to redirect_to("/ingredients-list")
+        end
       end
     end
 
-    context "when sorting by name_desc" do
+    describe "GET #responsible_person_notifications" do
+      let(:notification5) { create(:notification, product_name: "ZZZ", responsible_person: ingredient4.component.responsible_person) }
+      let(:component5) { create(:exact_component, notification: notification5) }
+      let(:ingredient5) { create(:exact_ingredient, inci_name: "Aqua", component: component5, created_at: 3.weeks.ago) }
+
       before do
-        get poison_centre_ingredients_path(sort_by: "name_desc")
+        ingredient5
       end
 
-      include_examples "unique ingredient names"
+      context "when sorting by date" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient5.component.responsible_person.id, ingredient_inci_name: "Aqua", sort_by: "date")
+        end
 
-      it "orders ingredients by name from last to first" do
-        expect(response.body).to match(/Sodium.*NaCl.*Aqua/m)
+        it "orders notifications from last to first added" do
+          expect(response.body).to match(/#{ingredient5.component.notification.product_name}.*#{ingredient4.component.notification.product_name}/m)
+        end
+      end
+
+      context "when sorting by name_desc" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient5.component.responsible_person.id, ingredient_inci_name: "Aqua", sort_by: "name_desc")
+        end
+
+        it "orders notifications by product name from last to first" do
+          expect(response.body).to match(/#{ingredient5.component.notification.product_name}.*#{ingredient4.component.notification.product_name}/m)
+        end
+      end
+
+      context "when sorting by name_asc" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient5.component.responsible_person.id, ingredient_inci_name: "Aqua", sort_by: "name_asc")
+        end
+
+        it "orders notifications by product name from first to last" do
+          expect(response.body).to match(/#{ingredient4.component.notification.product_name}.*#{ingredient5.component.notification.product_name}/m)
+        end
+      end
+
+      context "without sorting parameter" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient5.component.responsible_person.id, ingredient_inci_name: "Aqua")
+        end
+
+        it "orders notifications by product name from first to last" do
+          expect(response.body).to match(/#{ingredient4.component.notification.product_name}.*#{ingredient5.component.notification.product_name}/m)
+        end
+      end
+
+      context "without ingredient name" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient5.component.responsible_person.id, ingredient_inci_name: "")
+        end
+
+        it "redirects to the ingredients list page" do
+          expect(response).to redirect_to("/ingredients-list")
+        end
+      end
+    end
+  end
+
+  context "when signed in as an MSA user" do
+    before do
+      sign_in_as_msa_user
+    end
+
+    describe "GET #index" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_path
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
       end
     end
 
-    context "when sorting by name_asc" do
-      before do
-        get poison_centre_ingredients_path(sort_by: "name_asc")
-      end
+    describe "GET #responsible_persons" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua")
+        end
 
-      include_examples "unique ingredient names"
-
-      it "orders ingredients by name from last to first" do
-        expect(response.body).to match(/Aqua.*NaCl.*Sodium/m)
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
       end
     end
 
-    context "without sorting parameter" do
-      before do
-        get poison_centre_ingredients_path
+    describe "GET #responsible_person_notifications" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient2.component.responsible_person.id, ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
       end
+    end
+  end
 
-      include_examples "unique ingredient names"
+  context "when signed in as an OPSS Science user" do
+    before do
+      sign_in_as_opss_science_user
+    end
 
-      it "orders ingredients by name from last to first" do
-        expect(response.body).to match(/Aqua.*NaCl.*Sodium/m)
+    describe "GET #index" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_path
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_persons" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_person_notifications" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient2.component.responsible_person.id, ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
       end
     end
   end


### PR DESCRIPTION
JIRA links: https://regulatorydelivery.atlassian.net/browse/COSBETA-1737 and https://regulatorydelivery.atlassian.net/browse/COSBETA-1738

## Description

Adds two new pages under the ingredients list page:

* Responsible Persons - list of Responsible Persons who have created notifications of products containing a specified ingredient
* Notifications - list of notifications from a specified Responsible Person with products containing a specified ingredient

## Review apps

https://cosmetics-pr-2760-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2760-search-web.london.cloudapps.digital/

Note, this PR must be rebased and merged after https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/pull/2756 since it is based on that branch.