### PR TITLE
Remove some fields from cloned notifications

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -25,7 +25,6 @@ class Notification < ApplicationRecord
     responsible_person_id
     shades
     industry_reference
-    under_three_years
     still_on_the_market
     components_are_mixed
     ph_min_value

--- a/cosmetics-web/app/services/notification_cloner/base.rb
+++ b/cosmetics-web/app/services/notification_cloner/base.rb
@@ -27,10 +27,9 @@ module NotificationCloner
       old_notification.components.map do |old_component|
         new_component = clone_model(old_component)
         new_component.notification = new_notification
+        new_component.routing_questions_answers["contains_cmrs"] = nil
 
         clone_ingredients(old_component, new_component)
-
-        clone_cmrs(old_component, new_component)
 
         new_component.save!
         new_component
@@ -51,14 +50,6 @@ module NotificationCloner
         new_ingredient = clone_model(old_ingredient)
         new_ingredient.component = new_component
         new_ingredient.save!
-      end
-    end
-
-    def self.clone_cmrs(old_component, new_component)
-      old_component.cmrs.each do |old_cmsr|
-        new_cmsr = clone_model(old_cmsr)
-        new_cmsr.component = new_component
-        new_cmsr.save!
       end
     end
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/notification_cloning_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/notification_cloning_spec.rb
@@ -49,19 +49,23 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
     click_on "Copy this notification"
 
     fill_in "What is the product name?", with: "Product no nano no items copy"
-    click_button "ave"
+    click_button "Save"
 
     expect(page).to have_css("h3", text: "You have created the draft notification")
     click_on "task list page"
 
     click_on "Create the product"
-    5.times { click_button "Continue" }
+    2.times { click_button "Continue" }
+    choose "No" # children under 3
+    3.times { click_button "Continue" }
     click_button "Save and continue" # images page
     expect_task_has_been_completed_page
     click_on "task list page"
     expect_progress(1, 3)
     click_on "Product details"
-    8.times { click_button "Continue" }
+    3.times { click_button "Continue" }
+    choose "No" # contains CMRs
+    5.times { click_button "Continue" }
     click_button "Save and continue" # ingredient page
     choose "No"
     2.times { click_button "Continue" }


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1842

## Description

Removes the following fields from being cloned:

* Is the product intended to be used on children under 3 years old?
* Does [component] contain category 1A or 1B CMR substances?

Also removes the cloning of CMRs.

## Review apps

https://cosmetics-pr-2856-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2856-search-web.london.cloudapps.digital/