### PR TITLE
Remove alerts for loaded orphaned TQ/TQE

### DIFF
--- a/cosmetics-web/app/models/trigger_question.rb
+++ b/cosmetics-web/app/models/trigger_question.rb
@@ -8,13 +8,6 @@ class TriggerQuestion < ApplicationRecord
 
   validates :applicable, inclusion: { in: [true, false] }, on: :update
 
-  # TODO: remove this after executing the rake task cleaning up orphaned trigger questions
-  after_find do |trigger_question|
-    if trigger_question.component_id.nil? && Rails.env.production?
-      Sentry.capture_message "Orphaned TriggerQuestion has been loaded from DB. ID: #{trigger_question.id}"
-    end
-  end
-
   def ph_question?
     question == PH_QUESTION
   end

--- a/cosmetics-web/app/models/trigger_question_element.rb
+++ b/cosmetics-web/app/models/trigger_question_element.rb
@@ -20,13 +20,6 @@ class TriggerQuestionElement < ApplicationRecord
     maxrangevalue: "maxrangevalue",
   }
 
-  # TODO: remove this after executing the rake task cleaning up orphaned trigger question elements
-  after_find do |trigger_question_element|
-    if trigger_question_element.trigger_question_id.nil? && Rails.env.production?
-      Sentry.capture_message "Orphaned TriggerQuestionElement has been loaded from DB. ID: #{trigger_question_element.id}"
-    end
-  end
-
   def value_given_as_concentration?
     ELEMENTS_GIVEN_AS_CONCENTRATION.include? element
   end


### PR DESCRIPTION
Follow up on: https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/pull/2801

Remove the alerts set to identify any case when an orphaned TriggerQuestion or TriggerQuestionElement gets loaded from DB.

It turns out this needs to be removed BEFORE calling the rake task (as I painfully noticed), not after.

After this, I will trigger the task and then open a further PR to remove the one-off rake task code.