### PR TITLE
Fix HTML tags in “skip NPIS tables” link

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_add_ingredient_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_add_ingredient_concentration.html.erb
@@ -28,7 +28,7 @@
       <li>Confirm if the ingredient is listed in the National Poisons Information Service (<abbr>NPIS</abbr>) tables and if it is an ingredient the <abbr>NPIS</abbr> needs to know about</li>
     </ul>
 
-    <%= link_to "Skip <abbr>NPIS</abbr> tables.", "#skip-to-form", class: "govuk-skip-link opss-skip-link" %>
+    <%= link_to "Skip <abbr>NPIS</abbr> tables.".html_safe, "#skip-to-form", class: "govuk-skip-link opss-skip-link" %>
 
     <%= govukDetails(summaryText: "Show the <abbr>NPIS</abbr> tables".html_safe, classes: "govuk-!-margin-left-0") do %>
       <%= render "npis_tables" %>


### PR DESCRIPTION
## Description

Fixes the <abbr> HTML tag to not be rendered in the “skip NPIS tables” link.

## Review apps

https://cosmetics-pr-2831-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2831-search-web.london.cloudapps.digital/