### PR TITLE
Introduce a Success Notification Banner for image uploads

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/product/add_product_image.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/add_product_image.html.erb
@@ -12,6 +12,25 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @notification.errors.messages.include?(:image_uploads) %>
       <%= govukErrorSummary(titleText: "There is a problem", errorList: [{text: @notification.errors.messages[:image_uploads][0], href: "#image_upload"}]) %>
+
+    <% elsif params[:image_upload] %>
+      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Success
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <h3 class="govuk-notification-banner__heading">
+            Image upload success
+          </h3>
+          <% params[:image_upload].each do |image_upload| %>
+            <p class="govuk-body">
+              [<%= image_upload.original_filename %>] was uploaded.
+            </p>
+          <% end %>
+        </div>
+      </div>
     <% end %>
 
     <% if @clone_image_job&.pending? %>

--- a/cosmetics-web/spec/features/submit/notification_wizard/adding_and_removing_label_images_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/adding_and_removing_label_images_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
       expect(page).to have_h1("Upload an image of the product label")
       page.attach_file ["spec/fixtures/files/testImage.png"]
       click_button "Save and upload another image"
+      expect(page).to have_notification_banner("[testImage.png] was uploaded.")
       expect_product_label_images(["testImage.png"])
 
       click_button "Save and upload another image"

--- a/cosmetics-web/spec/support/matchers/capybara_matchers.rb
+++ b/cosmetics-web/spec/support/matchers/capybara_matchers.rb
@@ -3,6 +3,10 @@ module PageMatchers
     have_selector("h1", text:, exact_text: true)
   end
 
+  def have_notification_banner(text)
+    have_selector(".govuk-notification-banner--success", text:)
+  end
+
   # Matcher for items within the [Summary list](https://design-system.service.gov.uk/components/summary-list/) component.
   #
   # Works with both:


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1855

## Description
When an image is successfully uploaded and the user wants to add another image (rendering the image upload template again), we display a success notification banner.

## Review apps 
https://cosmetics-pr-2863-submit-web.london.cloudapps.digital/ 
 