### PR TITLE
Change default components count for multi item kits

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/product/single_or_multi_component_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/product/single_or_multi_component_form.rb
@@ -20,5 +20,13 @@ module ResponsiblePersons::Notifications::Product
     def multi_component?
       single_or_multi_component == MULTI
     end
+
+    def components_count
+      if multi_component?
+        super
+      else
+        1
+      end
+    end
   end
 end

--- a/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/single_or_multi_component.html.erb
@@ -39,9 +39,11 @@
           <%= govukInput(form: form,
                          key: :components_count,
                          id: "components_count",
+                         inputmode: "numeric",
+                         pattern: "[0-9]*",
                          classes: "govuk-input--width-3",
                          label: { text: "How many items does it contain?" },
-                         value: @notification.components_count > 0 ? @notification.components_count : '') %>
+                         value: [2, @notification.components_count].max) %>
         <% end %>
         <%= govukRadios(
               form: form,

--- a/cosmetics-web/spec/features/submit/notification_wizard/single_to_multi_item_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/single_to_multi_item_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature do
+  let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+  let(:user) { responsible_person.responsible_person_users.first.user }
+
+  before do
+    sign_in_as_member_of_responsible_person(responsible_person, user)
+  end
+
+  scenario "Notification changing from single to multi item" do
+    visit "/responsible_persons/#{responsible_person.id}/notifications"
+
+    click_on "Create a new product notification"
+
+    complete_product_wizard(name: "Product single to multi item")
+
+    expect_progress(1, 3)
+
+    complete_product_details
+
+    expect_progress(2, 3)
+
+    complete_product_wizard(name: "Product single to multi item", items_count: 3)
+
+    expect_progress(1, 4)
+
+    expect_multi_item_kit_task_not_started
+
+    complete_multi_item_kit_wizard
+
+    expect_progress(2, 4)
+
+    complete_item_wizard("Cream one", item_number: 1)
+
+    complete_item_wizard("Cream two", item_number: 2)
+
+    complete_item_wizard("Cream three", item_number: 3)
+
+    expect_progress(3, 4)
+
+    accept_and_submit_flow
+
+    expect_successful_submission
+  end
+end


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1857

## Description

Changes the default number of components for a multi item kit to “2” when:

* Creating a new multi item kit (current default: empty)
* Changing an existing draft of a single item kit to a multi item kit (current default: 1)
* Cloning an existing single item kit and changing to a multi item kit (current default: 1)

## Review apps

https://cosmetics-pr-2848-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2848-search-web.london.cloudapps.digital/