### PR TITLE
Show Responsible Person address history

### DIFF
--- a/cosmetics-web/app/helpers/privileges_helper.rb
+++ b/cosmetics-web/app/helpers/privileges_helper.rb
@@ -11,4 +11,6 @@ module PrivilegesHelper
   delegate :can_view_nanomaterial_notification_files?, to: :current_user
 
   delegate :can_view_nanomaterial_review_period_end_date?, to: :current_user
+
+  delegate :can_view_responsible_person_address_history?, to: :current_user
 end

--- a/cosmetics-web/app/models/concerns/privileges/abstract_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/abstract_concern.rb
@@ -25,6 +25,10 @@ module Privileges
       raise ArgumentError, "Implement role in each user type roles concern"
     end
 
+    def can_view_responsible_person_address_history?
+      raise ArgumentError, "Implement role in each user type roles concern"
+    end
+
     def poison_centre_user?
       false
     end

--- a/cosmetics-web/app/models/concerns/privileges/search_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/search_concern.rb
@@ -18,6 +18,10 @@ module Privileges
       opss_user? || trading_standards_user?
     end
 
+    def can_view_responsible_person_address_history?
+      trading_standards_user?
+    end
+
     def poison_centre_user?
       poison_centre?
     end

--- a/cosmetics-web/app/models/concerns/privileges/submit_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/submit_concern.rb
@@ -17,5 +17,9 @@ module Privileges
     def can_view_nanomaterial_review_period_end_date?
       true
     end
+
+    def can_view_responsible_person_address_history?
+      true
+    end
   end
 end

--- a/cosmetics-web/app/models/responsible_person_address_log.rb
+++ b/cosmetics-web/app/models/responsible_person_address_log.rb
@@ -1,5 +1,9 @@
 class ResponsiblePersonAddressLog < ApplicationRecord
+  ADDRESS_FIELDS = %i[line_1 line_2 city county postal_code].freeze
+
   belongs_to :responsible_person, inverse_of: :address_logs
+
+  scope :newest_first, -> { order(end_date: :desc) }
 
   validates :line_1, presence: true
   validates :city, presence: true
@@ -13,6 +17,10 @@ class ResponsiblePersonAddressLog < ApplicationRecord
 
   def to_s
     [line_1, line_2, city, county, postal_code].select(&:present?).join(", ")
+  end
+
+  def address_lines
+    ADDRESS_FIELDS.map { |field| public_send(field) }.select(&:present?)
   end
 
 private

--- a/cosmetics-web/app/views/notifications/_responsible_person_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_responsible_person_details.html.erb
@@ -13,5 +13,15 @@
         html: sanitize(responsible_person.address_lines.join("<br>"))
       },
     },
-  ]
+  ] +
+    (can_view_responsible_person_address_history? ? responsible_person.address_logs.newest_first.map do |address|
+      {
+        key: {
+          text: "Previous address (#{display_date(address.start_date)} &mdash; #{display_date(address.end_date)})".html_safe
+        },
+        value: {
+          html: sanitize(address.address_lines.join("<br>"))
+        },
+      }
+    end : [])
 ) %>

--- a/cosmetics-web/spec/factories/responsible_person.rb
+++ b/cosmetics-web/spec/factories/responsible_person.rb
@@ -13,6 +13,24 @@ FactoryBot.define do
       end
     end
 
+    trait :with_a_previous_address do
+      after(:create) do |responsible_person|
+        create(:responsible_person_address_log, responsible_person:)
+        responsible_person.reload
+      end
+    end
+
+    trait :with_previous_addresses do
+      after(:create) do |responsible_person|
+        build_list(:responsible_person_address_log, 2, responsible_person:) do |record, i|
+          record.start_date = (i + 1).days.ago.beginning_of_day
+          record.end_date = i.days.ago.end_of_day
+          record.save!
+        end
+        responsible_person.reload
+      end
+    end
+
     factory :business_responsible_person do
       account_type { :business }
     end

--- a/cosmetics-web/spec/factories/responsible_person_address_log.rb
+++ b/cosmetics-web/spec/factories/responsible_person_address_log.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :responsible_person_address_log do
     responsible_person
-    line_1 { "FooBar Building" }
-    line_2 { "33 Fake Street" }
-    city { "Gotham" }
-    county { "Greater Manchester" }
-    postal_code { "NN17 1PB" }
+    line_1 { Faker::Address.street_name }
+    line_2 { Faker::Address.street_address }
+    city { Faker::Address.city }
+    county { Faker::Address.state }
+    postal_code { Faker::Address.postcode }
     start_date { "2021-10-08 17:11:23" }
     end_date { "2021-11-03 13:16:38" }
   end

--- a/cosmetics-web/spec/models/search_user_spec.rb
+++ b/cosmetics-web/spec/models/search_user_spec.rb
@@ -112,4 +112,31 @@ RSpec.describe SearchUser, type: :model do
       expect(user).to be_can_view_nanomaterial_review_period_end_date
     end
   end
+
+  describe "#can_view_responsible_person_address_history?" do
+    it "is false for OPSS General users" do
+      user.role = :opss_general
+      expect(user).not_to be_can_view_responsible_person_address_history
+    end
+
+    it "is false for OPSS Enforcement users" do
+      user.role = :opss_enforcement
+      expect(user).not_to be_can_view_responsible_person_address_history
+    end
+
+    it "is true for Trading Standards users" do
+      user.role = :trading_standards
+      expect(user).to be_can_view_responsible_person_address_history
+    end
+
+    it "is false for Poison Centre users" do
+      user.role = :poison_centre
+      expect(user).not_to be_can_view_responsible_person_address_history
+    end
+
+    it "is false for OPSS Science users" do
+      user.role = :opss_science
+      expect(user).not_to be_can_view_responsible_person_address_history
+    end
+  end
 end

--- a/cosmetics-web/spec/rails_helper.rb
+++ b/cosmetics-web/spec/rails_helper.rb
@@ -27,6 +27,9 @@ unless SimpleCov.running
   SimpleCov.start "rails"
 end
 
+require "faker"
+Faker::Config.locale = "en-GB"
+
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production

--- a/cosmetics-web/spec/requests/poison_centre_page_spec.rb
+++ b/cosmetics-web/spec/requests/poison_centre_page_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Poison centre page", type: :request do
   include RSpecHtmlMatchers
 
-  let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+  let(:responsible_person) { create(:responsible_person, :with_a_contact_person, :with_previous_addresses) }
   let(:notification_exact) { create(:draft_notification, responsible_person:) }
   let(:params_exact) do
     {
@@ -38,7 +38,7 @@ RSpec.describe "Poison centre page", type: :request do
         sign_in_as_poison_centre_user
       end
 
-      it "displays the cosmetics product name " do
+      it "displays the cosmetics product name" do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to include(notification_exact.product_name)
       end
@@ -75,6 +75,17 @@ RSpec.describe "Poison centre page", type: :request do
         expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
       end
 
+      it "displays the Responsible Person's current address" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.address_line_1))
+      end
+
+      it "does not display the Responsible Person's previous address(es)" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.first.line_1))
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.second.line_1))
+      end
+
       it "displays the Contact Person" do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to have_tag("h2", text: "Contact person")
@@ -87,7 +98,7 @@ RSpec.describe "Poison centre page", type: :request do
         sign_in_as_opss_general_user
       end
 
-      it "displays the cosmetics product name " do
+      it "displays the cosmetics product name" do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to include(notification_exact.product_name)
       end
@@ -122,6 +133,17 @@ RSpec.describe "Poison centre page", type: :request do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to have_tag("h2", text: "Responsible Person")
         expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
+      end
+
+      it "displays the Responsible Person's current address" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.address_line_1))
+      end
+
+      it "does not display the Responsible Person's previous address(es)" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.first.line_1))
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.second.line_1))
       end
 
       it "displays the Contact Person" do
@@ -172,6 +194,17 @@ RSpec.describe "Poison centre page", type: :request do
         expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
       end
 
+      it "displays the Responsible Person's current address" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.address_line_1))
+      end
+
+      it "does not display the Responsible Person's previous address(es)" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.first.line_1))
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.second.line_1))
+      end
+
       it "displays the Contact Person" do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to have_tag("h2", text: "Contact person")
@@ -184,7 +217,7 @@ RSpec.describe "Poison centre page", type: :request do
         sign_in_as_opss_science_user
       end
 
-      it "displays the cosmetics product name " do
+      it "displays the cosmetics product name" do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to include(notification_exact.product_name)
       end
@@ -219,6 +252,17 @@ RSpec.describe "Poison centre page", type: :request do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to have_tag("h2", text: "Responsible Person")
         expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
+      end
+
+      it "displays the Responsible Person's current address" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.address_line_1))
+      end
+
+      it "does not display the Responsible Person's previous address(es)" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.first.line_1))
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.second.line_1))
       end
 
       it "displays the Contact Person" do
@@ -268,6 +312,16 @@ RSpec.describe "Poison centre page", type: :request do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to have_tag("h2", text: "Responsible Person")
         expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
+      end
+
+      it "displays the Responsible Person's current address" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.address_line_1))
+      end
+
+      it "displays the Responsible Person's previous address(es) in newest first order" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to match(/#{responsible_person.address_logs.first.line_1}.*#{responsible_person.address_logs.second.line_1}/m)
       end
 
       it "displays the Contact Person" do


### PR DESCRIPTION
JIRA link: https://regulatorydelivery.atlassian.net/browse/COSBETA-1317

## Description

Displays the address history for a Responsible Person on notification pages, only for MSA users.

## Review apps

https://cosmetics-pr-2780-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2780-search-web.london.cloudapps.digital/
