### PR TITLE
Add and clarify messages about multi-item kits

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/delete_items/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/delete_items/show.html.erb
@@ -28,17 +28,8 @@
       <% end %>
     <% else %>
       <h1 class="govuk-heading-m govuk-!-margin-bottom-0">You cannot remove an item</h1>
-      <p class="govuk-body opss-secondary-text govuk-!-margin-bottom-7">A multi-item kit product must include 2 or more items.</p>
       <p class="govuk-body">
-        This draft product notification has defined the product as being a multi-item kit and currently includes 2 items.
-        A product containing only 1 item (or component) is a single item product and is not a multi-item kit product.
-      </p>
-      <p class="govuk-body">
-        To remove an item you must first add a new item.
-        <span class="govuk-!-font-weight-bold">If the product is not a multi-item kit product</span>, you will need to
-        <%= link_to("delete this draft",
-                    delete_responsible_person_delete_notification_path(@notification.responsible_person, @notification),
-                    class: "govuk-link govuk-link--no-visited-state") %>.
+        A multi-item kit must contain, at least, 2 items. If this product is not a multi-item kit you will need to create a new product notification.
       </p>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <p class="govuk-body">

--- a/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
@@ -29,6 +29,12 @@
           submit a separate notification for each product.
         </p>
 
+        <%= govukWarningText(
+          iconFallbackText: "Warning",
+          classes: "govuk-!-margin-top-6 govuk-!-margin-bottom-5",
+          text: "You will be unable to change to a single item product once you select and confirm that this is a multi-item kit. You will need to create a new product notification in order to use the single item product option."
+        )%>
+
         <% count_input_html = capture do %>
           <%= govukInput(form: form,
                          key: :components_count,
@@ -63,11 +69,11 @@
   <% end %>
 <% else %>
   <h1 class="govuk-heading-m">
-      Items have already been added to the multi-item kit
+    This draft product notification has been defined as a multi-item kit.
   </h1>
 
   <p class="govuk-body">
-      You will be able to add and remove items directly from the tasks list page once the multi-item kit task is completed.
+    A multi-item kit must contain, at least, 2 items. If this product is not a multi-item kit you will need to create a new product notification.
   </p>
 
   <%= link_to "Continue", next_step_path, class: "govuk-button govuk-!-margin-top-8" %>

--- a/cosmetics-web/spec/support/helpers/product_wizard.rb
+++ b/cosmetics-web/spec/support/helpers/product_wizard.rb
@@ -28,7 +28,7 @@ def complete_product_wizard(name: "Product", items_count: 1, nano_materials_coun
       answer_is_product_multi_item_kit_with "No, this is a single product"
     end
   else
-    expect(page).to have_text("You will be able to add and remove items directly from the tasks list page once the multi-item kit task is completed.")
+    expect(page).to have_text("A multi-item kit must contain, at least, 2 items. If this product is not a multi-item kit you will need to create a new product notification.")
     click_on "Continue"
   end
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1807

## Description

Adds new and clarifies existing messaging about not being able to switch from a multi-item kit to a single item kit product once the choice has been made.

## Review apps

https://cosmetics-pr-2816-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2816-search-web.london.cloudapps.digital/