### PR TITLE
Remove date restriction from nanomaterials journey

### DIFF
--- a/cosmetics-web/app/models/nanomaterial_notification.rb
+++ b/cosmetics-web/app/models/nanomaterial_notification.rb
@@ -44,7 +44,7 @@ class NanomaterialNotification < ApplicationRecord
       date = nil
     end
 
-    self[:notified_to_eu_on] = date
+    self[:notified_to_eu_on] = eu_notified? ? date : nil
   end
 
   def submit!

--- a/cosmetics-web/app/models/nanomaterial_notification.rb
+++ b/cosmetics-web/app/models/nanomaterial_notification.rb
@@ -13,8 +13,6 @@ class NanomaterialNotification < ApplicationRecord
   validates :notified_to_eu_on, presence: true, on: :eu_notification, if: :eu_notified?
   validate :eu_notification_date_must_be_pre_brexit, on: :eu_notification, if: :eu_notified?
 
-  validate :eu_notification_date_is_nil, on: :eu_notification, if: :eu_not_notified?
-
   validate :eu_notification_date_is_real
 
   validate :pdf_file_attached, on: :upload_file
@@ -122,12 +120,6 @@ private
       end
 
       errors.add(:notified_to_eu_on, error_message)
-    end
-  end
-
-  def eu_notification_date_is_nil
-    unless notified_to_eu_on.nil?
-      errors.add(:notified_to_eu_on, I18n.t(:date_specified_but_eu_not_notified, scope: %i[activerecord errors models nanomaterial_notification attributes notified_to_eu_on]))
     end
   end
 

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -102,7 +102,6 @@ en:
               inclusion: "Select yes if the EU was notified about the nanomaterial before 1 January 2021"
             notified_to_eu_on:
               blank: "Enter the date the EU was notified about the nanomaterial on CPNP"
-              date_specified_but_eu_not_notified: "Remove date or change answer to Yes"
               post_brexit_date_given: "The date the EU was notified on CPNP must be before 1 January 2021"
               not_a_real_date: "Enter a real EU notification date"
               date_incomplete: "EU notification date must include a %{missing_date_parts}"

--- a/cosmetics-web/spec/models/nanomaterial_notification_spec.rb
+++ b/cosmetics-web/spec/models/nanomaterial_notification_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe NanomaterialNotification, type: :model do
     end
 
     describe "EU notification" do
+      let(:pre_brexit_date) { Date.parse("2020-01-20") }
+      let(:post_brexit_date) { Date.parse("2021-04-02") }
+
       context "when not specified" do
         let(:nanomaterial_notification) do
           described_class.new(eu_notified: nil)
@@ -57,7 +60,7 @@ RSpec.describe NanomaterialNotification, type: :model do
 
       context "when the EU was notified and a pre-Brexit date is set" do
         let(:nanomaterial_notification) do
-          described_class.new(responsible_person:, eu_notified: true, notified_to_eu_on: Date.parse("2020-01-20"))
+          described_class.new(responsible_person:, eu_notified: true, notified_to_eu_on: pre_brexit_date)
         end
 
         it "is valid" do
@@ -67,7 +70,7 @@ RSpec.describe NanomaterialNotification, type: :model do
 
       context "when the EU was notified and a post-Brexit date is set" do
         let(:nanomaterial_notification) do
-          described_class.new(eu_notified: true, notified_to_eu_on: Date.parse("2021-04-02"))
+          described_class.new(eu_notified: true, notified_to_eu_on: post_brexit_date)
         end
 
         before do
@@ -91,15 +94,15 @@ RSpec.describe NanomaterialNotification, type: :model do
 
       context "when the EU was not notified but a date has been set" do
         let(:nanomaterial_notification) do
-          described_class.new(eu_notified: false, notified_to_eu_on: Date.parse("2020-04-02"))
+          described_class.new(eu_notified: false, notified_to_eu_on: pre_brexit_date)
         end
 
         before do
           nanomaterial_notification.valid?(:eu_notification)
         end
 
-        it "adds an error" do
-          expect(nanomaterial_notification.errors[:notified_to_eu_on]).to include("Remove date or change answer to Yes")
+        it "assigns a null date" do
+          expect(nanomaterial_notification.notified_to_eu_on).to be_nil
         end
       end
 
@@ -190,7 +193,7 @@ RSpec.describe NanomaterialNotification, type: :model do
   end
 
   describe "#notified_to_eu_on=" do
-    let(:nanomaterial_notification) { described_class.new }
+    let(:nanomaterial_notification) { described_class.new(eu_notified: true) }
 
     context "when setting with a date object" do
       before do

--- a/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
     end
     let(:user_id)                    { submit_user.id }
     let(:nanomaterial_notification1) { create(:nanomaterial_notification, :submittable, :submitted, user_id:, responsible_person: rp) }
-    let(:nanomaterial_notification2) { create(:nanomaterial_notification, :submittable, :submitted, user_id:, responsible_person: rp, notified_to_eu_on: 3.days.ago.to_date) }
+    let(:nanomaterial_notification2) { create(:nanomaterial_notification, :submittable, :submitted, user_id:, responsible_person: rp, eu_notified: true, notified_to_eu_on: 3.days.ago.to_date) }
     let(:nanomaterial_notification3) { create(:nanomaterial_notification, user_id:, responsible_person: rp) }
 
     before do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1822

## Description
Here we update the `NanomaterialNotification#notified_to_eu_on=` method to assign a null date if the EU has **not** been notified. This might happen if the user selects 'Yes', enters a date, then changes their answer to 'No'

Previously, this raised an error and the user would have to go back and manually remove the date.

I can see some issues with the existing code:
- We use a [complex method to assign the date](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/blob/5860e464171ccb314a8bef4bb59d88451efeddb6/cosmetics-web/app/models/nanomaterial_notification.rb#L30). Rails should be able to handle good/bad dates.
- The  ActiveRecord `#notified_to_eu_on=` is overridden to prevent nil values. Yet, we assign a nil value if the date can't be parsed. 
- The proposed implementation in this PR will only work if `#eu_notified` is assigned before `#notified_to_eu_on`

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2851-submit-web.london.cloudapps.digital/ 