### PR TITLE
Bugfix: Allow poisonous range ingredients for multi-shade components without "used for multiple shades" value

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/ingredient_concentration_form.rb
@@ -23,7 +23,7 @@ module ResponsiblePersons::Notifications
     validates :poisonous, inclusion: { in: [true, false] }, if: :range?
     validates :name, presence: true, length: { maximum: NAME_LENGTH_LIMIT }, ingredient_name_format: { message: :invalid }
     validate :unique_name
-    validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { exact? && component&.multi_shade? }
+    validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { used_for_multiple_shades_required? }
     validates :exact_concentration,
               presence: true,
               numericality: { allow_blank: true, greater_than: 0, less_than_or_equal_to: 100 },
@@ -102,6 +102,11 @@ module ResponsiblePersons::Notifications
       if Ingredient.where(component_id: component, inci_name: name).where.not(id: updating_ingredient).any?
         errors.add(:name, :taken, entity: component.notification.is_multicomponent? ? "item" : "product")
       end
+    end
+
+    # TODO: Fix form so poisonous range ingredients require used_for_multiple_shades field too.
+    def used_for_multiple_shades_required?
+      exact? && component && component.multi_shade? && !component.range?
     end
   end
 end

--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -251,6 +251,10 @@ class Component < ApplicationRecord
     !!shades&.compact&.reject(&:blank?)&.any? # Double negated to return a boolean instead of nil
   end
 
+  def range?
+    notification_type == "range"
+  end
+
 private
 
   # This takes any value and returns nil if the value

--- a/cosmetics-web/app/models/ingredient.rb
+++ b/cosmetics-web/app/models/ingredient.rb
@@ -46,7 +46,7 @@ class Ingredient < ApplicationRecord
   validates :inci_name, presence: true, ingredient_name_format: { message: :invalid }
   validates :inci_name, uniqueness: { scope: :component_id }, if: :validate_inci_name_uniqueness?
 
-  validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { component&.multi_shade? && exact_concentration.present? }
+  validates :used_for_multiple_shades, inclusion: { in: [true, false] }, if: -> { used_for_multiple_shades_required? }
 
   # Exact and range concentration invalidate each other.
   validates :range_concentration, absence: true, if: -> { exact_concentration.present? }
@@ -96,5 +96,10 @@ private
         component.notification_type != "exact"
       errors.add(:exact_concentration, :non_poisonous_wrong_component_type)
     end
+  end
+
+  # TODO: Fix form so poisonous range ingredients require used_for_multiple_shades field too.
+  def used_for_multiple_shades_required?
+    exact_concentration.present? && component && component.multi_shade? && !component.range?
   end
 end

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
@@ -14,130 +14,269 @@ RSpec.describe "Adding ingredients to components", :with_stubbed_antivirus, type
     expect_product_details_task_not_started
 
     click_link "Product details"
-    answer_is_item_available_in_shades_with "No"
-    answer_what_is_physical_form_of_item_with "Liquid"
-    answer_what_is_product_contained_in_with "A typical non-pressurised bottle, jar, sachet or other package"
-    answer_does_item_contain_cmrs_with "No"
-    answer_item_category_with "Hair and scalp products"
-    answer_item_subcategory_with "Hair and scalp care and cleansing products"
-    answer_item_sub_subcategory_with "Shampoo"
   end
 
-  scenario "Adding exact concentration ingredients to a product" do
-    answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
-    expect_to_be_on_add_ingredients_page
+  context "when the item is not available in multiple shades" do
+    before do
+      answer_is_item_available_in_shades_with "No"
+      answer_what_is_physical_form_of_item_with "Liquid"
+      answer_what_is_product_contained_in_with "A typical non-pressurised bottle, jar, sachet or other package"
+      answer_does_item_contain_cmrs_with "No"
+      answer_item_category_with "Hair and scalp products"
+      answer_item_subcategory_with "Hair and scalp care and cleansing products"
+      answer_item_sub_subcategory_with "Shampoo"
+    end
 
-    # First attempt with validation errors
-    click_on "Save and continue"
+    scenario "Adding exact concentration ingredients to a product" do
+      answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
+      expect_to_be_on_add_ingredients_page
 
-    expect_to_be_on_add_ingredients_page
-    expect_form_to_have_errors(name: { message: "Enter a name", id: "name" },
-                               exact_concentration: { message: "Enter the concentration", id: "exact_concentration" })
+      # First attempt with validation errors
+      click_on "Save and continue"
 
-    # Successfully adds the first ingredient
-    fill_in "name", with: "FooBar ingredient"
-    fill_in "exact_concentration", with: "10.1"
-    fill_in "cas_number", with: "123456-78-9"
-    click_on "Save and continue"
+      expect_to_be_on_add_ingredients_page
+      expect_form_to_have_errors(name: { message: "Enter a name", id: "name" },
+                                 exact_concentration: { message: "Enter the concentration", id: "exact_concentration" })
 
-    answer_add_another_ingredient_with "Yes"
+      # Successfully adds the first ingredient
+      fill_in "name", with: "FooBar ingredient"
+      fill_in "exact_concentration", with: "10.1"
+      fill_in "cas_number", with: "123456-78-9"
+      click_on "Save and continue"
 
-    expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
+      answer_add_another_ingredient_with "Yes"
 
-    # Attempts to add the same ingredient again
-    fill_in "name", with: "foobar ingredient"
-    fill_in "exact_concentration", with: "2.0"
-    click_on "Save and continue"
+      expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
 
-    expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
-    expect_form_to_have_errors(name: { message: "Enter a name which is unique to this product", id: "name" })
+      # Attempts to add the same ingredient again
+      fill_in "name", with: "foobar ingredient"
+      fill_in "exact_concentration", with: "2.0"
+      click_on "Save and continue"
 
-    # Adds a new poisonous ingredient
-    fill_in "name", with: "newfoo poisonous"
-    check "Is it listed in the NPIS tables and does the NPIS need to know about it?"
-    fill_in "exact_concentration", with: "7.0"
-    click_on "Save and continue"
+      expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
+      expect_form_to_have_errors(name: { message: "Enter a name which is unique to this product", id: "name" })
 
-    answer_add_another_ingredient_with "Yes"
+      # Adds a new poisonous ingredient
+      fill_in "name", with: "newfoo poisonous"
+      check "Is it listed in the NPIS tables and does the NPIS need to know about it?"
+      fill_in "exact_concentration", with: "7.0"
+      click_on "Save and continue"
 
-    expect_to_be_on_add_ingredients_page(ingredient_number: 3, already_added: ["FooBar ingredient", "newfoo poisonous"])
+      answer_add_another_ingredient_with "Yes"
 
-    # Skips adding the ingredient
-    click_link "Skip"
-    expect_to_be_on__what_is_ph_range_of_product_page
+      expect_to_be_on_add_ingredients_page(ingredient_number: 3, already_added: ["FooBar ingredient", "newfoo poisonous"])
+
+      # Skips adding the ingredient
+      click_link "Skip"
+      expect_to_be_on__what_is_ph_range_of_product_page
+    end
+
+    scenario "Adding range concentration ingredients to a product" do
+      answer_how_do_you_want_to_give_formulation_with "List ingredients and their concentration range"
+
+      expect_to_be_on_add_ingredients_page
+
+      # First attempt failing due not indicating if ingredient is poisonous
+      fill_in "name", with: "FooBar ingredient"
+      click_on "Save and continue"
+
+      expect_to_be_on_add_ingredients_page
+      expect_form_to_have_errors(poisonous_true: {
+        message: "Select yes if the ingredient is poisonous",
+        id: "ingredient_concentration_form_poisonous",
+      })
+
+      # Second attempt failing due to not selecting a concentration range for a non poisonous ingredient
+      page.choose "No"
+      click_on "Save and continue"
+
+      expect_to_be_on_add_ingredients_page
+      expect_form_to_have_errors(greater_than_75_less_than_100_percent: {
+        message: "Select a concentration range",
+        id: "ingredient_concentration_form_range_concentration",
+      })
+
+      # Successfully adding the first ingredient by its concentration range
+      page.choose("greater_than_5_less_than_10_percent")
+      click_on "Save and continue"
+
+      answer_add_another_ingredient_with "Yes"
+      expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
+
+      # Attempt to add a poisonous ingredient with wrong value for concentration
+      fill_in "name", with: "New ingredient"
+      page.choose "Yes"
+      fill_in "exact_concentration", with: "Not Valid"
+      click_on "Save and continue"
+
+      expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
+      expect_form_to_have_errors(exact_concentration: { message: "Enter a number for the concentration", id: "exact_concentration" })
+
+      # Adds the second ingredient after entering a valid exact concentration
+      fill_in "exact_concentration", with: "5.2"
+      click_on "Save and continue"
+
+      answer_add_another_ingredient_with("No")
+      expect_to_be_on__what_is_ph_range_of_product_page
+    end
+
+    scenario "Adding poisonous ingredients for a product with predefined formulation" do
+      answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
+
+      expect_to_be_on__frame_formulation_select_page
+      answer_select_formulation_with "Shampoo plus conditioner"
+
+      answer_contains_ingredients_npis_needs_to_know_about_with("Yes")
+      expect_to_be_on_add_ingredients_page(forced_poisonous: true)
+
+      # First attempt with validation errors
+      click_on "Save and continue"
+      expect(page).to have_css("h1", text: "Add an ingredient the NPIS needs to know about")
+      expect_form_to_have_errors(name: { message: "Enter a name", id: "name" },
+                                 exact_concentration: { message: "Enter the concentration", id: "exact_concentration" })
+
+      # Successfully adds the first ingredient
+      fill_in "name", with: "FooBar ingredient"
+      fill_in "exact_concentration", with: "10.1"
+      fill_in "cas_number", with: "123456-78-9"
+      click_on "Save and continue"
+
+      answer_add_another_ingredient_with "No"
+      expect_to_be_on__what_is_ph_range_of_product_page
+    end
   end
 
-  scenario "Adding range concentration ingredients to a product" do
-    answer_how_do_you_want_to_give_formulation_with "List ingredients and their concentration range"
+  context "when the item is available in multiple shades" do
+    before do
+      answer_is_item_available_in_shades_with "Yes"
+      all("input#component_shades").first.fill_in with: "Blue"
+      all("input#component_shades").last.fill_in with: "Red"
+      click_button "Continue"
 
-    expect_to_be_on_add_ingredients_page
+      answer_what_is_physical_form_of_item_with "Liquid"
+      answer_what_is_product_contained_in_with "A typical non-pressurised bottle, jar, sachet or other package"
+      answer_does_item_contain_cmrs_with "No"
+      answer_item_category_with "Hair and scalp products"
+      answer_item_subcategory_with "Hair and scalp care and cleansing products"
+      answer_item_sub_subcategory_with "Shampoo"
+    end
 
-    # First attempt failing due not indicating if ingredient is poisonous
-    fill_in "name", with: "FooBar ingredient"
-    click_on "Save and continue"
+    scenario "Adding exact concentration ingredients to a product" do
+      answer_how_do_you_want_to_give_formulation_with "List ingredients and their exact concentration"
+      expect_to_be_on_add_ingredients_page
 
-    expect_to_be_on_add_ingredients_page
-    expect_form_to_have_errors(poisonous_true: {
-      message: "Select yes if the ingredient is poisonous",
-      id: "ingredient_concentration_form_poisonous",
-    })
+      # First attempt without answering if the ingredient is used for multiple shades
+      fill_in "name", with: "non-poisonous multi"
+      click_on "Save and continue"
 
-    # Second attempt failing due to not selecting a concentration range for a non poisonous ingredient
-    page.choose "No"
-    click_on "Save and continue"
+      expect_to_be_on_add_ingredients_page
+      expect_form_to_have_errors(used_for_multiple_shades_true: {
+        message: "Select yes if the ingredient is used for different shades",
+        id: "ingredient_concentration_form_used_for_multiple_shades",
+      })
 
-    expect_to_be_on_add_ingredients_page
-    expect_form_to_have_errors(greater_than_75_less_than_100_percent: {
-      message: "Select a concentration range",
-      id: "ingredient_concentration_form_range_concentration",
-    })
+      # Selecting the ingredient is used for multiple shades but not filling the max concentration field
+      choose "Yes"
+      click_on "Save and continue"
+      expect_form_to_have_errors(maximum_concentration: { message: "Enter the concentration", id: "maximum_concentration" })
 
-    # Successfully adding the first ingredient by its concentration range
-    page.choose("greater_than_5_less_than_10_percent")
-    click_on "Save and continue"
+      # Adds a non poisonous ingredient used for multiple shades
+      fill_in "maximum_concentration", with: "10.1"
+      fill_in "cas_number", with: "123456-78-9"
+      click_on "Save and continue"
 
-    answer_add_another_ingredient_with "Yes"
-    expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
+      answer_add_another_ingredient_with "Yes"
+      expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["non-poisonous multi"])
 
-    # Attempt to add a poisonous ingredient with wrong value for concentration
-    fill_in "name", with: "New ingredient"
-    page.choose "Yes"
-    fill_in "exact_concentration", with: "Not Valid"
-    click_on "Save and continue"
+      # Adds a poisonous ingredient used for multiple shades
+      fill_in "name", with: "poisonous multi"
+      check "Is it listed in the NPIS tables and does the NPIS need to know about it?"
+      choose "Yes"
+      fill_in "maximum_concentration", with: "7.0"
+      click_on "Save and continue"
 
-    expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: ["FooBar ingredient"])
-    expect_form_to_have_errors(exact_concentration: { message: "Enter a number for the concentration", id: "exact_concentration" })
+      answer_add_another_ingredient_with "Yes"
+      expect_to_be_on_add_ingredients_page(ingredient_number: 3, already_added: ["non-poisonous multi", "poisonous multi"])
 
-    # Adds the second ingredient after entering a valid exact concentration
-    fill_in "exact_concentration", with: "5.2"
-    click_on "Save and continue"
+      # Adds a non poisonous ingredient not used for multiple shades
+      fill_in "name", with: "non-poisonous no-multi"
+      choose "No"
+      fill_in "exact_concentration", with: "2.3"
+      click_on "Save and continue"
 
-    answer_add_another_ingredient_with("No")
-    expect_to_be_on__what_is_ph_range_of_product_page
-  end
+      answer_add_another_ingredient_with "Yes"
+      expect_to_be_on_add_ingredients_page(
+        ingredient_number: 4, already_added: ["non-poisonous multi", "poisonous multi", "non-poisonous no-multi"],
+      )
 
-  scenario "Adding poisonous ingredients for a product with predefined formulation" do
-    answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
+      # Adds a poisonous ingredient not used for multiple shades
+      fill_in "name", with: "poisonous no-multi"
+      check "Is it listed in the NPIS tables and does the NPIS need to know about it?"
+      choose "No"
+      fill_in "exact_concentration", with: "3.1"
+      click_on "Save and continue"
 
-    expect_to_be_on__frame_formulation_select_page
-    answer_select_formulation_with "Shampoo plus conditioner"
+      answer_add_another_ingredient_with "Yes"
+      expect_to_be_on_add_ingredients_page(
+        ingredient_number: 5,
+        already_added: ["non-poisonous multi", "poisonous multi", "non-poisonous no-multi", "poisonous no-multi"],
+      )
+      # Skips adding the ingredient
+      click_link "Skip"
+      expect_to_be_on__what_is_ph_range_of_product_page
+    end
 
-    answer_contains_ingredients_npis_needs_to_know_about_with("Yes")
-    expect_to_be_on_add_ingredients_page(forced_poisonous: true)
+    scenario "Adding range concentration ingredients to a product" do
+      answer_how_do_you_want_to_give_formulation_with "List ingredients and their concentration range"
 
-    # First attempt with validation errors
-    click_on "Save and continue"
-    expect(page).to have_css("h1", text: "Add an ingredient the NPIS needs to know about")
-    expect_form_to_have_errors(name: { message: "Enter a name", id: "name" },
-                               exact_concentration: { message: "Enter the concentration", id: "exact_concentration" })
+      expect_to_be_on_add_ingredients_page
 
-    # Successfully adds the first ingredient
-    fill_in "name", with: "FooBar ingredient"
-    fill_in "exact_concentration", with: "10.1"
-    fill_in "cas_number", with: "123456-78-9"
-    click_on "Save and continue"
+      # Adding a non-poisonous ingredient
+      fill_in "name", with: "non-poisonous"
+      page.choose "No"
+      page.choose("greater_than_5_less_than_10_percent")
+      click_on "Save and continue"
 
-    answer_add_another_ingredient_with "No"
-    expect_to_be_on__what_is_ph_range_of_product_page
+      answer_add_another_ingredient_with "Yes"
+      expect_to_be_on_add_ingredients_page(ingredient_number: 2, already_added: %w[non-poisonous])
+
+      # Adding a poisonous ingredient
+      fill_in "name", with: "poisonous"
+      page.choose "Yes"
+      fill_in "exact_concentration", with: "5.2"
+      click_on "Save and continue"
+
+      answer_add_another_ingredient_with("No")
+      expect_to_be_on__what_is_ph_range_of_product_page
+    end
+
+    scenario "Adding poisonous ingredients for a product with predefined formulation" do
+      answer_how_do_you_want_to_give_formulation_with "Choose a predefined frame formulation"
+
+      expect_to_be_on__frame_formulation_select_page
+      answer_select_formulation_with "Shampoo plus conditioner"
+
+      answer_contains_ingredients_npis_needs_to_know_about_with("Yes")
+      expect_to_be_on_add_ingredients_page(forced_poisonous: true)
+
+      # Adds a poisonous ingredient used for multiple shades
+      fill_in "name", with: "poisonous multi"
+      choose "Yes"
+      fill_in "maximum_concentration", with: "7.0"
+      click_on "Save and continue"
+
+      answer_add_another_ingredient_with "Yes"
+      expect_to_be_on_add_ingredients_page(forced_poisonous: true, ingredient_number: 2, already_added: ["poisonous multi"])
+
+      # Adds a poisonous ingredient not used for multiple shades
+      fill_in "name", with: "poisonous no-multi"
+      choose "No"
+      fill_in "exact_concentration", with: "10.1"
+      fill_in "cas_number", with: "123456-78-9"
+      click_on "Save and continue"
+
+      answer_add_another_ingredient_with "No"
+      expect_to_be_on__what_is_ph_range_of_product_page
+    end
   end
 end

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -663,4 +663,26 @@ RSpec.describe Component, type: :model do
       expect(component.multi_shade?).to eq(true)
     end
   end
+
+  describe "#range?" do
+    it "is false for component without notification type" do
+      component = build_stubbed(:component, notification_type: nil)
+      expect(component.range?).to eq(false)
+    end
+
+    it "is false for component with exact notification type" do
+      component = build_stubbed(:component, notification_type: "exact")
+      expect(component.range?).to eq(false)
+    end
+
+    it "is false for component with predefined notification type" do
+      component = build_stubbed(:component, notification_type: "predefined")
+      expect(component.range?).to eq(false)
+    end
+
+    it "is true for component with range notification type" do
+      component = build_stubbed(:component, notification_type: "range")
+      expect(component.range?).to eq(true)
+    end
+  end
 end

--- a/cosmetics-web/spec/models/ingredient_spec.rb
+++ b/cosmetics-web/spec/models/ingredient_spec.rb
@@ -148,51 +148,91 @@ RSpec.describe Ingredient, type: :model do
     end
 
     describe "used for multiple shades validation" do
-      context "with a range ingredient" do
-        let(:component) { build_stubbed(:ranges_component, :with_multiple_shades) }
+      RSpec.shared_examples "valid with a value" do
+        context "when the ingredient is used for multiple shades" do
+          let(:used_for_multiple_shades) { true }
 
-        it "is valid when the ingredient is used for multiple shades" do
-          ingredient = build_stubbed(:range_ingredient, component:, used_for_multiple_shades: true)
-          expect(ingredient).to be_valid
+          it { expect(ingredient).to be_valid }
         end
 
-        it "is valid when the ingredient is not used for multiple shades" do
-          ingredient = build_stubbed(:range_ingredient, component:, used_for_multiple_shades: false)
-          expect(ingredient).to be_valid
-        end
+        context "when the ingredient is not used for multiple shades" do
+          let(:used_for_multiple_shades) { false }
 
-        it "is valid when not specifying if the ingredient is used for multiple shades" do
-          ingredient = build_stubbed(:range_ingredient, component:, used_for_multiple_shades: nil)
-          expect(ingredient).to be_valid
+          it { expect(ingredient).to be_valid }
         end
       end
 
+      RSpec.shared_examples "valid without a value" do
+        context "when not specifying if the ingredient is used for multiple shades" do
+          let(:used_for_multiple_shades) { nil }
+
+          it { expect(ingredient).to be_valid }
+        end
+      end
+
+      RSpec.shared_examples "invalid without a value" do
+        context "when not specifying if the ingredient is used for multiple shades" do
+          let(:used_for_multiple_shades) { nil }
+
+          it "is not valid" do
+            expect(ingredient).not_to be_valid
+            expect(ingredient.errors[:used_for_multiple_shades])
+              .to eq(["Used for multiple shades is not included in the list"])
+          end
+        end
+      end
+
+      context "with a range ingredient" do
+        let(:component) { build_stubbed(:ranges_component, :with_multiple_shades) }
+        let(:ingredient) { build_stubbed(:range_ingredient, component:, used_for_multiple_shades:) }
+
+        include_examples "valid with a value"
+        include_examples "valid without a value"
+      end
+
       context "with an exact ingredient" do
-        let(:component) { build_stubbed(:exact_component, :with_multiple_shades) }
+        let(:ingredient) { build_stubbed(:exact_ingredient, :poisonous, component:, used_for_multiple_shades:) }
 
-        it "is valid when the ingredient is used for multiple shades" do
-          ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: true)
-          expect(ingredient).to be_valid
+        context "with a multi-shade exact component" do
+          let(:component) { build_stubbed(:exact_component, :with_multiple_shades, notification_type: "exact") }
+
+          include_examples "valid with a value"
+          include_examples "invalid without a value"
         end
 
-        it "is valid when the ingredient is not used for multiple shades" do
-          ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: false)
-          expect(ingredient).to be_valid
+        context "with a multi-shade range component" do
+          let(:component) { build_stubbed(:exact_component, :with_multiple_shades, notification_type: "range") }
+
+          include_examples "valid with a value"
+          include_examples "valid without a value"
         end
 
-        it "is not valid when not specifying if the ingredient is used for multiple shades" do
-          ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: nil)
-          expect(ingredient).not_to be_valid
-          expect(ingredient.errors[:used_for_multiple_shades]).to eq(["Used for multiple shades is not included in the list"])
+        context "with a multi-shade predefined component" do
+          let(:component) { build_stubbed(:exact_component, :with_multiple_shades, notification_type: "predefined") }
+
+          include_examples "valid with a value"
+          include_examples "invalid without a value"
         end
 
-        context "when the component is not multi-shade" do
+        context "with a non multi-shade exact component" do
           let(:component) { build_stubbed(:exact_component) }
 
-          it "is valid when not specifying if the ingredient is used for multiple shades" do
-            ingredient = build_stubbed(:exact_ingredient, component:, used_for_multiple_shades: nil)
-            expect(ingredient).to be_valid
-          end
+          include_examples "valid with a value"
+          include_examples "valid without a value"
+        end
+
+        context "with a non multi-shade range component" do
+          let(:component) { build_stubbed(:ranges_component) }
+
+          include_examples "valid with a value"
+          include_examples "valid without a value"
+        end
+
+        context "with a non multi-shade predefined component" do
+          let(:component) { build_stubbed(:predefined_component) }
+
+          include_examples "valid with a value"
+          include_examples "valid without a value"
         end
       end
     end


### PR DESCRIPTION
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1861)

## Description

- Allows poisonous ingredients for a range multi-shaded component not to have a value for the "used for multiple shades" attribute.
- Covers with feature specs the different ingredient flows for multi-shaded notification components.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2835-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2835-search-web.london.cloudapps.digital/
