### PR TITLE
Fix Act. Support hash digest class to SHA1

### DIFF
--- a/cosmetics-web/config/application.rb
+++ b/cosmetics-web/config/application.rb
@@ -63,5 +63,8 @@ module Cosmetics
 
     # Avoid file attachment errors with blank params
     config.active_storage.multiple_file_field_include_hidden = false
+
+    # Use SHA1 for key generator to avoid errors when decrypting secrets generated prior to Rails 7 (new default is SHA256)
+    config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
   end
 end


### PR DESCRIPTION
Since Rails 7 automatically uses SHA256 and it raises exceptions when trying to decrypt our current production encrypted data.
