### PR TITLE
Complete TODO: Regarding user with pending invitation flows

### DIFF
--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -63,18 +63,7 @@ module Users
       user.confirmed_at = nil
       user.account_security_completed = false
       user.save(validate: false)
-      # TODO: Remove this branch based on pending invitations once invitations
-      # contain user name (pending feature).
-      # Once that happens logic can default to resending the account setup link
-      # as done with user who registered without an invitation.
-      if (invitation = PendingResponsiblePersonUser.where(email_address: user.email).last)
-        invitation.refresh_token_expiration!
-        SubmitNotifyMailer.send_responsible_person_invite_email(
-          invitation.responsible_person, invitation, invitation.inviting_user.name
-        ).deliver_later
-      else
-        user.resend_account_setup_link
-      end
+      user.resend_account_setup_link
       redirect_to check_your_email_path
     end
 

--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -26,7 +26,7 @@ module Registration
       if user.confirmed?
         SubmitNotifyMailer.send_account_already_exists(user).deliver_later
       else
-        user.resend_confirmation_instructions
+        user.resend_account_setup_link
       end
     end
   end

--- a/cosmetics-web/app/forms/registration/new_account_form.rb
+++ b/cosmetics-web/app/forms/registration/new_account_form.rb
@@ -25,15 +25,6 @@ module Registration
     def send_link(user)
       if user.confirmed?
         SubmitNotifyMailer.send_account_already_exists(user).deliver_later
-      # TODO: Remove this branch based on pending invitations once invitations
-      # contain user name (pending feature).
-      # Once that happens logic can default to resending the account setup link
-      # as done with user who registered without an invitation.
-      elsif (invitation = PendingResponsiblePersonUser.where(email_address: user.email).last)
-        invitation.refresh_token_expiration!
-        SubmitNotifyMailer.send_responsible_person_invite_email(
-          invitation.responsible_person, invitation, invitation.inviting_user.name
-        ).deliver_later
       else
         user.resend_confirmation_instructions
       end

--- a/cosmetics-web/app/models/submit_user.rb
+++ b/cosmetics-web/app/models/submit_user.rb
@@ -18,7 +18,7 @@ class SubmitUser < User
     new_user = SubmitUser.find_by!(confirmation_token:)
 
     if new_user.send(:confirmation_period_expired?)
-      new_user.resend_confirmation_instructions
+      new_user.resend_account_setup_link
       raise ActiveRecord::RecordInvalid
     end
     new_user
@@ -29,7 +29,7 @@ class SubmitUser < User
   end
 
   def resend_account_setup_link
-    resend_confirmation_instructions
+    resend_confirmation_instructions # Defined at Devise::Models::Confirmable#resend_confirmation_instructions
   end
 
   def regenerate_confirmation_token_if_expired; end

--- a/cosmetics-web/app/models/user.rb
+++ b/cosmetics-web/app/models/user.rb
@@ -91,6 +91,12 @@ class User < ApplicationRecord
            account_security_completed: false)
   end
 
+  def reset_account_setup!
+    self.confirmed_at = nil
+    self.account_security_completed = false
+    save(validate: false)
+  end
+
   def uses_email_address?(email_address)
     return false if email_address.blank?
 

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -499,6 +499,11 @@ def expect_to_be_on__responsible_person_declaration_page
   expect(page).to have_h1("Responsible Person Declaration")
 end
 
+def expect_to_be_on__pending_invitations_page
+  expect(page.current_path).to eq("/responsible_persons/account/pending_invitations")
+  expect(page).to have_h1("Who do you want to submit cosmetic product notifications for?")
+end
+
 def expect_form_to_have_errors(errors)
   expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
   errors.each do |attribute, error|

--- a/cosmetics-web/spec/support/shared_examples/common_user_tests.rb
+++ b/cosmetics-web/spec/support/shared_examples/common_user_tests.rb
@@ -448,4 +448,18 @@ RSpec.shared_examples "common user tests" do
       expect(user.uses_email_address?("userNEW@example.com")).to eq true
     end
   end
+
+  describe "#reset_account_setup!" do
+    let(:confirmation_timestamp) { Time.zone.now }
+    let(:user_factory) { user.class.to_s.underscore.to_sym }
+    let(:set_user) { create(user_factory, confirmed_at: confirmation_timestamp, account_security_completed: true) }
+
+    it "removes user's confirmation timestamp" do
+      expect { set_user.reset_account_setup! }.to change(set_user, :confirmed_at).from(confirmation_timestamp).to(nil)
+    end
+
+    it "removes user's account security completed flag" do
+      expect { set_user.reset_account_setup! }.to change(set_user, :account_security_completed).from(true).to(false)
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

**TLDR:** We are actioning 2 pending `TODO` comments regarding simplifying users with pending invitation flows once the invitations contain a user name that can be used for emails.


## Description
There were 2 Submit user flows with a pending TODO action to remove specific branching for users with a pending Responsible Person invitation:
- When trying to **register a new user** after having **partially created** a user following an RP invitation email for the same email address.
- When attempting to **reset the user password** after having the same **partially created** user as the first case.

In those cases, the **service did resend the Invitation instead of sending the default account setup email**.

Now that the RP Team invitations require the introduction of a user name, we can resend the user account confirmation instructions email as done with any other user that hasn't completed their account security. This reduces our code logic branching.

## Service behaviour changes.
- Until now, as we were sending the invitation again, the user was added to the RP as soon as they followed the re-sent invitation link and completed the account security.

- Since we are no longer sending the invitation, now these users, upon completing the account security page, will be redirected to a "you have pending invitations" page instead, encouraging them to search their email inbox and follow the invitation link to be added to the RP.

We can either:
- Ensure this is OK through testing and onboarding the team on this change.
- ~Study adding the user to the RP and deleting the invitation as soon as they follow the invitation link and land on the account security completion page. Why wasn't this happening already? (There may be a reason).~
  - **Found the reason** :
    -  When the user gets added to the RP before they complete their account security.
    - And they abandon the flow without completing the security step. 
    - Then they won't have any "complete registration" link to follow, as it was never issued for users registered through an invitation.
    - And the invitation link won't be valid anymore, as the invitation gets removed when adding the user to the RP.
    - And they will be blocked without being able to complete their registration anymore.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2811-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2811-search-web.london.cloudapps.digital/
