### PR TITLE
Fix CloundFoundry client download from GH actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         CF_CLI_VERSION: v7
       run: |
-        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
+        curl -A "" -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf
 
     - name: Create GitHub deployment for Staging

--- a/.github/workflows/review-apps-delete-dangling.yml
+++ b/.github/workflows/review-apps-delete-dangling.yml
@@ -22,7 +22,7 @@ jobs:
       env:
         CF_CLI_VERSION: v7
       run: |
-        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
+        curl -A "" -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf
     - name: Retrieve list of active pull requests
       id: retrieve-pull-requests

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -22,7 +22,7 @@ jobs:
       env:
         CF_CLI_VERSION: v7
       run: |
-        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
+        curl -A "" -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf
 
     - name: Delete review app

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -41,7 +41,7 @@ jobs:
       env:
         CF_CLI_VERSION: v7
       run: |
-        curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
+        curl -A "" -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf
 
     - name: Deploy


### PR DESCRIPTION
There is an issue with Cloudfoundry CDN providing their client binaries download, as it has recently started rejecting the download attempts from CURL client.

To solve it, we are removing CURL user agent from the CF client download requests.

More context: https://github.com/cloudfoundry/cli/issues/2390#issuecomment-1486526928