### PR TITLE
Remove "UnusedCodeAlerting" flag from called code

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/product/add_product_image.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/add_product_image.html.erb
@@ -2,7 +2,6 @@
 <% page_title title, errors: @notification.errors.messages.include?(:image_uploads) %>
 <% content_for :after_header do %>
   <% if params[:back_to_edit] %>
-    <% UnusedCodeAlerting.alert # back_to_edit does not seem to be set anywhere. %>
     <%= govukBackLink text: "Back", href: edit_responsible_person_notification_path(@notification.responsible_person, @notification) %>
   <% else %>
     <%= govukBackLink text: "Back", href: previous_wizard_path %>


### PR DESCRIPTION
"back_to_edit" param is actually being set as true with some flows.

Removing the flag as it is alerting about it being hit.

