### PR TITLE
Remove MSA role

### DIFF
--- a/cosmetics-web/app/models/concerns/privileges/search_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/search_concern.rb
@@ -23,11 +23,11 @@ module Privileges
     end
 
     def opss_user?
-      opss_general? || opss_enforcement? || opss_science? || msa? # Remove once all MSA users have been migrated
+      opss_general? || opss_enforcement? || opss_science?
     end
 
     def opss_general_user?
-      opss_general? || msa? # Remove once all MSA users have been migrated
+      opss_general?
     end
 
     def opss_enforcement_user?

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -17,7 +17,6 @@ class SearchUser < User
 
   enum role: {
     poison_centre: "poison_centre",
-    msa: "market_surveilance_authority", # Remove once all MSA users have been migrated
     opss_general: "opss_general",
     opss_enforcement: "opss_enforcement",
     opss_science: "opss_science",

--- a/cosmetics-web/app/views/errors/wrong_service_for_search_user.html.erb
+++ b/cosmetics-web/app/views/errors/wrong_service_for_search_user.html.erb
@@ -2,9 +2,7 @@
   title = "You cannot submit notifications with this account"
   role_wording = case user_role
                  when "poison_centre" then "the National Poisons Information Service"
-                 when "msa" then "a market surveillance authority" # Remove once all MSA users have been migrated
-                 when "opss_general" then "OPSS"
-                 when "opss_enforcement" then "OPSS enforcement"
+                 when "opss_general", "opss_enforcement", "opss_science" then "the Office for Product Safety and Standards"
                  when "trading_standards" then "Trading Standards"
                  end
 


### PR DESCRIPTION
## Description

All MSA users have been migrated to other roles, so remove the redundant MSA role.

## Review apps

https://cosmetics-pr-2786-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2786-search-web.london.cloudapps.digital/
