### PR TITLE
Point ActiveHash gem to its latest version

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -6,9 +6,7 @@ gem "kaminari" # Must be loaded before ElasticSearch gems
 
 # Needed a feature added into AASM master branch but still not tagged with a new version.
 gem "aasm", "5.2.0"
-# Needed to point active_hash to master version since the latest release is not compatible with Ruby 3 new keyword arg syntax.
-# TODO: Switch back to semantic versioning when a version > 3.1.0 is released.
-gem "active_hash", github: "zilkey/active_hash", ref: "1c95f99"
+gem "active_hash", "~> 3.1.1"
 gem "activerecord-pg_enum"
 gem "after_commit_everywhere"
 gem "aws-sdk-s3", "~> 1.60.1"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -5,14 +5,6 @@ GIT
     coverband (5.2.6.rc.1)
       redis (>= 3.0)
 
-GIT
-  remote: https://github.com/zilkey/active_hash.git
-  revision: 1c95f992af3ec94c07e19846f042e12bd0b11dd1
-  ref: 1c95f99
-  specs:
-    active_hash (3.1.0)
-      activesupport (>= 5.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -63,6 +55,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.1)
+      activesupport (>= 5.0.0)
     activejob (7.0.4.2)
       activesupport (= 7.0.4.2)
       globalid (>= 0.3.6)
@@ -562,7 +556,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (= 5.2.0)
-  active_hash!
+  active_hash (~> 3.1.1)
   activerecord-pg_enum
   after_commit_everywhere
   aws-sdk-s3 (~> 1.60.1)


### PR DESCRIPTION
This resolves a compatibility issue that forced us to point to a specific commit in the gemfile.
