### PR TITLE
Reintroduce notification archiving

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -14,10 +14,7 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
   end
 
   def archived
-    # TODO: Remove following redirection guard once we re-enable archiving
-    return redirect_to responsible_person_notifications_path(@responsible_person)
-
-    @registered_notifications = get_registered_archived_notifications(20) # rubocop:disable Lint/UnreachableCode
+    @registered_notifications = get_registered_archived_notifications(20)
     respond_to do |format|
       format.html
       format.csv do
@@ -67,10 +64,7 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
     @notification = Notification.completed.find_by!(reference_number: params[:notification_reference_number])
     authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
 
-    # TODO: Remove following redirection guard once we re-enable archiving
-    return redirect_to responsible_person_notifications_path(@notification.responsible_person)
-
-    @notification.archive! # rubocop:disable Lint/UnreachableCode
+    @notification.archive!
 
     flash[:success_banner] = {
       heading: "#{@notification.product_name} (#{@notification.reference_number_for_display}) has been archived.",
@@ -84,10 +78,7 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
     @notification = Notification.archived.find_by!(reference_number: params[:notification_reference_number])
     authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
 
-    # TODO: Remove following redirection guard once we re-enable archiving
-    return redirect_to responsible_person_notifications_path(@notification.responsible_person)
-
-    @notification.unarchive! # rubocop:disable Lint/UnreachableCode
+    @notification.unarchive!
 
     flash[:success_banner] = {
       heading: "#{@notification.product_name} (#{@notification.reference_number_for_display}) has been unarchived.",

--- a/cosmetics-web/app/views/responsible_persons/notifications/_complete_notifications_table.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_complete_notifications_table.html.erb
@@ -1,6 +1,4 @@
-
-<table class="govuk-table govuk-!-margin-top-6 govuk-!-margin-bottom-0 opss-table opss-table--last-col-right opss-table--first-col-normal">
-<% # TODO: Replace table when re-enable archiving <table class="govuk-table govuk-!-margin-top-6 govuk-!-margin-bottom-0 opss-table opss-table--last-two-cols-right opss-table--first-col-normal"> %>
+<table class="govuk-table govuk-!-margin-top-6 govuk-!-margin-bottom-0 opss-table opss-table--last-two-cols-right opss-table--first-col-normal">
   <caption class="govuk-table__caption govuk-visually-hidden">List of notified products</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
@@ -8,9 +6,7 @@
       <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
       <th scope="col" class="govuk-table__header"><abbr>UKCP</abbr> number</th>
       <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View</span></th>
-      <% if false # TODO: Enable when re-introducing archiving %>
-        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
-      <% end %>
+      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -23,12 +19,10 @@
           <a href="<%= responsible_person_notification_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">View<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
           </a>
         </td>
-        <% if false # TODO: Enable when re-introducing archiving %>
-          <td class="govuk-table__cell">
-            <a href="<%= responsible_person_notification_archive_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">Archive<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
-            </a>
-          </td>
-        <% end %>
+        <td class="govuk-table__cell">
+          <a href="<%= responsible_person_notification_archive_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">Archive<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
+          </a>
+        </td>
       </tr>
     <% end %>
   </tbody>
@@ -39,9 +33,7 @@
         <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
         <th scope="col" class="govuk-table__header"><abbr>UKCP</abbr> number</th>
         <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View</span></th>
-        <% if false # TODO: Enable when re-introducing archiving %>
-          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
-        <% end %>
+        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
       </tr>
     </tfoot>
   <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/_notification_nav.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_notification_nav.html.erb
@@ -13,13 +13,11 @@
         Draft notifications
       </a>
     </li>
-    <% if false # TODO: Enable when re-introducing archiving %>
-      <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %> govuk-!-margin-bottom-6">
-        <a href="<%= responsible_person_archived_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %>>
-          Archived notifications
-        </a>
-      </li>
-    <% end %>
+    <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %> govuk-!-margin-bottom-6">
+      <a href="<%= responsible_person_archived_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %>>
+        Archived notifications
+      </a>
+    </li>
     <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/search_notifications" %>">
       <a href="<%= responsible_person_search_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/search_notifications" %>>
         Product - search

--- a/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-top-4 govuk-!-margin-bottom-6">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds opss-desktop-min-height--xs">
+      <div class="govuk-grid-column-full opss-desktop-min-height--xs">
         <% notification_html = capture do %>
         <h3 class="govuk-notification-banner__heading">
           <%= flash[:success_banner]["heading"] %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
@@ -48,7 +48,7 @@
       <div class="govuk-grid-column-two-thirds">
         <% if @notification.archived? %>
           <%= govukButton(text: "Unarchive this notification", href: responsible_person_notification_unarchive_path(@responsible_person, @notification), classes: "govuk-button--secondary") %>
-        <% elsif false # TODO: Enable back to 'else' when re-introducing archiving %>
+        <% else %>
           <%= govukButton(text: "Archive this notification", href: responsible_person_notification_archive_path(@responsible_person, @notification), classes: "govuk-button--secondary") %>
         <% end %>
         <% if @notification.can_be_deleted? %>

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
-  xdescribe "GET /archived-notifications" do
+  describe "GET /archived-notifications" do
     it "assigns the correct Responsible Person" do
       get :archived, params: { responsible_person_id: responsible_person.id }
       expect(assigns(:responsible_person)).to eq(responsible_person)
@@ -157,7 +157,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
-  xdescribe "GET /archive" do
+  describe "GET /archive" do
     let(:notification) { create(:registered_notification, responsible_person:) }
 
     it "archives the notification" do
@@ -172,7 +172,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
-  xdescribe "GET /unarchive" do
+  describe "GET /unarchive" do
     let(:archived_notification) { create(:registered_notification, :archived, responsible_person:) }
 
     it "unarchives the notification and redirects to the index page" do

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     end
 
     factory :registered_notification, traits: [:registered]
+    factory :archived_notification, traits: %i[registered archived]
 
     trait :registered do
       state { NotificationStateConcern::NOTIFICATION_COMPLETE }

--- a/cosmetics-web/spec/features/submit/notifications_archiving_spec.rb
+++ b/cosmetics-web/spec/features/submit/notifications_archiving_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe "Notifications archiving", type: :feature do
+  let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+  let(:user) { responsible_person.responsible_person_users.first.user }
+  let(:notification) { create(:registered_notification, responsible_person:) }
+  let(:archived_notification) { create(:archived_notification, responsible_person:) }
+
+  before do
+    configure_requests_for_submit_domain
+    sign_in user
+  end
+
+  scenario "archiving a notification from the notifications dashboard" do
+    notification
+    visit "/responsible_persons/#{responsible_person.id}/notifications"
+    click_link("Archive #{notification.product_name}")
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css("h3", text: "#{notification.product_name} (#{notification.reference_number_for_display}) has been archived.")
+    end
+    expect(page).not_to have_link("View #{notification.product_name}")
+  end
+
+  scenario "archiving a notification from the notification page" do
+    notification
+    visit "/responsible_persons/#{responsible_person.id}/notifications"
+    click_link "View #{notification.product_name}"
+
+    expect(page).to have_h1("Notified product: #{notification.product_name}")
+    click_link "Archive this notification"
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css("h3", text: "#{notification.product_name} (#{notification.reference_number_for_display}) has been archived.")
+    end
+    expect(page).not_to have_link("View #{notification.product_name}")
+  end
+
+  scenario "unarchiving a notification from the notifications archive dashboard" do
+    travel_to Time.zone.local(2020, 1, 1, 12, 0, 0) do
+      archived_notification
+    end
+    visit "/responsible_persons/#{responsible_person.id}/archived-notifications"
+    click_link("Unarchive #{archived_notification.product_name}")
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css(
+        "h3",
+        text: "#{archived_notification.product_name} (#{archived_notification.reference_number_for_display}) has been unarchived.",
+      )
+    end
+    expect(page).to have_link("View #{archived_notification.product_name}")
+    # Notification can be archived again
+    expect(page).to have_link("Archive #{archived_notification.product_name}")
+    # Notification original 'UK notified' date is kept
+    title = page.find("th", text: archived_notification.product_name, exact_text: true)
+    expect(title).to have_sibling("td", text: "1 January 2020", exact_text: true)
+  end
+
+  scenario "unarchiving a notification from the notification page" do
+    travel_to Time.zone.local(2020, 1, 1, 12, 0, 0) do
+      archived_notification
+    end
+    visit "/responsible_persons/#{responsible_person.id}/archived-notifications"
+    click_link "View #{archived_notification.product_name}"
+
+    expect(page).to have_h1("Notified product: #{archived_notification.product_name} Archived")
+    click_link("Unarchive this notification")
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css(
+        "h3",
+        text: "#{archived_notification.product_name} (#{archived_notification.reference_number_for_display}) has been unarchived.",
+      )
+    end
+    expect(page).to have_link("View #{archived_notification.product_name}")
+    # Notification can be archived again
+    expect(page).to have_link("Archive #{archived_notification.product_name}")
+    # Notification original 'UK notified' date is kept
+    title = page.find("th", text: archived_notification.product_name, exact_text: true)
+    expect(title).to have_sibling("td", text: "1 January 2020", exact_text: true)
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->
Reintroduction of [notification archiving](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/pull/2836) after[ disabling it](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/pull/2843) due to issues with the notification completion date and possible desired further discussions about the flow.

Changes over the original flow:
- Keep the original "UK Notified" (`notification_complete_at) for the notification, even after archiving and unarchiving it. Disables notifications from being deleted after unarchived past 7 days from their original submission/completion.
- Modify confirmation banner width to fit the full page (https://regulatorydelivery.atlassian.net/browse/COSBETA-1865)

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2845-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2845-search-web.london.cloudapps.digital/
