### PR TITLE
Fix cloning of notifications with multiple shades

### DIFF
--- a/cosmetics-web/db/migrate/20230309111036_backfill_used_for_multiple_shades_for_ingredients.rb
+++ b/cosmetics-web/db/migrate/20230309111036_backfill_used_for_multiple_shades_for_ingredients.rb
@@ -1,0 +1,19 @@
+class BackfillUsedForMultipleShadesForIngredients < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    affected_ingredients = Ingredient.joins(:component)
+      .where.not(exact_concentration: nil)
+      .where(used_for_multiple_shades: nil)
+      .where.not(component: { shades: [nil] })
+      .where.not(component: { shades: [""] })
+    affected_ingredients.in_batches do |ingredients|
+      ingredients.update_all(used_for_multiple_shades: false)
+      sleep(0.01) # throttle
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_03_111821) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_09_111036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1856

## Description

Backfills all existing ingredients with exact concentrations to denote that they do not apply across multiple shades by default.

## Review apps

https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/