### PR TITLE
Hide frame formulations option when unavailable

### DIFF
--- a/cosmetics-web/app/assets/files/frame_formulations/categories.json
+++ b/cosmetics-web/app/assets/files/frame_formulations/categories.json
@@ -128,10 +128,6 @@
         "makeup_remover_non_foaming_oil_cleanser",
         "other_makeup_remover_products"
       ],
-      "external_intimate_hygiene_products": [
-        "gentle_cleansing_gel",
-        "other_external_intimate_hygiene_products"
-      ],
       "other_skin_cleansing_products": [
         "skin_gel_hydroalcoholic_based",
         "skin_cleansing_cream_lotion_scrub_gel",
@@ -312,11 +308,6 @@
       "other_sun_and_selftanning_products": [
         "other_sun_and_selftanning_products"
       ]
-    },
-    "other_skin_products": {
-      "other_skin_products": [
-        "other_skin_products"
-      ]
     }
   },
   "hair_and_scalp_products": {
@@ -441,9 +432,6 @@
         "hair_shine_wax_or_brilliantine",
         "hair_shine_spray_aerosol",
         "other_hair_sun_protection_products"
-      ],
-      "other_hair_and_scalp_products": [
-        "other_hair_and_scalp_products"
       ]
     }
   },
@@ -453,9 +441,6 @@
         "nail_varnish",
         "nail_white_pencil",
         "other_nail_varnish_nail_makeup"
-      ],
-      "nail_varnish_remover": [
-        "nail_varnish_remover"
       ],
       "nail_varnish_thinner": [
         "nail_varnish_thinner"
@@ -472,27 +457,8 @@
         "nail_conditioner_oil_based",
         "other_nail_care_products"
       ],
-      "nail_hardener": [
-        "nail_hardener"
-      ],
       "other_nail_care_nail_hardener_products": [
         "other_nail_care_nail_hardener_products"
-      ]
-    },
-    "nail_glue_remover_products": {
-      "nail_glue_remover": [
-        "nail_glue_remover"
-      ]
-    },
-    "other_nail_and_cuticle_products": {
-      "cuticle_remover_softener": [
-        "cuticle_remover_softener"
-      ],
-      "nail_sculpting_products": [
-        "nail_sculpting_products"
-      ],
-      "other_nail_and_cuticle_products": [
-        "other_nail_and_cuticle_products"
       ]
     }
   },
@@ -501,12 +467,6 @@
       "toothpaste": [
         "toothpaste",
         "other_toothpaste_products"
-      ],
-      "tooth_cleasing_powder_salt": [
-        "tooth_cleasing_powder_salt"
-      ],
-      "other_tooth_care_products": [
-        "other_tooth_care_products"
       ]
     },
     "mouth_wash_breath_spray": {
@@ -521,16 +481,6 @@
       ],
       "other_mouth_wash_breath_spray_products": [
         "other_mouth_wash_breath_spray_products"
-      ]
-    },
-    "tooth_whiteners": {
-      "tooth_whiteners": [
-        "tooth_whiteners"
-      ]
-    },
-    "other_oral_hygiene_products": {
-      "other_oral_hygiene_products": [
-        "other_oral_hygiene_products"
       ]
     }
   }

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/select_formulation_type.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/select_formulation_type.html.erb
@@ -1,16 +1,25 @@
 <% title = "Select formulation type" %>
 <% question = "How do you want to give the formulation of #{@component_name}?" %>
-<% items = formulations_types_label.map { |type_key, type_text| { text: type_text, value: type_key.to_sym, checked: answer_checked?(type_key.to_sym) } } %>
+<%
+  frame_formulations = FrameFormulations::CATEGORIES.dig(@component.root_category.to_s, @component.sub_category.to_s, @component.sub_sub_category.to_s)
+  items = formulations_types_label
+    .reject { |type_key, _| type_key == :predefined && frame_formulations.nil? }
+    .map { |type_key, type_text| { text: type_text, value: type_key.to_sym, checked: answer_checked?(type_key.to_sym) } }
+%>
 
 <% page_title title, errors: @component.errors.any? %>
 <% content_for :after_header do %>
   <%= govukBackLink text: "Back", href: previous_wizard_path %>
 <% end %>
 
-<% warning_html = if @component.notification_type.present?
+<%
+  warning_text = ""
+  warning_text += "There are no frame formulations for the chosen category. List ingredients either by exact concentration or concentration range. " if frame_formulations.nil?
+  warning_text += "Changing the formulation type will remove all ingredients already added." if @component.notification_type.present?
+  warning_html = if warning_text.present?
     govukWarningText(iconFallbackText: "Warning",
                      classes: "govuk-!-width-three-quarters govuk-!-margin-top-3 opss-warning-text--m",
-                     text: "Changing the formulation type will remove all ingredients already added")
+                     text: warning_text)
   end
 %>
 

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
@@ -77,6 +77,35 @@ RSpec.describe ResponsiblePersons::Notifications::Components::BuildController, t
       expect(assigns(:component).cmrs).to all(have_attributes(name: be_nil))
     end
 
+    describe "select formulation type" do
+      before { get(:show, params: params.merge(id: :select_formulation_type)) }
+
+      render_views
+
+      context "when the chosen category has available frame formulations" do
+        # rubocop:disable RSpec/MultipleExpectations
+        it "allows the user to choose between frame formulations, exact or range" do
+          expect(response.body).to include("Choose a predefined frame formulation")
+          expect(response.body).to include("List ingredients and their exact concentration")
+          expect(response.body).to include("List ingredients and their concentration range")
+        end
+        # rubocop:enable RSpec/MultipleExpectations
+      end
+
+      context "when the chosen category does not have any available frame formulations" do
+        let(:component) { create(:component, :with_other_category, notification:, notification_type: component_type) }
+
+        # rubocop:disable RSpec/MultipleExpectations
+        it "allows the user to choose between exact or range only" do
+          expect(response.body).to include("There are no frame formulations for the chosen category. List ingredients either by exact concentration or concentration range.")
+          expect(response.body).not_to include("Choose a predefined frame formulation")
+          expect(response.body).to include("List ingredients and their exact concentration")
+          expect(response.body).to include("List ingredients and their concentration range")
+        end
+        # rubocop:enable RSpec/MultipleExpectations
+      end
+    end
+
     describe "add component predefined frame formulation poisonous ingredient" do
       let(:component_type) { "predefined" }
 

--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -94,6 +94,10 @@ FactoryBot.define do
       sub_sub_category { "shampoo" }
     end
 
+    trait :with_other_category do
+      sub_sub_category { "other_skin_care_products_child" }
+    end
+
     trait :with_range_ingredients do
       notification_type { "range" }
       after(:create) do |component|


### PR DESCRIPTION
JIRA link: https://regulatorydelivery.atlassian.net/browse/COSBETA-1824

## Description

Hides the option to choose a frame formulation (as opposed to listing ingredients by exact or range concentrations) when the chosen category does not have any frame formulations associated with it.

Also removes some categories where either there were no frame formulations or had no ingredient data to prevent them appearing as options.

## Review apps

https://cosmetics-pr-2785-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2785-search-web.london.cloudapps.digital/
