### PR TITLE
Cleanup orphaned Trigger Question data

### DIFF
--- a/cosmetics-web/app/models/trigger_question.rb
+++ b/cosmetics-web/app/models/trigger_question.rb
@@ -8,6 +8,13 @@ class TriggerQuestion < ApplicationRecord
 
   validates :applicable, inclusion: { in: [true, false] }, on: :update
 
+  # TODO: remove this after executing the rake task cleaning up dangling trigger questions
+  after_find do |trigger_question|
+    if trigger_question.component_id.nil? && Rails.env.production?
+      Sentry.capture_message "Dangling TriggerQuestion has been loaded from DB. ID: #{trigger_question.id}"
+    end
+  end
+
   def ph_question?
     question == PH_QUESTION
   end

--- a/cosmetics-web/app/models/trigger_question.rb
+++ b/cosmetics-web/app/models/trigger_question.rb
@@ -1,8 +1,7 @@
 class TriggerQuestion < ApplicationRecord
   PH_QUESTION = "please_indicate_the_ph".freeze
 
-  # TODO: make this non-optional after refactoring CpnpParser
-  belongs_to :component, optional: true
+  belongs_to :component
 
   has_many :trigger_question_elements, -> { order(answer_order: :asc, element_order: :asc) }, dependent: :destroy, inverse_of: :trigger_question
   accepts_nested_attributes_for :trigger_question_elements

--- a/cosmetics-web/app/models/trigger_question.rb
+++ b/cosmetics-web/app/models/trigger_question.rb
@@ -8,10 +8,10 @@ class TriggerQuestion < ApplicationRecord
 
   validates :applicable, inclusion: { in: [true, false] }, on: :update
 
-  # TODO: remove this after executing the rake task cleaning up dangling trigger questions
+  # TODO: remove this after executing the rake task cleaning up orphaned trigger questions
   after_find do |trigger_question|
     if trigger_question.component_id.nil? && Rails.env.production?
-      Sentry.capture_message "Dangling TriggerQuestion has been loaded from DB. ID: #{trigger_question.id}"
+      Sentry.capture_message "Orphaned TriggerQuestion has been loaded from DB. ID: #{trigger_question.id}"
     end
   end
 

--- a/cosmetics-web/app/models/trigger_question_element.rb
+++ b/cosmetics-web/app/models/trigger_question_element.rb
@@ -1,8 +1,7 @@
 class TriggerQuestionElement < ApplicationRecord
   ELEMENTS_GIVEN_AS_CONCENTRATION = %w[incivalue value propanol ethanol concentration].freeze
 
-  # TODO: make this non-optional after refactoring CpnpParser
-  belongs_to :trigger_question, optional: true
+  belongs_to :trigger_question
 
   validates :answer, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 14 }, if: -> { question_is_applicable? && ph? }
   validates :answer, presence: true, if: -> { question_is_applicable? && answer_is_single_value? }

--- a/cosmetics-web/app/models/trigger_question_element.rb
+++ b/cosmetics-web/app/models/trigger_question_element.rb
@@ -20,6 +20,13 @@ class TriggerQuestionElement < ApplicationRecord
     maxrangevalue: "maxrangevalue",
   }
 
+  # TODO: remove this after executing the rake task cleaning up dangling trigger question elements
+  after_find do |trigger_question_element|
+    if trigger_question_element.trigger_question_id.nil? && Rails.env.production?
+      Sentry.capture_message "Dangling TriggerQuestionElement has been loaded from DB. ID: #{trigger_question_element.id}"
+    end
+  end
+
   def value_given_as_concentration?
     ELEMENTS_GIVEN_AS_CONCENTRATION.include? element
   end

--- a/cosmetics-web/app/models/trigger_question_element.rb
+++ b/cosmetics-web/app/models/trigger_question_element.rb
@@ -20,10 +20,10 @@ class TriggerQuestionElement < ApplicationRecord
     maxrangevalue: "maxrangevalue",
   }
 
-  # TODO: remove this after executing the rake task cleaning up dangling trigger question elements
+  # TODO: remove this after executing the rake task cleaning up orphaned trigger question elements
   after_find do |trigger_question_element|
     if trigger_question_element.trigger_question_id.nil? && Rails.env.production?
-      Sentry.capture_message "Dangling TriggerQuestionElement has been loaded from DB. ID: #{trigger_question_element.id}"
+      Sentry.capture_message "Orphaned TriggerQuestionElement has been loaded from DB. ID: #{trigger_question_element.id}"
     end
   end
 

--- a/cosmetics-web/lib/tasks/trigger_questions.rake
+++ b/cosmetics-web/lib/tasks/trigger_questions.rake
@@ -1,14 +1,14 @@
 namespace :trigger_questions do
-  desc "Deletes dangling trigger questions and trigger question elements"
-  task delete_dangling: :environment do
-    dangling_trigger_questions = TriggerQuestion.where(component_id: nil)
-    dangling_elements = TriggerQuestionElement.where(trigger_question_id: nil)
+  desc "Deletes orphaned trigger questions and trigger question elements"
+  task delete_orphaned: :environment do
+    orphaned_trigger_questions = TriggerQuestion.where(component_id: nil)
+    orphaned_elements = TriggerQuestionElement.where(trigger_question_id: nil)
 
-    puts "Deleting #{dangling_trigger_questions.count} dangling trigger questions and #{dangling_elements.count} dangling trigger question elements"
+    puts "Deleting #{orphaned_trigger_questions.count} orphaned trigger questions and #{orphaned_elements.count} orphaned trigger question elements"
 
     ActiveRecord::Base.transaction do
-      dangling_trigger_questions.destroy_all
-      dangling_elements.destroy_all
+      orphaned_trigger_questions.destroy_all
+      orphaned_elements.destroy_all
     end
   end
 end

--- a/cosmetics-web/lib/tasks/trigger_questions.rake
+++ b/cosmetics-web/lib/tasks/trigger_questions.rake
@@ -1,0 +1,14 @@
+namespace :trigger_questions do
+  desc "Deletes dangling trigger questions and trigger question elements"
+  task delete_dangling: :environment do
+    dangling_trigger_questions = TriggerQuestion.where(component_id: nil)
+    dangling_elements = TriggerQuestionElement.where(trigger_question_id: nil)
+
+    puts "Deleting #{dangling_trigger_questions.count} dangling trigger questions and #{dangling_elements.count} dangling trigger question elements"
+
+    ActiveRecord::Base.transaction do
+      dangling_trigger_questions.destroy_all
+      dangling_elements.destroy_all
+    end
+  end
+end

--- a/cosmetics-web/spec/factories/trigger_question.rb
+++ b/cosmetics-web/spec/factories/trigger_question.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :trigger_question do
+    trait :without_validations do
+      to_create { |instance| instance.save(validate: false) }
+    end
   end
 end

--- a/cosmetics-web/spec/factories/trigger_question_element.rb
+++ b/cosmetics-web/spec/factories/trigger_question_element.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :trigger_question_element do
+    trait :without_validations do
+      to_create { |instance| instance.save(validate: false) }
+    end
   end
 end

--- a/cosmetics-web/spec/lib/tasks/deleted_notifications_spec.rb
+++ b/cosmetics-web/spec/lib/tasks/deleted_notifications_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "deleted_notifications.rake" do
       create(:notification, :deleted, deleted_at: nil, updated_at: deletion_time, created_at: creation_time)
     end
 
+    after do
+      # Rake tasks only run on the first invocation per suite. This re-enables the task for the next test.
+      task.reenable
+    end
+
     it "sets the deletion timestampt to the last time the notification got updated" do
       expect { task.invoke }.to change { deleted_notification.reload.deleted_at }.from(nil).to(deletion_time)
     end

--- a/cosmetics-web/spec/lib/tasks/trigger_questions_spec.rb
+++ b/cosmetics-web/spec/lib/tasks/trigger_questions_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+Rails.application.load_tasks
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "trigger_questions.rake" do
+  describe "delete_dangling" do
+    subject(:task) { Rake::Task["trigger_questions:delete_dangling"] }
+
+    let!(:component) { create(:component) }
+    let!(:trigger_question) { create(:trigger_question, component:) }
+    let!(:trigger_question_element) { create(:trigger_question_element, trigger_question:) }
+
+    before do
+      allow($stdout).to receive(:puts) # Silences the output on rspec run and allow to assert over its calls.
+      create(:trigger_question, :without_validations, component_id: nil)
+      create(:trigger_question_element, :without_validations, trigger_question_id: nil)
+    end
+
+    after do
+      # Rake tasks only run on the first invocation per suite. This re-enables the task for the next test.
+      task.reenable
+    end
+
+    it "deletes the trigger question that is not associated with a component" do
+      expect { task.invoke }.to change(TriggerQuestion, :count).from(2).to(1)
+      expect(TriggerQuestion.last).to eq(trigger_question)
+    end
+
+    it "deletes the trigger question element that is not associated with a trigger question" do
+      expect { task.invoke }.to change(TriggerQuestionElement, :count).from(2).to(1)
+      expect(TriggerQuestionElement.last).to eq(trigger_question_element)
+    end
+
+    it "informs the user of the number of dangling trigger questions and trigger question elements that were deleted" do
+      task.invoke
+      expect($stdout).to have_received(:puts)
+                     .with("Deleting 1 dangling trigger questions and 1 dangling trigger question elements")
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/cosmetics-web/spec/lib/tasks/trigger_questions_spec.rb
+++ b/cosmetics-web/spec/lib/tasks/trigger_questions_spec.rb
@@ -3,8 +3,8 @@ Rails.application.load_tasks
 
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe "trigger_questions.rake" do
-  describe "delete_dangling" do
-    subject(:task) { Rake::Task["trigger_questions:delete_dangling"] }
+  describe "delete_orphaned" do
+    subject(:task) { Rake::Task["trigger_questions:delete_orphaned"] }
 
     let!(:component) { create(:component) }
     let!(:trigger_question) { create(:trigger_question, component:) }
@@ -31,10 +31,10 @@ RSpec.describe "trigger_questions.rake" do
       expect(TriggerQuestionElement.last).to eq(trigger_question_element)
     end
 
-    it "informs the user of the number of dangling trigger questions and trigger question elements that were deleted" do
+    it "informs the user of the number of orphaned trigger questions and trigger question elements that were deleted" do
       task.invoke
       expect($stdout).to have_received(:puts)
-                     .with("Deleting 1 dangling trigger questions and 1 dangling trigger question elements")
+                     .with("Deleting 1 orphaned trigger questions and 1 orphaned trigger question elements")
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

When the service allowed importing/parsing data from the European CPNP service, some TriggerQuestions and TriggerQuestionElements were created without being associated with a component/notification or, in the case of the TQElements,  to any TQ.

As the ERD shows, if a TQElement is not associated with a TQ, or a TQ is not associated with a Component, there is no way they can be related with any notification, so it is orphaned invalid data.

### Production numbers:
- Orphaned Trigger Questions not associated with any component: 93.580
- Orphaned Trigger Question Elements not associated with any TQ:  12

### Solution
1. Following up on the `TODO` comment introduced in their model associations, removing the `optional` association parameter.
2. Sending an alert to Sentry anytime any of the orphaned TQ/TQE gets loaded from DB. This will help us identify if any of them gets loaded unexpectedly or if they're actually orphaned/not used.
3. Introducing a rake task to delete all those affected TQ & TQE from DB.

![image](https://user-images.githubusercontent.com/1227578/220315605-035ebde4-e042-4ac1-81a9-c37961fc66ea.png)



