### PR TITLE
Disable notification archiving

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -64,7 +64,10 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
     @notification = Notification.completed.find_by!(reference_number: params[:notification_reference_number])
     authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
 
-    @notification.archive!
+    # TODO: Remove following redirection guard once we re-enable archiving
+    return redirect_to responsible_person_notifications_path(@notification.responsible_person)
+
+    @notification.archive! # rubocop:disable Lint/UnreachableCode
 
     flash[:success_banner] = {
       heading: "#{@notification.product_name} (#{@notification.reference_number_for_display}) has been archived.",
@@ -78,7 +81,10 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
     @notification = Notification.archived.find_by!(reference_number: params[:notification_reference_number])
     authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
 
-    @notification.unarchive!
+    # TODO: Remove following redirection guard once we re-enable archiving
+    return redirect_to responsible_person_notifications_path(@notification.responsible_person)
+
+    @notification.unarchive! # rubocop:disable Lint/UnreachableCode
 
     flash[:success_banner] = {
       heading: "#{@notification.product_name} (#{@notification.reference_number_for_display}) has been unarchived.",

--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -14,7 +14,10 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
   end
 
   def archived
-    @registered_notifications = get_registered_archived_notifications(20)
+    # TODO: Remove following redirection guard once we re-enable archiving
+    return redirect_to responsible_person_notifications_path(@responsible_person)
+
+    @registered_notifications = get_registered_archived_notifications(20) # rubocop:disable Lint/UnreachableCode
     respond_to do |format|
       format.html
       format.csv do

--- a/cosmetics-web/app/views/responsible_persons/notifications/_complete_notifications_table.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_complete_notifications_table.html.erb
@@ -1,4 +1,6 @@
-<table class="govuk-table govuk-!-margin-top-6 govuk-!-margin-bottom-0 opss-table opss-table--last-two-cols-right opss-table--first-col-normal">
+
+<table class="govuk-table govuk-!-margin-top-6 govuk-!-margin-bottom-0 opss-table opss-table--last-col-right opss-table--first-col-normal">
+<% # TODO: Replace table when re-enable archiving <table class="govuk-table govuk-!-margin-top-6 govuk-!-margin-bottom-0 opss-table opss-table--last-two-cols-right opss-table--first-col-normal"> %>
   <caption class="govuk-table__caption govuk-visually-hidden">List of notified products</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/cosmetics-web/app/views/responsible_persons/notifications/_complete_notifications_table.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_complete_notifications_table.html.erb
@@ -6,7 +6,9 @@
       <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
       <th scope="col" class="govuk-table__header"><abbr>UKCP</abbr> number</th>
       <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View</span></th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
+      <% if false # TODO: Enable when re-introducing archiving %>
+        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
+      <% end %>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -19,10 +21,12 @@
           <a href="<%= responsible_person_notification_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">View<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
           </a>
         </td>
-        <td class="govuk-table__cell">
-          <a href="<%= responsible_person_notification_archive_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">Archive<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
-          </a>
-        </td>
+        <% if false # TODO: Enable when re-introducing archiving %>
+          <td class="govuk-table__cell">
+            <a href="<%= responsible_person_notification_archive_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">Archive<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
+            </a>
+          </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>
@@ -33,7 +37,9 @@
         <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
         <th scope="col" class="govuk-table__header"><abbr>UKCP</abbr> number</th>
         <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View</span></th>
-        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
+        <% if false # TODO: Enable when re-introducing archiving %>
+          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
+        <% end %>
       </tr>
     </tfoot>
   <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/_notification_nav.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_notification_nav.html.erb
@@ -13,11 +13,13 @@
         Draft notifications
       </a>
     </li>
-    <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %> govuk-!-margin-bottom-6">
-      <a href="<%= responsible_person_archived_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %>>
-        Archived notifications
-      </a>
-    </li>
+    <% if false # TODO: Enable when re-introducing archiving %>
+      <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %> govuk-!-margin-bottom-6">
+        <a href="<%= responsible_person_archived_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %>>
+          Archived notifications
+        </a>
+      </li>
+    <% end %>
     <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/search_notifications" %>">
       <a href="<%= responsible_person_search_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/search_notifications" %>>
         Product - search

--- a/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
@@ -48,7 +48,7 @@
       <div class="govuk-grid-column-two-thirds">
         <% if @notification.archived? %>
           <%= govukButton(text: "Unarchive this notification", href: responsible_person_notification_unarchive_path(@responsible_person, @notification), classes: "govuk-button--secondary") %>
-        <% else %>
+        <% elsif false # TODO: Enable back to 'else' when re-introducing archiving %>
           <%= govukButton(text: "Archive this notification", href: responsible_person_notification_archive_path(@responsible_person, @notification), classes: "govuk-button--secondary") %>
         <% end %>
         <% if @notification.can_be_deleted? %>

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
-  describe "GET /archived-notifications" do
+  xdescribe "GET /archived-notifications" do
     it "assigns the correct Responsible Person" do
       get :archived, params: { responsible_person_id: responsible_person.id }
       expect(assigns(:responsible_person)).to eq(responsible_person)

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
-  describe "GET /archive" do
+  xdescribe "GET /archive" do
     let(:notification) { create(:registered_notification, responsible_person:) }
 
     it "archives the notification" do
@@ -172,7 +172,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
-  describe "GET /unarchive" do
+  xdescribe "GET /unarchive" do
     let(:archived_notification) { create(:registered_notification, :archived, responsible_person:) }
 
     it "unarchives the notification and redirects to the index page" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
Since the team discovered some unintended behaviours after release, we are disabling the archiving feature until we clarify/fix it.

- Disabled "Archived" page in the RP notifications index.
- Disabled link to archiving each notification from the RP notifications list.
- Disabled the button for archiving notifications in their individual pages.
- Disabled controller actions that archive/unarchive notifications.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2843-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2843-search-web.london.cloudapps.digital/
