### PR TITLE
Fix ingredient used for multiple shades validation issue

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
@@ -23,7 +23,7 @@ module ResponsiblePersons::Notifications
     validates :poisonous, inclusion: { in: [true, false] }, if: :range?
     validates :name, presence: true, length: { maximum: NAME_LENGTH_LIMIT }, ingredient_name_format: { message: :invalid }
     validate :unique_name
-    validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { component.multi_shade? }
+    validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { exact? && component&.multi_shade? }
     validates :exact_concentration,
               presence: true,
               numericality: { allow_blank: true, greater_than: 0, less_than_or_equal_to: 100 },

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -247,6 +247,10 @@ class Component < ApplicationRecord
     end
   end
 
+  def multi_shade?
+    !!shades&.compact&.reject(&:blank?)&.any? # Double negated to return a boolean instead of nil
+  end
+
 private
 
   # This takes any value and returns nil if the value

--- a/cosmetics-web/app/models/ingredient.rb
+++ b/cosmetics-web/app/models/ingredient.rb
@@ -46,7 +46,7 @@ class Ingredient < ApplicationRecord
   validates :inci_name, presence: true, ingredient_name_format: { message: :invalid }
   validates :inci_name, uniqueness: { scope: :component_id }, if: :validate_inci_name_uniqueness?
 
-  validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: :multi_shade?
+  validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { component.multi_shade? }
 
   # Exact and range concentration invalidate each other.
   validates :range_concentration, absence: true, if: -> { exact_concentration.present? }
@@ -96,9 +96,5 @@ private
         component.notification_type != "exact"
       errors.add(:exact_concentration, :non_poisonous_wrong_component_type)
     end
-  end
-
-  def multi_shade?
-    component&.shades&.compact&.uniq&.any?
   end
 end

--- a/cosmetics-web/app/models/ingredient.rb
+++ b/cosmetics-web/app/models/ingredient.rb
@@ -46,7 +46,7 @@ class Ingredient < ApplicationRecord
   validates :inci_name, presence: true, ingredient_name_format: { message: :invalid }
   validates :inci_name, uniqueness: { scope: :component_id }, if: :validate_inci_name_uniqueness?
 
-  validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { component.multi_shade? }
+  validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { component&.multi_shade? && exact_concentration.present? }
 
   # Exact and range concentration invalidate each other.
   validates :range_concentration, absence: true, if: -> { exact_concentration.present? }

--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -43,6 +43,19 @@ FactoryBot.define do
           }
         end
       end
+
+      trait :with_multiple_shades do
+        routing_questions_answers do
+          {
+            "contains_cmrs" => "no",
+            "number_of_shades" => "multiple-shades-same-notification",
+            "select_formulation_type" => "range",
+            "contains_special_applicator" => "no",
+            "contains_poisonous_ingredients" => "true",
+          }
+        end
+        shades { %w[Black White] }
+      end
     end
 
     factory :exact_component do

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/ingredient_concentration_form_spec.rb
@@ -457,6 +457,66 @@ RSpec.describe ResponsiblePersons::Notifications::IngredientConcentrationForm do
         include_examples "name taken validations"
       end
     end
+
+    describe "used for multiple shades validation" do
+      context "with an 'range' type" do
+        let(:component) { build_stubbed(:ranges_component, :with_multiple_shades) }
+        let(:range_concentration) { "greater_than_10_less_than_25_percent" }
+
+        before do
+          form.type = "range"
+        end
+
+        it "is valid when it is used for multiple shades" do
+          form.used_for_multiple_shades = true
+          expect(form).to be_valid
+        end
+
+        it "is valid when it is not used for multiple shades" do
+          form.used_for_multiple_shades = false
+          expect(form).to be_valid
+        end
+
+        it "is valid when not specifying if it is used for multiple shades" do
+          form.used_for_multiple_shades = nil
+          expect(form).to be_valid
+        end
+      end
+
+      context "with an 'exact' type" do
+        let(:component) { build_stubbed(:exact_component, :with_multiple_shades) }
+        let(:maximum_concentration) { "4.2" }
+
+        before do
+          form.type = "exact"
+        end
+
+        it "is valid when it is used for multiple shades" do
+          form.used_for_multiple_shades = true
+          expect(form).to be_valid
+        end
+
+        it "is valid when it is not used for multiple shades" do
+          form.used_for_multiple_shades = false
+          expect(form).to be_valid
+        end
+
+        it "is not valid when not specifying if the ingredient is used for multiple shades" do
+          form.used_for_multiple_shades = nil
+          expect(form).not_to be_valid
+          expect(form.errors[:used_for_multiple_shades]).to eq(["Select yes if the ingredient is used for different shades"])
+        end
+
+        context "when the component is not multi-shade" do
+          let(:component) { build_stubbed(:exact_component) }
+
+          it "is valid when not specifying if the ingredient is used for multiple shades" do
+            form.used_for_multiple_shades = nil
+            expect(form).to be_valid
+          end
+        end
+      end
+    end
   end
 
   describe "#range?" do

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -631,4 +631,36 @@ RSpec.describe Component, type: :model do
         .and not_change(component, :state)
     end
   end
+
+  describe "#multi_shade?" do
+    it "returns false for a component without shades" do
+      component = build_stubbed(:component, shades: nil)
+      expect(component.multi_shade?).to eq(false)
+    end
+
+    it "returns false for a component with an empty array of shades" do
+      component = build_stubbed(:component, shades: [])
+      expect(component.multi_shade?).to eq(false)
+    end
+
+    it "returns false for a component with an array with blank shades" do
+      component = build_stubbed(:component, shades: [" ", ""])
+      expect(component.multi_shade?).to eq(false)
+    end
+
+    it "returns true for a component with one shade" do
+      component = build_stubbed(:component, shades: %w[blue])
+      expect(component.multi_shade?).to eq(true)
+    end
+
+    it "returns true for a component with multiple shades" do
+      component = build_stubbed(:component, shades: %w[blue yellow])
+      expect(component.multi_shade?).to eq(true)
+    end
+
+    it "returns true for a component with multiple shades and blank shades" do
+      component = build_stubbed(:component, shades: %w[blue yellow ""])
+      expect(component.multi_shade?).to eq(true)
+    end
+  end
 end

--- a/cosmetics-web/spec/models/ingredient_spec.rb
+++ b/cosmetics-web/spec/models/ingredient_spec.rb
@@ -146,6 +146,56 @@ RSpec.describe Ingredient, type: :model do
         expect(ingredient).to be_valid
       end
     end
+
+    describe "used for multiple shades validation" do
+      context "with a range ingredient" do
+        let(:component) { build_stubbed(:ranges_component, :with_multiple_shades) }
+
+        it "is valid when the ingredient is used for multiple shades" do
+          ingredient = build_stubbed(:range_ingredient, component:, used_for_multiple_shades: true)
+          expect(ingredient).to be_valid
+        end
+
+        it "is valid when the ingredient is not used for multiple shades" do
+          ingredient = build_stubbed(:range_ingredient, component:, used_for_multiple_shades: false)
+          expect(ingredient).to be_valid
+        end
+
+        it "is valid when not specifying if the ingredient is used for multiple shades" do
+          ingredient = build_stubbed(:range_ingredient, component:, used_for_multiple_shades: nil)
+          expect(ingredient).to be_valid
+        end
+      end
+
+      context "with an exact ingredient" do
+        let(:component) { build_stubbed(:exact_component, :with_multiple_shades) }
+
+        it "is valid when the ingredient is used for multiple shades" do
+          ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: true)
+          expect(ingredient).to be_valid
+        end
+
+        it "is valid when the ingredient is not used for multiple shades" do
+          ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: false)
+          expect(ingredient).to be_valid
+        end
+
+        it "is not valid when not specifying if the ingredient is used for multiple shades" do
+          ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: nil)
+          expect(ingredient).not_to be_valid
+          expect(ingredient.errors[:used_for_multiple_shades]).to eq(["Used for multiple shades is not included in the list"])
+        end
+
+        context "when the component is not multi-shade" do
+          let(:component) { build_stubbed(:exact_component) }
+
+          it "is valid when not specifying if the ingredient is used for multiple shades" do
+            ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: nil)
+            expect(ingredient).to be_valid
+          end
+        end
+      end
+    end
   end
 
   describe ".unique_names_by_created_last" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1858)

#### Problem:
For multi-shaded components/products, when selecting ingredient range concentration ingredients, the ingredients cannot be added due to a validation that can only be fulfilled by the exact ingredients.
This blocks the submission of range ingredients on multi-shaded components.

#### Solution: Only validate "used_for_multiple_shades" for exact ingredients.

The form does not display the selector for this value when filling a range concentration ingredient.

The validation was blocking the form from being submitted with range concentration ingredients.

In the same way, the model validation blocked cloning notifications with range ingredients, since the
"used_for_multiple_shades" isn't filled for those and fails validation for the new records.

Solution: Make the validation optional, as we do not want the value being set for range ingredients.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2833-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2833-search-web.london.cloudapps.digital/
