### PR TITLE
Fix notification cloning for components with no routing answers

### DIFF
--- a/cosmetics-web/app/services/notification_cloner/base.rb
+++ b/cosmetics-web/app/services/notification_cloner/base.rb
@@ -27,7 +27,7 @@ module NotificationCloner
       old_notification.components.map do |old_component|
         new_component = clone_model(old_component)
         new_component.notification = new_notification
-        new_component.routing_questions_answers["contains_cmrs"] = nil
+        new_component.routing_questions_answers["contains_cmrs"] = nil if new_component.routing_questions_answers
 
         clone_ingredients(old_component, new_component)
 


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1874

## Description

Fixes a bug where a notification that has one or more components with no routing answers defined raises an exception on clone.

## Review apps

https://cosmetics-pr-2857-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2857-search-web.london.cloudapps.digital/