### PR TITLE
Remove Submit landing page from unused view alert

### DIFF
--- a/cosmetics-web/app/views/submit/landing_page/index.html.erb
+++ b/cosmetics-web/app/views/submit/landing_page/index.html.erb
@@ -1,4 +1,3 @@
-<% marked_as_unused_view %>
 <% content_for :page_title, "Landing Page" %>
 <div class="app-masthead">
   <div class="govuk-width-container">


### PR DESCRIPTION
This was set up during testing on the review app to be able to monitor the integration with Sentry easily, forgot to remove it before merging to master.

