### PR TITLE
Allow “maximum concentration” for multi shade ingredients

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/build_controller.rb
@@ -366,11 +366,21 @@ private
 
     { name: ingredient.inci_name,
       cas_number: ingredient.cas_number,
-      exact_concentration: ingredient.exact_concentration,
+      used_for_multiple_shades: ingredient.used_for_multiple_shades,
+      exact_concentration: ingredient_form_value_exact_concentration(ingredient),
+      maximum_concentration: ingredient_form_value_maximum_concentration(ingredient),
       range_concentration: ingredient.range_concentration,
       poisonous: ingredient.poisonous,
       updating_ingredient: ingredient,
       ingredient_number: }
+  end
+
+  def ingredient_form_value_exact_concentration(ingredient)
+    ingredient.exact_concentration unless ingredient.used_for_multiple_shades
+  end
+
+  def ingredient_form_value_maximum_concentration(ingredient)
+    ingredient.exact_concentration if ingredient.used_for_multiple_shades
   end
 
   def component_params
@@ -399,7 +409,9 @@ private
     params.fetch(:ingredient_concentration_form, {})
       .permit(
         :name,
+        :used_for_multiple_shades,
         :exact_concentration,
+        :maximum_concentration,
         :range_concentration,
         :cas_number,
         :poisonous,

--- a/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
@@ -7,7 +7,9 @@ module ResponsiblePersons::Notifications
     include StripWhitespace
 
     attribute :name, :string
+    attribute :used_for_multiple_shades, :boolean
     attribute :exact_concentration
+    attribute :maximum_concentration
     attribute :range_concentration, :string
     attribute :cas_number, :string
     attribute :poisonous, :boolean
@@ -21,10 +23,15 @@ module ResponsiblePersons::Notifications
     validates :poisonous, inclusion: { in: [true, false] }, if: :range?
     validates :name, presence: true, length: { maximum: NAME_LENGTH_LIMIT }, ingredient_name_format: { message: :invalid }
     validate :unique_name
+    validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: :multi_shade?
     validates :exact_concentration,
               presence: true,
               numericality: { allow_blank: true, greater_than: 0, less_than_or_equal_to: 100 },
-              if: :exact?
+              if: -> { exact? && (!multi_shade? || used_for_single_shade?) }
+    validates :maximum_concentration,
+              presence: true,
+              numericality: { allow_blank: true, greater_than: 0, less_than_or_equal_to: 100 },
+              if: -> { exact? && used_for_multiple_shades? }
     validates :range_concentration,
               presence: true,
               if: -> { range? && poisonous == false }
@@ -44,6 +51,10 @@ module ResponsiblePersons::Notifications
         self.type = EXACT
         self.range_concentration = nil
       end
+
+      unless multi_shade?
+        self.used_for_multiple_shades = nil
+      end
     end
 
     def range?
@@ -52,6 +63,14 @@ module ResponsiblePersons::Notifications
 
     def exact?
       type == EXACT
+    end
+
+    def used_for_single_shade?
+      used_for_multiple_shades == false
+    end
+
+    def used_for_multiple_shades?
+      used_for_multiple_shades == true
     end
 
     def save
@@ -69,7 +88,8 @@ module ResponsiblePersons::Notifications
     def ingredient_attributes
       {
         inci_name: name,
-        exact_concentration:,
+        used_for_multiple_shades:,
+        exact_concentration: exact? && used_for_multiple_shades? ? maximum_concentration : exact_concentration,
         range_concentration:,
         cas_number:,
         poisonous: poisonous.presence || false,
@@ -82,6 +102,10 @@ module ResponsiblePersons::Notifications
       if Ingredient.where(component_id: component, inci_name: name).where.not(id: updating_ingredient).any?
         errors.add(:name, :taken, entity: component.notification.is_multicomponent? ? "item" : "product")
       end
+    end
+
+    def multi_shade?
+      component&.shades&.compact&.uniq&.any?
     end
   end
 end

--- a/cosmetics-web/app/helpers/concentration_helper.rb
+++ b/cosmetics-web/app/helpers/concentration_helper.rb
@@ -1,13 +1,14 @@
 module ConcentrationHelper
-  def display_concentration(concentration)
+  def display_concentration(concentration, used_for_multiple_shades: false)
+    prefix = "Maximum concentration: " if used_for_multiple_shades
     if concentration.to_s.split(".").last.size > 2
-      "#{concentration}% w/w"
+      "#{prefix}#{concentration}%&nbsp;w/w".html_safe
     else
-      "#{number_with_precision(concentration, precision: 2)}% w/w"
+      "#{prefix}#{number_with_precision(concentration, precision: 2)}%&nbsp;w/w".html_safe
     end
   end
 
   def display_concentration_range(range)
-    "#{get_unit_name(range)}% w/w"
+    "#{get_unit_name(range)}%&nbsp;w/w".html_safe
   end
 end

--- a/cosmetics-web/app/helpers/ingredient_helper.rb
+++ b/cosmetics-web/app/helpers/ingredient_helper.rb
@@ -16,7 +16,7 @@ module IngredientHelper
 
   def format_exact_ingredients(exact_ingredients)
     exact_ingredients.map do |ingredient|
-      { inci_name: ingredient.inci_name, exact_concentration: display_concentration(ingredient.exact_concentration) }
+      { inci_name: ingredient.inci_name, exact_concentration: display_concentration(ingredient.exact_concentration, used_for_multiple_shades: ingredient.used_for_multiple_shades?) }
     end
   end
 

--- a/cosmetics-web/app/views/application/_formulation_table.html.erb
+++ b/cosmetics-web/app/views/application/_formulation_table.html.erb
@@ -8,10 +8,9 @@
         <% if value_name.start_with?("range")%>
           <%= display_concentration_range(entity[value_name]) %>
         <% else %>
-          <%= display_concentration(entity[value_name]) %>
+          <%= display_concentration(entity[value_name], used_for_multiple_shades: entity["used_for_multiple_shades"]) %>
         <% end %>
       </td>
     </tr>
   <% end %>
 <% end %>
-

--- a/cosmetics-web/app/views/responsible_persons/notifications/_ingredients.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_ingredients.html.erb
@@ -7,15 +7,15 @@
           <dd><abbr>CAS</abbr>: <%= ingredient.cas_number %> </dd>
         <% end %>
         <% if ingredient.exact_concentration.present? %>
-          <dd><%= ingredient.exact_concentration %>% <abbr>w/w</abbr></dd>
+          <dd><% if ingredient.used_for_multiple_shades? %>Maximum concentration: <% end %><%= ingredient.exact_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
         <% elsif ingredient.range_concentration.present? %>
           <% range = ingredient_concentration_range(ingredient.range_concentration) %>
           <% if range.upto.present? %>
             <% if range.above.present? %>
-               <dd>Above <%= range.above %>% <abbr>w/w</abbr></dd>
-               <dd>Up to <%= range.upto %>% <abbr>w/w</abbr></dd>
+               <dd>Above <%= range.above %>%&nbsp;<abbr>w/w</abbr></dd>
+               <dd>Up to <%= range.upto %>%&nbsp;<abbr>w/w</abbr></dd>
             <% else %>
-               <dd>Up to and including <%= range.upto %>% <abbr>w/w</abbr></dd>
+               <dd>Up to and including <%= range.upto %>%&nbsp;<abbr>w/w</abbr></dd>
             <% end %>
           <% end %>
         <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_exact_concentration_input.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_exact_concentration_input.html.erb
@@ -1,18 +1,47 @@
-<% concentration_error = model.errors[:exact_concentration]&.first %>
-<div class="govuk-form-group <%= "govuk-form-group--error" if concentration_error %>">
-  <%= govukLabel(for: :exact_concentration, text: "What is the exact concentration?", classes: "govuk-label--s govuk-!-font-weight-regular")%>
-  <% if concentration_error %>
-    <%= govukErrorMessage(id: "exact_concentration-error", text: concentration_error) %>
-  <% end %>
-  <div class="govuk-input__wrapper">
-    <%= form.text_field(:exact_concentration,
-                        id: "exact_concentration",
-                        class: "govuk-input govuk-input--width-5 #{'govuk-input--error' if concentration_error}",
-                        maxlength: 12,
-                        size: nil,
-                        "aria-describedby" => ("exact_concentration-error" if concentration_error)) %>
-    <div class="govuk-input__suffix" aria-hidden="true">
-      <span title="Percentage weight by weight">&percnt; w/w</span>
+<div class="govuk-form-group">
+  <% exact_concentration_field_html = capture do %>
+    <div class="govuk-input__wrapper">
+      <%= govukInput(form: form,
+           key: :exact_concentration,
+           id: "exact_concentration",
+           label: { text: "What is the exact concentration?" },
+           suffix: { text: "% w/w", attributes: { title: "Percentage weight by weight" } },
+           classes: "govuk-input--width-5",
+           attributes: { maxlength: 12 }) %>
     </div>
-  </div>
+  <% end %>
+  <% maximum_concentration_field_html = capture do %>
+    <div class="govuk-input__wrapper">
+      <%= govukInput(form: form,
+           key: :maximum_concentration,
+           id: "maximum_concentration",
+           label: { text: "What is the maximum concentration?" },
+           hint: { text: "Enter the maximum concentration used in the shades." },
+           suffix: { text: "% w/w", attributes: { title: "Percentage weight by weight" } },
+           classes: "govuk-input--width-5",
+           attributes: { maxlength: 12 }) %>
+    </div>
+  <% end %>
+  <% if show_maximum_concentration %>
+    <%= govukRadios(
+      form: form,
+      key: :used_for_multiple_shades,
+      id: "used_for_multiple_shades",
+      fieldset: { legend: { text: "Is it used for different shades?", classes: "govuk-label--s" } },
+      items: [
+        { text: "Yes",
+          value: "true",
+          id: "used_for_multiple_shades_true",
+          conditional: { html: maximum_concentration_field_html },
+          checked: params.dig(:ingredient_concentration_form, :used_for_multiple_shades) == "true" || model.attributes["used_for_multiple_shades"] == "true" },
+        { text: "No",
+          value: "false",
+          id: "used_for_multiple_shades_false",
+          conditional: { html: exact_concentration_field_html },
+          checked: params.dig(:ingredient_concentration_form, :used_for_multiple_shades) == "false" || model.attributes["used_for_multiple_shades"] == "false" },
+      ],
+    ) %>
+  <% else %>
+    <%= exact_concentration_field_html %>
+  <% end %>
 </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_ingredient_exact_concentration_fields.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_ingredient_exact_concentration_fields.html.erb
@@ -4,20 +4,10 @@
                label: { text: "What is the name?" },
                attributes: { spellcheck: "false" }) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <%= render "exact_concentration_input", model: model, form: form %>
-  </div>
+<%= render "exact_concentration_input", model: model, form: form, show_maximum_concentration: component.shades.present? %>
 
-  <div class="govuk-grid-column-one-half">
-    <div class="govuk-form-group">
-      <div class="govuk-checkboxes opss-float-right-desktop">
-        <%= govukInput(form: form,
-                       key: :cas_number,
-                       id: "cas_number",
-                       label: { html: "What is the CAS number? <span class='opss-secondary-text govuk-!-font-size-16'>(optional)</span>".html_safe, classes: "govuk-label--s govuk-!-font-weight-regular" },
-                       classes: "govuk-input--width-10") %>
-      </div>
-    </div>
-  </div>
-</div>
+<%= govukInput(form: form,
+               key: :cas_number,
+               id: "cas_number",
+               label: { html: "What is the CAS number? <span class='opss-secondary-text govuk-!-font-size-16'>(optional)</span>".html_safe, classes: "govuk-label--s govuk-!-font-weight-regular" },
+               classes: "govuk-input--width-10") %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_ingredient_range_concentration_option.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_ingredient_range_concentration_option.html.erb
@@ -1,2 +1,2 @@
-Above <span class='govuk-!-font-weight-bold'><%= above %>%</span> <abbr class='govuk-!-font-size-16' title='Weight by weight'>w/w</abbr>
-up to <span class='govuk-!-font-weight-bold'><%= up_to %>%</span> <abbr class='govuk-!-font-size-16'>w/w</abbr>
+Above <span class='govuk-!-font-weight-bold'><%= above %>%</span>&nbsp;<abbr class='govuk-!-font-size-16' title='Weight by weight'>w/w</abbr>
+up to <span class='govuk-!-font-weight-bold'><%= up_to %>%</span>&nbsp;<abbr class='govuk-!-font-size-16'>w/w</abbr>

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -5,10 +5,10 @@
   <%= govukBackLink text: "Back", href: previous_wizard_path %>
 <% end %>
 
-<%= error_summary(@ingredient_concentration_form.errors) %>
+<%= error_summary(@ingredient_concentration_form.errors, map_errors: { used_for_multiple_shades: "used_for_multiple_shades_true" }) %>
 
 <%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form do |form| %>
-  <%= render "ingredient_exact_concentration_fields", model: @ingredient_concentration_form, form: form %>
+  <%= render "ingredient_exact_concentration_fields", component: @component, model: @ingredient_concentration_form, form: form %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= govukCheckboxes(form: form,

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_npis_needs_to_know.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_npis_needs_to_know.html.erb
@@ -10,7 +10,7 @@
            component: @component,
            model: @ingredient_concentration_form,
            poisonous: true do |form| %>
-  <%= render "ingredient_exact_concentration_fields", model: @ingredient_concentration_form, form: form %>
+  <%= render "ingredient_exact_concentration_fields", component: @component, model: @ingredient_concentration_form, form: form %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= govukCheckboxes(form: form,

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_range_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_range_concentration.html.erb
@@ -24,7 +24,7 @@
                  classes: "govuk-input--width-10") %>
 
   <% exact_concentration_html = capture do %>
-    <%= render "exact_concentration_input", model: @ingredient_concentration_form, form: form %>
+    <%= render "exact_concentration_input", model: @ingredient_concentration_form, form: form, show_maximum_concentration: false %>
   <% end %>
 
   <% range_concentration_html = capture do %>

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -274,7 +274,14 @@ en:
           attributes:
             component:
               blank: "Provide a component to associate the ingredient to"
+            used_for_multiple_shades:
+              inclusion: "Select yes if the ingredient is used for different shades"
             exact_concentration:
+              blank: "Enter the concentration"
+              greater_than: "Enter a concentration greater than 0"
+              less_than_or_equal_to: "Enter a concentration less than or equal to 100"
+              not_a_number: "Enter a number for the concentration"
+            maximum_concentration:
               blank: "Enter the concentration"
               greater_than: "Enter a concentration greater than 0"
               less_than_or_equal_to: "Enter a concentration less than or equal to 100"

--- a/cosmetics-web/db/migrate/20230303111821_add_used_for_multiple_shades_to_ingredients.rb
+++ b/cosmetics-web/db/migrate/20230303111821_add_used_for_multiple_shades_to_ingredients.rb
@@ -1,0 +1,5 @@
+class AddUsedForMultipleShadesToIngredients < ActiveRecord::Migration[7.0]
+  def change
+    add_column :ingredients, :used_for_multiple_shades, :boolean
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_131742) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_03_111821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -147,6 +147,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_131742) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "component_id"
+    t.boolean "used_for_multiple_shades"
     t.index ["component_id"], name: "index_ingredients_on_component_id"
     t.index ["created_at"], name: "index_ingredients_on_created_at"
     t.index ["exact_concentration"], name: "index_ingredients_on_exact_concentration"

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 RSpec.describe ResponsiblePersons::Notifications::Components::BuildController, type: :controller do
   let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
-  let(:component) { create(:component, :with_category, notification:, notification_type: component_type) }
+  let(:component) { create(:component, :with_category, shades:, notification:, notification_type: component_type) }
   let(:notification) do
     create(:notification,
            responsible_person:,
            state: NotificationStateConcern::READY_FOR_COMPONENTS)
   end
+  let(:shades) { [] }
   let(:component_type) { nil }
 
   let(:params) do
@@ -140,10 +141,25 @@ RSpec.describe ResponsiblePersons::Notifications::Components::BuildController, t
       # rubocop:disable RSpec/MultipleExpectations
       it "shows the page for adding ingredients with exact concentration" do
         expect(response.body).to match(/<title>Add the ingredients .+<\/title>/)
+        expect(response.body).not_to include("Is it used for different shades?")
         expect(response.body).to include("What is the exact concentration?")
         expect(response.body).not_to include("What is the concentration range?")
       end
       # rubocop:enable RSpec/MultipleExpectations
+
+      context "when the component has multiple shades" do
+        let(:shades) { %w[Black White] }
+
+        # rubocop:disable RSpec/MultipleExpectations
+        it "shows the page for adding ingredients with exact concentration" do
+          expect(response.body).to match(/<title>Add the ingredients .+<\/title>/)
+          expect(response.body).to include("Is it used for different shades?")
+          expect(response.body).to include("What is the maximum concentration?")
+          expect(response.body).to include("What is the exact concentration?")
+          expect(response.body).not_to include("What is the concentration range?")
+        end
+        # rubocop:enable RSpec/MultipleExpectations
+      end
 
       it "links to the select formulation type page" do
         expect(response.body).to have_back_link_to(

--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -63,6 +63,19 @@ FactoryBot.define do
           }
         end
       end
+
+      trait :with_multiple_shades do
+        routing_questions_answers do
+          {
+            "contains_cmrs" => "no",
+            "number_of_shades" => "multiple-shades-same-notification",
+            "select_formulation_type" => "exact",
+            "contains_special_applicator" => "no",
+            "contains_poisonous_ingredients" => "true",
+          }
+        end
+        shades { %w[Black White] }
+      end
     end
 
     trait :with_poisonous_ingredients do
@@ -105,10 +118,17 @@ FactoryBot.define do
       end
     end
 
-    trait :with_exact_ingredients do
+    trait :with_exact_ingredient do
       notification_type { "exact" }
       after(:create) do |component|
         create(:exact_ingredient, component:)
+      end
+    end
+
+    trait :with_exact_ingredients do
+      notification_type { "exact" }
+      after(:create) do |component|
+        create_list(:exact_ingredient, 2, component:)
       end
     end
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Adding ingredients to components", :with_stubbed_antivirus, type
     })
 
     # Successfully adding the first ingredient by its concentration range
-    page.choose("Above 5% w/w up to 10% w/w")
+    page.choose("greater_than_5_less_than_10_percent")
     click_on "Save and continue"
 
     answer_add_another_ingredient_with "Yes"

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/editing_ingredients_on_components_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/editing_ingredients_on_components_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Editing ingredients on components", :with_stubbed_antivirus, typ
     expect(page).to have_field("What is the name?", with: "Ingredient A")
     expect(page).to have_field("What is the CAS number?")
     expect(page).to have_checked_field("No")
-    expect(page).to have_checked_field("Above 75% w/w up to 100% w/w")
+    expect(page).to have_checked_field("greater_than_75_less_than_100_percent")
     expect(page).not_to have_link("Skip", exact: true)
     click_on "Save and continue"
 
@@ -107,11 +107,11 @@ RSpec.describe "Editing ingredients on components", :with_stubbed_antivirus, typ
     expect(page).to have_field("What is the name?", with: "Ingredient B")
     expect(page).to have_field("What is the CAS number?")
     expect(page).to have_checked_field("No")
-    expect(page).to have_checked_field("Above 10% w/w up to 25% w/w")
+    expect(page).to have_checked_field("greater_than_10_less_than_25_percent")
     expect(page).not_to have_link("Skip", exact: true)
 
     fill_in "What is the name?", with: "Ingredient B modified"
-    page.choose("Above 5% w/w up to 10% w/w")
+    page.choose("greater_than_5_less_than_10_percent")
     click_on "Save and continue"
 
     expect_to_be_on_add_ingredients_page(ingredient_number: 3, already_added: ["Ingredient A", "Ingredient B modified", "Ingredient C"])
@@ -124,7 +124,7 @@ RSpec.describe "Editing ingredients on components", :with_stubbed_antivirus, typ
     fill_in "What is the name?", with: "Ingredient C non poisonous"
     fill_in "What is the CAS number?", with: "123456-78-9"
     page.choose("No")
-    page.choose("Above 25% w/w up to 50% w/w")
+    page.choose("greater_than_25_less_than_50_percent")
 
     click_on "Save and continue"
     answer_add_another_ingredient_with("No", success_banner: false)

--- a/cosmetics-web/spec/features/submit/responsible_person/notifications_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/notifications_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Viewing a notification", type: :feature do
+  let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+  let(:single_shade_notification) { create(:notification, responsible_person:) }
+  let(:single_shade_component) { create(:exact_component, :completed, :with_exact_ingredients, notification: single_shade_notification) }
+  let(:multi_shade_notification) { create(:notification, responsible_person:) }
+  let(:multi_shade_component) { create(:exact_component, :completed, :with_multiple_shades, notification: multi_shade_notification) }
+  let(:multi_shade_ingredient1) { create(:exact_ingredient, used_for_multiple_shades: true, component: multi_shade_component) }
+  let(:multi_shade_ingredient2) { create(:exact_ingredient, exact_concentration: 20, used_for_multiple_shades: false, component: multi_shade_component) }
+
+  before do
+    single_shade_component
+    multi_shade_ingredient1
+    multi_shade_ingredient2
+    sign_in_as_member_of_responsible_person(responsible_person)
+  end
+
+  context "when viewing a single shade notification with exact concentrations" do
+    let(:user) { responsible_person.responsible_person_users.first.user }
+
+    it "displays the ingredient concentrations" do
+      visit responsible_person_notification_path(responsible_person, single_shade_notification)
+
+      expect(body).to have_css("dd", text: /10.0%\u00A0w\/w/)
+      expect(body).not_to have_css("dd", text: /Maximum concentration: 10.0%\u00A0w\/w/)
+    end
+  end
+
+  context "when viewing a multi shade notification with exact concentrations" do
+    let(:user) { responsible_person.responsible_person_users.first.user }
+
+    it "displays the ingredient concentrations with prefix where applicable" do
+      visit responsible_person_notification_path(responsible_person, multi_shade_notification)
+
+      expect(body).to have_css("dd", text: /Maximum concentration: 10.0%\u00A0w\/w/)
+      expect(body).to have_css("dd", text: /20.0%\u00A0w\/w/)
+      expect(body).not_to have_css("dd", text: /Maximum concentration: 20.0%\u00A0w\/w/)
+    end
+  end
+end

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe Component, type: :model do
     end
 
     context "when exact formulation type is set again" do
-      let(:component) { create(:component, :with_exact_ingredients) }
+      let(:component) { create(:component, :with_exact_ingredient) }
 
       it "leaves the existing ingredients" do
         expect { component.update_formulation_type("exact") }
@@ -484,7 +484,7 @@ RSpec.describe Component, type: :model do
     end
 
     context "when changing from exact to range" do
-      let(:component) { create(:component, :with_exact_ingredients) }
+      let(:component) { create(:component, :with_exact_ingredient) }
 
       it "removes the ingredients formulas" do
         expect { component.update_formulation_type("range") }
@@ -581,7 +581,7 @@ RSpec.describe Component, type: :model do
     end
 
     it "returns false for an exact component with ingredients" do
-      component = create(:component, :with_exact_ingredients)
+      component = create(:component, :with_exact_ingredient)
       expect(component.missing_ingredients?).to eq(false)
     end
 
@@ -603,7 +603,7 @@ RSpec.describe Component, type: :model do
   end
 
   describe "#delete_ingredient!" do
-    let(:component) { create(:exact_component, :completed, :with_exact_ingredients) }
+    let(:component) { create(:exact_component, :completed, :with_exact_ingredient) }
 
     it "returns false when the ingredient does not belong to the component" do
       ingredient = create(:range_ingredient)

--- a/cosmetics-web/spec/services/notification_cloner/base_spec.rb
+++ b/cosmetics-web/spec/services/notification_cloner/base_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NotificationCloner::Base do
   let(:component1) { create(:ranges_component, :completed, :with_range_ingredients, notification:) }
 
   before do
-    create(:exact_component, :completed, :with_exact_ingredients, notification:)
+    create(:exact_component, :completed, :with_exact_ingredient, notification:)
     create(:cmr, component: component1)
 
     component1.nano_materials << nanomaterial1


### PR DESCRIPTION
JIRA tickets: https://regulatorydelivery.atlassian.net/browse/COSBETA-1745 and https://regulatorydelivery.atlassian.net/browse/COSBETA-1682

## Description

Allows users to enter a maximum concentration for an ingredient that is used for multiple shades of a product.

## Review apps

https://cosmetics-pr-2819-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2819-search-web.london.cloudapps.digital/