### PR TITLE
Create new user roles for search service

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@
 
 ## Guides
 
+* [Glossary](cosmetics-web/docs/glossary.md)
 * [Review apps](cosmetics-web/docs/REVIEW_APPS.md)
 * [Opensearch](cosmetics-web/docs/Opensearch.md)
+* [Frame formulations](cosmetics-web/docs/frame_formulations.md)
 * [User Roles](cosmetics-web/docs/ROLES.md)
 
 ## Inviting search users
 
 1. SSH and run rails console: `app/bin/tll bin/rails c`.
 2. Run `InviteSearchUser.call name: 'Joe Doe', email: 'email@example.org', role: :poison_centre`.
-3. Role could be `poison_centre`, `msa` or `opss_science`.
+3. Role can be `poison_centre`, `opss_general`, `opss_enforcement`, `opss_science` or `trading_standards`.
 
 ## Entity Relationship Diagram
 

--- a/cosmetics-web/app/controllers/declaration_controller.rb
+++ b/cosmetics-web/app/controllers/declaration_controller.rb
@@ -16,7 +16,7 @@ private
   def show_declaration
     if current_user&.poison_centre_user?
       render "poison_centre_declaration"
-    elsif current_user&.msa_user? || current_user&.opss_science_user?
+    elsif current_user&.opss_user? || current_user&.trading_standards_user?
       render "msa_user_declaration"
     else
       render "business_declaration"

--- a/cosmetics-web/app/models/concerns/privileges/abstract_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/abstract_concern.rb
@@ -29,11 +29,23 @@ module Privileges
       false
     end
 
-    def msa_user?
+    def opss_user?
+      false
+    end
+
+    def opss_general_user?
+      false
+    end
+
+    def opss_enforcement_user?
       false
     end
 
     def opss_science_user?
+      false
+    end
+
+    def trading_standards_user?
       false
     end
   end

--- a/cosmetics-web/app/models/concerns/privileges/search_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/search_concern.rb
@@ -3,7 +3,7 @@ module Privileges
     include AbstractConcern
 
     def can_view_product_ingredients?
-      !msa_user?
+      poison_centre_user? || opss_enforcement_user? || opss_science_user?
     end
 
     def can_view_ingredients_list?
@@ -15,19 +15,31 @@ module Privileges
     end
 
     def can_view_nanomaterial_review_period_end_date?
-      msa_user? || opss_science_user?
+      opss_user? || trading_standards_user?
     end
 
     def poison_centre_user?
       poison_centre?
     end
 
-    def msa_user?
-      msa?
+    def opss_user?
+      opss_general? || opss_enforcement? || opss_science? || msa? # Remove once all MSA users have been migrated
+    end
+
+    def opss_general_user?
+      opss_general? || msa? # Remove once all MSA users have been migrated
+    end
+
+    def opss_enforcement_user?
+      opss_enforcement?
     end
 
     def opss_science_user?
       opss_science?
+    end
+
+    def trading_standards_user?
+      trading_standards?
     end
   end
 end

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -17,8 +17,11 @@ class SearchUser < User
 
   enum role: {
     poison_centre: "poison_centre",
-    msa: "market_surveilance_authority",
+    msa: "market_surveilance_authority", # Remove once all MSA users have been migrated
+    opss_general: "opss_general",
+    opss_enforcement: "opss_enforcement",
     opss_science: "opss_science",
+    trading_standards: "trading_standards",
   }
 
   validates :mobile_number,

--- a/cosmetics-web/app/policies/poison_centre_notification_policy.rb
+++ b/cosmetics-web/app/policies/poison_centre_notification_policy.rb
@@ -1,7 +1,7 @@
 class PoisonCentreNotificationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.all if user.poison_centre_user? || user.msa_user?
+      scope.all if user.poison_centre_user? || user.opss_user? || user.trading_standards_user?
     end
   end
 
@@ -10,6 +10,6 @@ class PoisonCentreNotificationPolicy < ApplicationPolicy
   end
 
   def show?
-    user.poison_centre_user? || user.msa_user? || user.opss_science_user?
+    user.poison_centre_user? || user.opss_user? || user.trading_standards_user?
   end
 end

--- a/cosmetics-web/app/views/errors/wrong_service_for_search_user.html.erb
+++ b/cosmetics-web/app/views/errors/wrong_service_for_search_user.html.erb
@@ -2,7 +2,10 @@
   title = "You cannot submit notifications with this account"
   role_wording = case user_role
                  when "poison_centre" then "the National Poisons Information Service"
-                 when "msa" then "a market surveillance authority"
+                 when "msa" then "a market surveillance authority" # Remove once all MSA users have been migrated
+                 when "opss_general" then "OPSS"
+                 when "opss_enforcement" then "OPSS enforcement"
+                 when "trading_standards" then "Trading Standards"
                  end
 
 %>
@@ -18,6 +21,3 @@
     <p>To search product notifications, you need to sign in to the <%= link_to "cosmetic product information service", search_domain_url, class: "govuk-link govuk-link--no-visited-state" %>.</p>
   </div>
 </div>
-
-
-

--- a/cosmetics-web/app/views/notifications/_component_details.html.erb
+++ b/cosmetics-web/app/views/notifications/_component_details.html.erb
@@ -57,7 +57,7 @@
         value: { text: get_notification_type_name(component.notification_type) },
       }
     end,
-    if can_view_product_ingredients?
+    if can_view_product_ingredients? && component.predefined?
       {
         key: { text: "Frame formulation" },
         value: { text: get_frame_formulation_name(component.frame_formulation) },

--- a/cosmetics-web/db/migrate/20230208115825_add_opss_general_to_user_roles.rb
+++ b/cosmetics-web/db/migrate/20230208115825_add_opss_general_to_user_roles.rb
@@ -1,0 +1,9 @@
+class AddOpssGeneralToUserRoles < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      ActiveRecord::Base.connection.execute <<-SQL
+        ALTER TYPE user_roles ADD VALUE 'opss_general'
+      SQL
+    end
+  end
+end

--- a/cosmetics-web/db/migrate/20230208115835_add_opss_enforcement_to_user_roles.rb
+++ b/cosmetics-web/db/migrate/20230208115835_add_opss_enforcement_to_user_roles.rb
@@ -1,0 +1,9 @@
+class AddOpssEnforcementToUserRoles < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      ActiveRecord::Base.connection.execute <<-SQL
+        ALTER TYPE user_roles ADD VALUE 'opss_enforcement'
+      SQL
+    end
+  end
+end

--- a/cosmetics-web/db/migrate/20230208115847_add_trading_standards_to_user_roles.rb
+++ b/cosmetics-web/db/migrate/20230208115847_add_trading_standards_to_user_roles.rb
@@ -1,0 +1,9 @@
+class AddTradingStandardsToUserRoles < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      ActiveRecord::Base.connection.execute <<-SQL
+        ALTER TYPE user_roles ADD VALUE 'trading_standards'
+      SQL
+    end
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_113757) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_08_115847) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_113757) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "ingredient_range_concentration", ["less_than_01_percent", "greater_than_01_less_than_1_percent", "greater_than_1_less_than_5_percent", "greater_than_5_less_than_10_percent", "greater_than_10_less_than_25_percent", "greater_than_25_less_than_50_percent", "greater_than_50_less_than_75_percent", "greater_than_75_less_than_100_percent"]
-  create_enum "user_roles", ["poison_centre", "market_surveilance_authority", "opss_science"]
+  create_enum "user_roles", ["poison_centre", "market_surveilance_authority", "opss_science", "opss_general", "opss_enforcement", "trading_standards"]
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/cosmetics-web/docs/glossary.md
+++ b/cosmetics-web/docs/glossary.md
@@ -1,0 +1,43 @@
+# Glossary
+
+This is a glossary of terms used in this app.
+
+## CMR
+
+Carcinogenic, mutagenic or reprotoxic substances; these are ingredients that can cause cancers, genetic mutations
+or reproductive damage.
+
+## Component
+
+Another name for a cosmetic product.
+
+## Frame formulation
+
+A predefined group of ingredients that are commonly used in many cosmetic preparations. See [frame formulations](frame_formulations.md)
+for more detailed information on how they are used in this app.
+
+## MSA
+
+A market surveillance authority, for example OPSS or a local Trading Standards office, that ensures products are safe.
+
+## Nanomaterial
+
+A manufactured material between 1 and 100 nm in size.
+
+## NPIS
+
+National Poisons Information Service, part of the UK Health Security Agency. Provides advice and assistance to the NHS
+on cases of poisoning.
+
+## OPSS
+
+Office for Product Safety and Standards, part of the Department for Business & Trade. Responsible for the enforcement of
+product safety standards.
+
+## Poison centre
+
+See NPIS.
+
+## Responsible Person
+
+A named person or company (generally the manufacturer or distributor) that is responsible for the product notification.

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do
     end
   end
 
-  describe "When signed in as an MSA user" do
+  describe "When signed in as an OPSS General user" do
     before do
-      sign_in_as_msa_user
+      sign_in_as_opss_general_user
     end
 
     describe "GET #show" do
@@ -92,7 +92,163 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do
           expect(response.body).not_to match(/Minimum pH value/)
         end
 
-        it "does not render Maximum pH" do
+        it "does not render maximum pH" do
+          expect(response.body).not_to match(/Maximum pH value/)
+        end
+
+        it "does not render still on the market" do
+          expect(response.body).not_to match(/Still on the market/)
+        end
+
+        it "renders nanomaterials" do
+          expect(response.body).to match(/Nanomaterials/)
+        end
+
+        it "renders physical form" do
+          expect(response.body).to match(/Physical form/)
+        end
+      end
+
+      describe "Notification with CMRS substances" do
+        let(:cmr) { create(:cmr) }
+        let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions, cmrs: [cmr]) }
+        let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+        let(:notification) { create(:notification, :registered, :ph_values, components: [component], responsible_person:) }
+
+        render_views
+
+        it "renders CMR substances" do
+          expect(response.body).to match(/Contains CMR substances/)
+        end
+      end
+    end
+  end
+
+  describe "When signed in as an OPSS Enforcement user" do
+    before do
+      sign_in_as_opss_enforcement_user
+    end
+
+    describe "GET #show" do
+      let(:notification) { rp_1_notifications.first }
+
+      before { get :show, params: { reference_number: notification.reference_number } }
+
+      it "renders the show template" do
+        expect(response).to render_template("notifications/show_msa")
+      end
+
+      describe "displayed information" do
+        let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions) }
+        let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+        let(:notification) { create(:notification, :registered, :ph_values, components: [component], responsible_person:) }
+
+        render_views
+
+        it "renders contact person overview" do
+          expect(response.body).to match(/Contact person/)
+        end
+
+        it "renders component formulations" do
+          expect(response.body).to match(/Formulation given as/)
+          expect(response.body).to match(/Frame formulation/)
+        end
+
+        it "does not render acute poisoning info" do
+          expect(response.body).not_to match(/Acute poisoning information/)
+        end
+
+        it "does not render poisonous ingredients" do
+          expect(response.body).not_to match(/Contains poisonous ingredients/)
+        end
+
+        it "does not render trigger questions" do
+          expect(response.body).not_to match(/<tr class="govuk-table__row trigger-question">/)
+        end
+
+        it "renders minimum pH" do
+          expect(response.body).to match(/Minimum pH value/)
+        end
+
+        it "renders maximum pH" do
+          expect(response.body).to match(/Maximum pH value/)
+        end
+
+        it "does not render still on the market" do
+          expect(response.body).not_to match(/Still on the market/)
+        end
+
+        it "renders nanomaterials" do
+          expect(response.body).to match(/Nanomaterials/)
+        end
+
+        it "renders physical form" do
+          expect(response.body).to match(/Physical form/)
+        end
+      end
+
+      describe "Notification with CMRS substances" do
+        let(:cmr) { create(:cmr) }
+        let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions, cmrs: [cmr]) }
+        let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+        let(:notification) { create(:notification, :registered, :ph_values, components: [component], responsible_person:) }
+
+        render_views
+
+        it "renders CMR substances" do
+          expect(response.body).to match(/Contains CMR substances/)
+        end
+      end
+    end
+  end
+
+  describe "When signed in as an Trading Standards user" do
+    before do
+      sign_in_as_trading_standards_user
+    end
+
+    describe "GET #show" do
+      let(:notification) { rp_1_notifications.first }
+
+      before { get :show, params: { reference_number: notification.reference_number } }
+
+      it "renders the show template" do
+        expect(response).to render_template("notifications/show_msa")
+      end
+
+      describe "displayed information" do
+        let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions) }
+        let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+        let(:notification) { create(:notification, :registered, :ph_values, components: [component], responsible_person:) }
+
+        render_views
+
+        it "renders contact person overview" do
+          expect(response.body).to match(/Contact person/)
+        end
+
+        it "does not render component formulations" do
+          expect(response.body).not_to match(/Formulation given as/)
+          expect(response.body).not_to match(/Frame formulation/)
+        end
+
+        it "does not render acute poisoning info" do
+          expect(response.body).not_to match(/Acute poisoning information/)
+        end
+
+        it "does not render poisonous ingredients" do
+          expect(response.body).not_to match(/Contains poisonous ingredients/)
+        end
+
+        it "does not render trigger questions" do
+          expect(response.body).not_to match(/<tr class="govuk-table__row trigger-question">/)
+        end
+
+        it "does not render minimum pH" do
+          expect(response.body).not_to match(/Minimum pH value/)
+        end
+
+        it "does not render maximum pH" do
           expect(response.body).not_to match(/Maximum pH value/)
         end
 

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_search_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_search_controller_spec.rb
@@ -59,9 +59,35 @@ RSpec.describe PoisonCentres::NotificationsSearchController, type: :controller d
     end
   end
 
-  describe "When signed in as an MSA user" do
+  describe "When signed in as an OPSS General user" do
     before do
-      sign_in_as_msa_user
+      sign_in_as_opss_general_user
+    end
+
+    describe "GET #show" do
+      it "renders the show template" do
+        get :show
+        expect(response).to render_template("notifications_search/show")
+      end
+    end
+  end
+
+  describe "When signed in as an OPSS Enforcement user" do
+    before do
+      sign_in_as_opss_enforcement_user
+    end
+
+    describe "GET #show" do
+      it "renders the show template" do
+        get :show
+        expect(response).to render_template("notifications_search/show")
+      end
+    end
+  end
+
+  describe "When signed in as a Trading Standards user" do
+    before do
+      sign_in_as_trading_standards_user
     end
 
     describe "GET #show" do

--- a/cosmetics-web/spec/controllers/search/dashboard_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/search/dashboard_controller_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe Search::DashboardController, type: :controller do
     end
 
     describe "GET #show" do
-      it "redirects to the Poison Centre/MSA notifications index page" do
+      it "redirects to the correct notifications index page" do
         get :show
         expect(response).to redirect_to(poison_centre_notifications_search_path)
       end
     end
   end
 
-  describe "When signed in as a MSA user" do
+  describe "When signed in as an OPSS General user" do
     before do
-      sign_in_as_msa_user
+      sign_in_as_opss_general_user
     end
 
     after do
@@ -28,7 +28,41 @@ RSpec.describe Search::DashboardController, type: :controller do
     end
 
     describe "GET #show" do
-      it "redirects to the Poison Centre/MSA notifications index page" do
+      it "redirects to the correct notifications index page" do
+        get :show
+        expect(response).to redirect_to(poison_centre_notifications_search_path)
+      end
+    end
+  end
+
+  describe "When signed in as an OPSS Enforcement user" do
+    before do
+      sign_in_as_opss_enforcement_user
+    end
+
+    after do
+      sign_out(:search_user)
+    end
+
+    describe "GET #show" do
+      it "redirects to the correct notifications index page" do
+        get :show
+        expect(response).to redirect_to(poison_centre_notifications_search_path)
+      end
+    end
+  end
+
+  describe "When signed in as a Trading Standards user" do
+    before do
+      sign_in_as_trading_standards_user
+    end
+
+    after do
+      sign_out(:search_user)
+    end
+
+    describe "GET #show" do
+      it "redirects to the correct notifications index page" do
         get :show
         expect(response).to redirect_to(poison_centre_notifications_search_path)
       end

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -92,12 +92,20 @@ FactoryBot.define do
         role { :poison_centre }
       end
 
-      factory :msa_user do
-        role { :msa }
+      factory :opss_general_user do
+        role { :opss_general }
+      end
+
+      factory :opss_enforcement_user do
+        role { :opss_enforcement }
       end
 
       factory :opss_science_user do
         role { :opss_science }
+      end
+
+      factory :trading_standards_user do
+        role { :trading_standards }
       end
 
       after :create do |user, options|

--- a/cosmetics-web/spec/features/search/notification_search_result_nanomaterial_details_spec.rb
+++ b/cosmetics-web/spec/features/search/notification_search_result_nanomaterial_details_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Search result nanomaterial details", :with_stubbed_notify, :with_
     sign_in user
   end
 
-  context "with a opss science user" do
+  context "with an opss science user" do
     let(:user) { create(:opss_science_user, :with_sms_secondary_authentication) }
 
     scenario "user can see the nanomaterial details with review period section and link to nanomaterial pdf file" do
@@ -45,8 +45,40 @@ RSpec.feature "Search result nanomaterial details", :with_stubbed_notify, :with_
     end
   end
 
-  context "with a market surveillance authority user" do
-    let(:user) { create(:msa_user, :with_sms_secondary_authentication) }
+  context "with an opss general user" do
+    let(:user) { create(:opss_general_user, :with_sms_secondary_authentication) }
+
+    scenario "user can see the nanomaterial details with review period section but without link to nanomaterial pdf file" do
+      expect(page).to have_h1("Search cosmetic products")
+      click_link("Cream")
+
+      expect(page).to have_h1("Cream")
+      expect(page).to have_summary_item(key: "Nanomaterials", value: "#{nanomaterial_notification.ukn} - Zinc oxide")
+      expect(page).to have_summary_item(
+        key: "Nanomaterials review period end date",
+        value: "#{nanomaterial_notification.ukn} - Zinc oxide - 1 July 2022",
+      )
+    end
+  end
+
+  context "with an opss enforcement user" do
+    let(:user) { create(:opss_enforcement_user, :with_sms_secondary_authentication) }
+
+    scenario "user can see the nanomaterial details with review period section but without link to nanomaterial pdf file" do
+      expect(page).to have_h1("Search cosmetic products")
+      click_link("Cream")
+
+      expect(page).to have_h1("Cream")
+      expect(page).to have_summary_item(key: "Nanomaterials", value: "#{nanomaterial_notification.ukn} - Zinc oxide")
+      expect(page).to have_summary_item(
+        key: "Nanomaterials review period end date",
+        value: "#{nanomaterial_notification.ukn} - Zinc oxide - 1 July 2022",
+      )
+    end
+  end
+
+  context "with a trading standards user" do
+    let(:user) { create(:trading_standards_user, :with_sms_secondary_authentication) }
 
     scenario "user can see the nanomaterial details with review period section but without link to nanomaterial pdf file" do
       expect(page).to have_h1("Search cosmetic products")

--- a/cosmetics-web/spec/login_helpers.rb
+++ b/cosmetics-web/spec/login_helpers.rb
@@ -8,12 +8,22 @@ module LoginHelpers
     sign_in(user)
   end
 
-  def sign_in_as_msa_user(user: create(:msa_user))
+  def sign_in_as_opss_general_user(user: create(:opss_general_user))
+    configure_requests_for_search_domain
+    sign_in(user)
+  end
+
+  def sign_in_as_opss_enforcement_user(user: create(:opss_enforcement_user))
     configure_requests_for_search_domain
     sign_in(user)
   end
 
   def sign_in_as_opss_science_user(user: create(:opss_science_user))
+    configure_requests_for_search_domain
+    sign_in(user)
+  end
+
+  def sign_in_as_trading_standards_user(user: create(:trading_standards_user))
     configure_requests_for_search_domain
     sign_in(user)
   end

--- a/cosmetics-web/spec/models/search_user_spec.rb
+++ b/cosmetics-web/spec/models/search_user_spec.rb
@@ -6,8 +6,18 @@ RSpec.describe SearchUser, type: :model do
   include_examples "common user tests"
 
   describe "#can_view_product_ingredients?" do
-    it "is false for MSA users" do
-      user.role = :msa
+    it "is false for OPSS General users" do
+      user.role = :opss_general
+      expect(user).not_to be_can_view_product_ingredients
+    end
+
+    it "is true for OPSS Enforcement users" do
+      user.role = :opss_enforcement
+      expect(user).to be_can_view_product_ingredients
+    end
+
+    it "is false for Trading Standards users" do
+      user.role = :trading_standards
       expect(user).not_to be_can_view_product_ingredients
     end
 
@@ -23,8 +33,18 @@ RSpec.describe SearchUser, type: :model do
   end
 
   describe "#can_view_ingredients_list?" do
-    it "is false for MSA users" do
-      user.role = :msa
+    it "is false for OPSS General users" do
+      user.role = :opss_general
+      expect(user).not_to be_can_view_ingredients_list
+    end
+
+    it "is false for OPSS Enforcement users" do
+      user.role = :opss_enforcement
+      expect(user).not_to be_can_view_ingredients_list
+    end
+
+    it "is false for Trading Standards users" do
+      user.role = :trading_standards
       expect(user).not_to be_can_view_ingredients_list
     end
 
@@ -40,8 +60,18 @@ RSpec.describe SearchUser, type: :model do
   end
 
   describe "#can_view_nanomaterial_notification_files?" do
-    it "is false for MSA users" do
-      user.role = :msa
+    it "is false for OPSS General users" do
+      user.role = :opss_general
+      expect(user).not_to be_can_view_nanomaterial_notification_files
+    end
+
+    it "is false for OPSS Enforcement users" do
+      user.role = :opss_enforcement
+      expect(user).not_to be_can_view_nanomaterial_notification_files
+    end
+
+    it "is false for Trading Standards users" do
+      user.role = :trading_standards
       expect(user).not_to be_can_view_nanomaterial_notification_files
     end
 
@@ -57,8 +87,18 @@ RSpec.describe SearchUser, type: :model do
   end
 
   describe "#can_view_nanomaterial_review_period_end_date?" do
-    it "is true for MSA users" do
-      user.role = :msa
+    it "is true for OPSS General users" do
+      user.role = :opss_general
+      expect(user).to be_can_view_nanomaterial_review_period_end_date
+    end
+
+    it "is true for OPSS Enforcement users" do
+      user.role = :opss_enforcement
+      expect(user).to be_can_view_nanomaterial_review_period_end_date
+    end
+
+    it "is true for Trading Standards users" do
+      user.role = :trading_standards
       expect(user).to be_can_view_nanomaterial_review_period_end_date
     end
 

--- a/cosmetics-web/spec/policies/poison_centre_notification_policy_spec.rb
+++ b/cosmetics-web/spec/policies/poison_centre_notification_policy_spec.rb
@@ -18,8 +18,34 @@ RSpec.describe PoisonCentreNotificationPolicy, type: :policy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context "with a msa user" do
-    let(:user) { build_stubbed(:msa_user) }
+  context "with an OPSS General user" do
+    let(:user) { build_stubbed(:opss_general_user) }
+
+    it { is_expected.to permit(:index) }
+    it { is_expected.to permit(:show) }
+
+    it { is_expected.not_to permit(:create)  }
+    it { is_expected.not_to permit(:new)     }
+    it { is_expected.not_to permit(:update)  }
+    it { is_expected.not_to permit(:edit)    }
+    it { is_expected.not_to permit(:destroy) }
+  end
+
+  context "with an OPSS Enforcement user" do
+    let(:user) { build_stubbed(:opss_enforcement_user) }
+
+    it { is_expected.to permit(:index) }
+    it { is_expected.to permit(:show) }
+
+    it { is_expected.not_to permit(:create)  }
+    it { is_expected.not_to permit(:new)     }
+    it { is_expected.not_to permit(:update)  }
+    it { is_expected.not_to permit(:edit)    }
+    it { is_expected.not_to permit(:destroy) }
+  end
+
+  context "with a Trading Standards user" do
+    let(:user) { build_stubbed(:trading_standards_user) }
 
     it { is_expected.to permit(:index) }
     it { is_expected.to permit(:show) }
@@ -44,7 +70,7 @@ RSpec.describe PoisonCentreNotificationPolicy, type: :policy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context "with neither a poison centre/msa/OPSS science user" do
+  context "with neither a poison centre/OPSS General/OPSS Enforcement/OPSS Science/Trading Standards user" do
     let(:user) { build_stubbed(:search_user) }
 
     it { is_expected.not_to permit(:index) }

--- a/cosmetics-web/spec/requests/declaration_requests_spec.rb
+++ b/cosmetics-web/spec/requests/declaration_requests_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe "User declarations", :with_stubbed_antivirus, type: :request do
     end
   end
 
-  context "when signed in as a a market surveilance authority user" do
-    let(:user) { create(:msa_user, has_accepted_declaration: false) }
+  context "when signed in as an OPSS General user" do
+    let(:user) { create(:opss_general_user, has_accepted_declaration: false) }
 
     before do
-      sign_in_as_msa_user(user:)
+      sign_in_as_opss_general_user(user:)
     end
 
     after do
@@ -76,7 +76,81 @@ RSpec.describe "User declarations", :with_stubbed_antivirus, type: :request do
     end
   end
 
-  context "when signed in as a a poison centre user" do
+  context "when signed in as an OPSS Enforcement user" do
+    let(:user) { create(:opss_enforcement_user, has_accepted_declaration: false) }
+
+    before do
+      sign_in_as_opss_enforcement_user(user:)
+    end
+
+    after do
+      sign_out(:search_user)
+    end
+
+    context "when viewing the declaration page" do
+      before do
+        get declaration_path
+      end
+
+      it "renders the page" do
+        expect(response.status).to be(200)
+        expect(response).to render_template("declaration/msa_user_declaration")
+      end
+    end
+
+    context "when submitting the declaration page" do
+      before do
+        post accept_declaration_path
+      end
+
+      it "redirects to the Search homepage" do
+        expect(response).to redirect_to(search_root_path)
+      end
+
+      it "updates the user attributes" do
+        expect(user.has_accepted_declaration?).to be true
+      end
+    end
+  end
+
+  context "when signed in as a Trading Standards user" do
+    let(:user) { create(:trading_standards_user, has_accepted_declaration: false) }
+
+    before do
+      sign_in_as_trading_standards_user(user:)
+    end
+
+    after do
+      sign_out(:search_user)
+    end
+
+    context "when viewing the declaration page" do
+      before do
+        get declaration_path
+      end
+
+      it "renders the page" do
+        expect(response.status).to be(200)
+        expect(response).to render_template("declaration/msa_user_declaration")
+      end
+    end
+
+    context "when submitting the declaration page" do
+      before do
+        post accept_declaration_path
+      end
+
+      it "redirects to the Search homepage" do
+        expect(response).to redirect_to(search_root_path)
+      end
+
+      it "updates the user attributes" do
+        expect(user.has_accepted_declaration?).to be true
+      end
+    end
+  end
+
+  context "when signed in as a poison centre user" do
     let(:user) { create(:poison_centre_user, has_accepted_declaration: false) }
 
     before do
@@ -113,7 +187,7 @@ RSpec.describe "User declarations", :with_stubbed_antivirus, type: :request do
     end
   end
 
-  context "when signed in as a a OPSS Science team user" do
+  context "when signed in as an OPSS Science user" do
     let(:user) { create(:opss_science_user, has_accepted_declaration: false) }
 
     before do

--- a/cosmetics-web/spec/requests/ingredient_list_spec.rb
+++ b/cosmetics-web/spec/requests/ingredient_list_spec.rb
@@ -202,9 +202,51 @@ RSpec.describe "Ingredient list", type: :request do
     end
   end
 
-  context "when signed in as an MSA user" do
+  context "when signed in as an OPSS General user" do
     before do
-      sign_in_as_msa_user
+      sign_in_as_opss_general_user
+    end
+
+    describe "GET #index" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_path
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_persons" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_person_notifications" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient2.component.responsible_person.id, ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+  end
+
+  context "when signed in as an OPSS Enforcement user" do
+    before do
+      sign_in_as_opss_enforcement_user
     end
 
     describe "GET #index" do
@@ -247,6 +289,48 @@ RSpec.describe "Ingredient list", type: :request do
   context "when signed in as an OPSS Science user" do
     before do
       sign_in_as_opss_science_user
+    end
+
+    describe "GET #index" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_path
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_persons" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_person_notifications" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient2.component.responsible_person.id, ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+  end
+
+  context "when signed in as a Trading Standards user" do
+    before do
+      sign_in_as_trading_standards_user
     end
 
     describe "GET #index" do

--- a/cosmetics-web/spec/requests/poison_centre_page_spec.rb
+++ b/cosmetics-web/spec/requests/poison_centre_page_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe "Poison centre page", type: :request do
       end
     end
 
-    context "with a Market Surveillance Authority user" do
+    context "with an OPSS General user" do
       before do
-        sign_in_as_msa_user
+        sign_in_as_opss_general_user
       end
 
       it "displays the cosmetics product name " do
@@ -131,7 +131,55 @@ RSpec.describe "Poison centre page", type: :request do
       end
     end
 
-    context "with a OPSS Science user" do
+    context "with an OPSS Enforcement user" do
+      before do
+        sign_in_as_opss_enforcement_user
+      end
+
+      it "displays the cosmetics product name " do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to include(notification_exact.product_name)
+      end
+
+      it "displays the product ingredients" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to include("Foo Ingredient")
+      end
+
+      it "does not display the product frame formulations for a product with only exact or range ingredients" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to include("Frame formulations")
+      end
+
+      it "does not display the product frame formulations for a product with only frame formulations" do
+        get poison_centre_notification_path(params_frame_formulation)
+        expect(response.body).not_to include("Frame formulations")
+      end
+
+      it "displays the product CMRs" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: /Foo CMR/)
+      end
+
+      it "displays the product Nanomaterials" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: /Foo Nanomaterial/)
+      end
+
+      it "displays the Responsible Person" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("h2", text: "Responsible Person")
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
+      end
+
+      it "displays the Contact Person" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("h2", text: "Contact person")
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.contact_persons.first.name))
+      end
+    end
+
+    context "with an OPSS Science user" do
       before do
         sign_in_as_opss_science_user
       end
@@ -165,6 +213,55 @@ RSpec.describe "Poison centre page", type: :request do
       it "displays the product Nanomaterials" do
         get poison_centre_notification_path(params_exact)
         expect(response.body).to have_tag("td", text: /Foo Nanomaterial/)
+      end
+
+      it "displays the Responsible Person" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("h2", text: "Responsible Person")
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
+      end
+
+      it "displays the Contact Person" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("h2", text: "Contact person")
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.contact_persons.first.name))
+      end
+    end
+
+    context "with a Trading Standards user" do
+      before do
+        sign_in_as_trading_standards_user
+      end
+
+      it "displays the cosmetics product name " do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to include(notification_exact.product_name)
+      end
+
+      it "does not display the product ingredients" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to include("Ingredients")
+        expect(response.body).not_to include("Foo Ingredient")
+      end
+
+      it "does not display the product frame formulations for a product with only exact or range ingredients" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to include("Frame formulations")
+      end
+
+      it "does not display the product frame formulations for a product with only frame formulations" do
+        get poison_centre_notification_path(params_frame_formulation)
+        expect(response.body).not_to include("Frame formulations")
+      end
+
+      it "displays the product CMRs" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: /Foo CMR/)
+      end
+
+      it "displays the product Nanomaterials" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: /Foo Nanomaterial/)
       end
 
       it "displays the Responsible Person" do

--- a/cosmetics-web/spec/requests/root_path_spec.rb
+++ b/cosmetics-web/spec/requests/root_path_spec.rb
@@ -131,11 +131,11 @@ RSpec.describe "Root path", :with_stubbed_antivirus, type: :request do
       end
     end
 
-    context "when signed in as a market surveilance authority user" do
-      let(:user) { create(:msa_user) }
+    context "when signed in as an OPSS General user" do
+      let(:user) { create(:opss_general_user) }
 
       before do
-        sign_in_as_msa_user(user:)
+        sign_in_as_opss_general_user(user:)
         get "/"
       end
 
@@ -148,7 +148,24 @@ RSpec.describe "Root path", :with_stubbed_antivirus, type: :request do
       end
     end
 
-    context "when signed in as a OPSS Science user" do
+    context "when signed in as an OPSS Enforcement user" do
+      let(:user) { create(:opss_enforcement_user) }
+
+      before do
+        sign_in_as_opss_enforcement_user(user:)
+        get "/"
+      end
+
+      after do
+        sign_out(:search_user)
+      end
+
+      it "redirects to the notifications page" do
+        expect(response).to redirect_to("/notifications")
+      end
+    end
+
+    context "when signed in as an OPSS Science user" do
       let(:user) { create(:opss_science_user) }
 
       before do
@@ -163,6 +180,23 @@ RSpec.describe "Root path", :with_stubbed_antivirus, type: :request do
       it "redirects to the notifications page" do
         expect(response).to redirect_to("/notifications")
       end
+    end
+  end
+
+  context "when signed in as a Trading Standards user" do
+    let(:user) { create(:trading_standards_user) }
+
+    before do
+      sign_in_as_trading_standards_user(user:)
+      get "/"
+    end
+
+    after do
+      sign_out(:search_user)
+    end
+
+    it "redirects to the notifications page" do
+      expect(response).to redirect_to("/notifications")
     end
   end
 

--- a/cosmetics-web/spec/requests/user_account_page_spec.rb
+++ b/cosmetics-web/spec/requests/user_account_page_spec.rb
@@ -107,11 +107,11 @@ RSpec.describe "User account page", type: :request do
     include_examples "can't download nanomaterials"
   end
 
-  context "with a Search market surveilance authority user" do
-    let(:user) { create(:msa_user) }
+  context "with a Search OPSS General user" do
+    let(:user) { create(:opss_general_user) }
 
     before do
-      sign_in_as_msa_user(user:)
+      sign_in_as_opss_general_user(user:)
       get "/my_account"
     end
 
@@ -120,7 +120,20 @@ RSpec.describe "User account page", type: :request do
     include_examples "can't download nanomaterials"
   end
 
-  context "with a Search OPSS science user" do
+  context "with a Search OPSS Enforcement user" do
+    let(:user) { create(:opss_enforcement_user) }
+
+    before do
+      sign_in_as_opss_enforcement_user(user:)
+      get "/my_account"
+    end
+
+    include_examples "can change name and security"
+    include_examples "can't change email"
+    include_examples "can't download nanomaterials"
+  end
+
+  context "with a Search OPSS Science user" do
     let(:user) { create(:opss_science_user) }
 
     before do
@@ -158,5 +171,18 @@ RSpec.describe "User account page", type: :request do
         with_tag("dd.govuk-summary-list__actions a", text: optional_spaces("Download notified nanomaterials as PDFs"))
       end
     end
+  end
+
+  context "with a Search Trading Standards user" do
+    let(:user) { create(:trading_standards_user) }
+
+    before do
+      sign_in_as_trading_standards_user(user:)
+      get "/my_account"
+    end
+
+    include_examples "can change name and security"
+    include_examples "can't change email"
+    include_examples "can't download nanomaterials"
   end
 end

--- a/cosmetics-web/spec/services/invite_search_user_spec.rb
+++ b/cosmetics-web/spec/services/invite_search_user_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe InviteSearchUser, :with_stubbed_mailer do
     end
 
     it "does not change the user role when the inviter is called for a different role" do
-      user.update_column(:role, inviter.role == "msa" ? "poison_centre" : "msa")
+      user.update_column(:role, inviter.role == "opss_general" ? "poison_centre" : "opss_general")
       expect {
         inviter.call
         user.reload
@@ -72,7 +72,7 @@ RSpec.describe InviteSearchUser, :with_stubbed_mailer do
   end
 
   it "fails when no user name is provided" do
-    expect { described_class.new(email: "user@example.com", role: "msa").call }
+    expect { described_class.new(email: "user@example.com", role: "opss_general").call }
       .to raise_error(Interactor::Failure)
   end
 
@@ -87,7 +87,7 @@ RSpec.describe InviteSearchUser, :with_stubbed_mailer do
   end
 
   context "when an user is provided" do
-    subject(:inviter) { described_class.new(name: "John Doe", role: "msa", user:) }
+    subject(:inviter) { described_class.new(name: "John Doe", role: "opss_general", user:) }
 
     let(:user) do
       create(:search_user, :registration_incomplete, email: "existentuser@example.com")
@@ -98,7 +98,7 @@ RSpec.describe InviteSearchUser, :with_stubbed_mailer do
 
   context "when an email is provided" do
     subject(:inviter) do
-      described_class.new(name: "John Doe", role: "msa", email: "inviteduser@example.com")
+      described_class.new(name: "John Doe", role: "opss_general", email: "inviteduser@example.com")
     end
 
     context "when the provided email belongs to an existing user" do

--- a/cosmetics-web/spec/services/one_off/search_user_bulk_inviter_spec.rb
+++ b/cosmetics-web/spec/services/one_off/search_user_bulk_inviter_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe OneOff::SearchUserBulkInviter, :with_stubbed_mailer do
-  subject(:bulk_inviter) { described_class.new(file, :msa) }
+  subject(:bulk_inviter) { described_class.new(file, :opss_general) }
 
   let(:file) { "spec/fixtures/bulk_inviter/users.csv" }
 


### PR DESCRIPTION
JIRA link: https://regulatorydelivery.atlassian.net/browse/COSBETA-1776

## Description

Creates the following new user roles:

* OPSS General
* OPSS Enforcement
* Trading Standards

Keeps the following roles:

* Poison centre (NPIS)
* OPSS Science

Users with the existing MSA role will be migrated manually to one of the newly-created roles separately.

## Review apps

https://cosmetics-pr-2783-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2783-search-web.london.cloudapps.digital/
