### PR TITLE
Fix success text for Responsible Person

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/contact_persons_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/contact_persons_controller.rb
@@ -75,9 +75,9 @@ private
 
   def create_successful_message
     if current_user.responsible_persons.count > 1
-      "The new Responsible Person has been added to your list of Responsible Persons and can be selected as the Responsible Person."
+      "The new Responsible Person has been added to your list of Responsible Persons and can be selected as the Responsible Person"
     else
-      "Success: The Responsible Person was created."
+      "The Responsible Person was created"
     end
   end
 end

--- a/cosmetics-web/spec/features/submit/responsible_person/creation_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/creation_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Creating a responsible person", type: :feature do
     fill_in_rp_contact_details
 
     expect(page).to have_h1("Responsible Person")
-    expect(page).to have_text("Success: The Responsible Person was created")
+    expect(page).to have_text("The Responsible Person was created")
     expect(page).to have_text("Auto-test rpuser")
   end
 

--- a/cosmetics-web/spec/features/submit/responsible_person/multiple_responsible_person_creation_from_the_same_user_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/multiple_responsible_person_creation_from_the_same_user_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Creating multiple responsible persons from the same user", type:
     fill_in_rp_business_details(name: "Second RP")
     fill_in_rp_contact_details
 
-    expect(page).to have_text("The new Responsible Person has been added to your list of Responsible Persons and can be selected as the Responsible Person.")
+    expect(page).to have_text("The new Responsible Person has been added to your list of Responsible Persons and can be selected as the Responsible Person")
     expect(page).to have_text("First RP")
   end
 


### PR DESCRIPTION
JIRA link: https://regulatorydelivery.atlassian.net/browse/COSBETA-1800

## Description

Remove the extraneous “success” text in the body of the confirmation banner.

## Review apps

https://cosmetics-pr-2793-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2793-search-web.london.cloudapps.digital/