### PR TITLE
Restrict Coverband to production environment

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -53,7 +53,9 @@ gem "webpacker", "~> 5.0"
 gem "webrick", "~> 1.7"
 gem "wicked", "~> 1.3.4"
 
-gem "coverband", git: "https://github.com/OfficeForProductSafetyAndStandards/coverband.git"
+group :production do
+  gem "coverband", git: "https://github.com/OfficeForProductSafetyAndStandards/coverband.git"
+end
 
 group :development do
   gem "rails-erd"

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
 
-  if ENV["COVERBAND_PASS"]
+  if Rails.env.production? && ENV["COVERBAND_PASS"]
     mount Coverband::Reporters::Web.new, at: "/coverage"
   end
 


### PR DESCRIPTION
We only want it running in Review Apps/Staging/Production, not on development/testing.

Theoretically, this can be disabled with an ENV variable, but Coverband in Rails keeps loading before the env variable gets loaded in the local environment, causing issues with local Redis and not being disabled on command.

The solution: Only load the gem in the production environment.
