### PR TITLE
Remove default responses from nanomaterials

### DIFF
--- a/cosmetics-web/app/services/notification_cloner/base.rb
+++ b/cosmetics-web/app/services/notification_cloner/base.rb
@@ -19,6 +19,11 @@ module NotificationCloner
 
     def self.clone_notification(old_notification, new_notification)
       new_notification = clone_model(old_notification, object_to_clone_to: new_notification)
+
+      if new_notification.nano_materials.empty? && new_notification.routing_questions_answers
+        new_notification.routing_questions_answers[:contains_nanomaterials] = nil
+      end
+
       new_notification.save!
       new_notification
     end

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -317,7 +317,7 @@ en:
         responsible_persons/notifications/product/contains_nanomaterials_form:
           attributes:
             contains_nanomaterials:
-              inclusion: "Select yes if the product is a multi-item kit, no if its single item"
+              inclusion: "Select yes if the product contains nanomaterials"
             nanomaterials_count:
               not_a_number: "Enter a number for how many nanomaterials"
               not_an_integer: "Enter a number for how many nanomaterials"

--- a/cosmetics-web/spec/features/submit/notification_wizard/notification_cloning_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/notification_cloning_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
     click_on "Create the product"
     2.times { click_button "Continue" }
     choose "No" # children under 3
-    3.times { click_button "Continue" }
+    click_button "Continue"
+    choose "No" # nano materials
+    2.times { click_button "Continue" }
     click_button "Save and continue" # images page
     expect_task_has_been_completed_page
     click_on "task list page"

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/product/contains_nanomaterials_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/product/contains_nanomaterials_form_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ResponsiblePersons::Notifications::Product::ContainsNanomaterials
         end
 
         it "adds an error message for the contains nanomaterials attribute" do
-          expect(form.errors.full_messages_for(:contains_nanomaterials)).to eq(["Select yes if the product is a multi-item kit, no if its single item"])
+          expect(form.errors.full_messages_for(:contains_nanomaterials)).to eq(["Select yes if the product contains nanomaterials"])
         end
 
         context "when the nanomaterials count is also invalid" do


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-1859

## Description
If a notification does *not* contain nano materials, then we remove the
`contains_nanomaterials` question from the notification's `routing_questions_answers`

Here we also fix an incorrect validation error message:
'mulit-item kit' was displayed, instead of 'nanomaterial'

Testing note: You will need to create a notification manually, and clone that.
If you clone a notification that was created with seed data, the 
`new_notification.routing_questions_answers` attribute won't be set properly,

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-2868-submit-web.london.cloudapps.digital/ 