### PR TITLE
Add notification archiving

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -31,6 +31,7 @@ gem "net-imap", require: false # Needed for running Rails 6 with ruby 3.1
 gem "net-pop", require: false # Needed for running Rails 6 with ruby 3.1
 gem "net-smtp", require: false # Needed for running Rails 6 with ruby 3.1
 gem "okcomputer", "~> 1.18.1"
+gem "paper_trail", "~> 14.0"
 gem "pg", "~> 1.2"
 gem "puma", "~> 4.3"
 gem "pundit", "~> 2.1.0"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -292,6 +292,9 @@ GEM
     numerizer (0.1.1)
     okcomputer (1.18.4)
     orm_adapter (0.5.0)
+    paper_trail (14.0.0)
+      activerecord (>= 6.0)
+      request_store (~> 1.4)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
@@ -582,6 +585,7 @@ DEPENDENCIES
   net-pop
   net-smtp
   okcomputer (~> 1.18.1)
+  paper_trail (~> 14.0)
   pg (~> 1.2)
   pry (~> 0.14.1)
   pry-byebug

--- a/cosmetics-web/app/assets/stylesheets/opss/_opss-shared.scss
+++ b/cosmetics-web/app/assets/stylesheets/opss/_opss-shared.scss
@@ -1247,6 +1247,18 @@ dd dl.opss-nested-definition-list {
   }
 }
 
+.opss-table--last-two-cols-right {
+  thead tr .govuk-table__header:nth-last-child(-n+2),
+  tbody tr .govuk-table__cell:nth-last-child(-n+2),
+  tfoot tr .govuk-table__header:nth-last-child(-n+2) {
+    text-align: right;
+  }
+
+  tbody tr td:nth-last-child(-n+2) a {
+    white-space: nowrap;
+  }
+}
+
 .opss-table--first-col-normal {
   tbody tr th:first-child {
     font-weight: normal;

--- a/cosmetics-web/app/controllers/concerns/wizard_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/wizard_concern.rb
@@ -87,7 +87,7 @@ module WizardConcern
   def set_notification
     @notification ||= Notification.find_by reference_number: params[:notification_reference_number]
 
-    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete? || @notification&.archived?
 
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
@@ -96,7 +96,7 @@ module WizardConcern
     @component = Component.find(params[:component_id])
     @notification = @component.notification
 
-    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete? || @notification&.archived?
 
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
     @component_name = @notification.is_multicomponent? ? @component.name : "the product"

--- a/cosmetics-web/app/controllers/poison_centres/notifications_search_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/notifications_search_controller.rb
@@ -26,6 +26,7 @@ private
       { date_from: %i[day month year] },
       { date_to: %i[day month year] },
       :category,
+      :status,
       :sort_by,
     )
   end
@@ -43,6 +44,7 @@ private
       category: @search_form.category,
       from_date: @search_form.date_from_for_search,
       to_date: @search_form.date_to_for_search,
+      status: @search_form.status,
       sort_by: @search_form.sort_by,
       match_similar: @search_form.match_similar,
       search_fields: @search_form.search_fields,

--- a/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
@@ -35,7 +35,7 @@ private
   def set_notification
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
 
-    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete? || @notification&.archived?
 
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components/delete_ingredients_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components/delete_ingredients_controller.rb
@@ -64,7 +64,7 @@ private
     @component = Component.find(params[:component_id])
     @notification = @component.notification
 
-    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete? || @notification&.archived?
 
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/components_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/components_controller.rb
@@ -30,7 +30,7 @@ private
   def set_notification
     @notification ||= Notification.find_by reference_number: params[:notification_reference_number]
 
-    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete? || @notification&.archived?
 
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end

--- a/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/nanomaterials_controller.rb
@@ -31,7 +31,7 @@ private
   def set_notification
     @notification ||= Notification.find_by reference_number: params[:notification_reference_number]
 
-    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete?
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification&.notification_complete? || @notification&.archived?
 
     authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end

--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -1,20 +1,35 @@
 class ResponsiblePersons::NotificationsController < SubmitApplicationController
   before_action :set_responsible_person
   before_action :validate_responsible_person
-  before_action :set_notification, only: %i[show]
+  before_action :set_paper_trail_whodunnit
 
   def index
     @registered_notifications = get_registered_notifications(20)
     respond_to do |format|
       format.html
       format.csv do
-        @notifications = NotificationsDecorator.new(@responsible_person.notifications.completed.order(notification_complete_at: :desc))
+        @notifications = NotificationsDecorator.new(@registered_notifications.except(:limit, :offset))
         render csv: @notifications, filename: "all-notifications-#{Time.zone.now.to_fs(:db)}"
       end
     end
   end
 
-  def show; end
+  def archived
+    @registered_notifications = get_registered_archived_notifications(20)
+    respond_to do |format|
+      format.html
+      format.csv do
+        @notifications = NotificationsDecorator.new(@registered_notifications.except(:limit, :offset))
+        render csv: @notifications, filename: "all-archived-notifications-#{Time.zone.now.to_fs(:db)}"
+      end
+    end
+  end
+
+  def show
+    @notification = Notification.where.not(state: :deleted).find_by!(reference_number: params[:reference_number])
+    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+    @history_entries = @notification.versions.map { |version| { "whodunnit" => SubmitUser.find(version.whodunnit)&.name || "Unknown", "object" => version.object } }
+  end
 
   def new
     @notification = @responsible_person.notifications.new
@@ -33,13 +48,51 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
   def edit
     @notification = Notification.where.not(state: :deleted).find_by! reference_number: params[:reference_number]
 
-    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification.notification_complete?
+    return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification.notification_complete? || @notification.archived?
 
     authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
 
     if params[:submit_failed]
       add_image_upload_errors
     end
+  end
+
+  def choose_archive_reason
+    @notification = Notification.completed.find_by!(reference_number: params[:notification_reference_number])
+    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+  end
+
+  def archive
+    @notification = Notification.completed.find_by!(reference_number: params[:notification_reference_number])
+    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+
+    @notification.assign_attributes(archive_params)
+    return render "choose_archive_reason" unless @notification.valid?(:archive)
+
+    # This transition does not save automatically since AASM will save via paper trail
+    @notification.archive
+
+    flash[:success_banner] = {
+      heading: "#{@notification.product_name} (#{@notification.reference_number_for_display}) has been archived.",
+      body: "View your <a href=\"#{responsible_person_archived_notifications_path(@notification.responsible_person)}\">archived notifications</a> for any amendments.",
+    }
+
+    redirect_to responsible_person_notifications_path(@notification.responsible_person)
+  end
+
+  def unarchive
+    @notification = Notification.archived.find_by!(reference_number: params[:notification_reference_number])
+    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+
+    # This transition does not save automatically since AASM will save via paper trail
+    @notification.unarchive
+
+    flash[:success_banner] = {
+      heading: "#{@notification.product_name} (#{@notification.reference_number_for_display}) has been unarchived.",
+      body: "",
+    }
+
+    redirect_to responsible_person_notifications_path(@notification.responsible_person)
   end
 
 private
@@ -49,14 +102,16 @@ private
     authorize @responsible_person, :show?
   end
 
-  def set_notification
-    @notification = Notification.where.not(state: :deleted).find_by! reference_number: params[:reference_number]
-    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
-  end
-
   def get_registered_notifications(page_size)
     @responsible_person.notifications
       .completed
+      .order(notification_complete_at: :desc)
+      .page(params[:page]).per(page_size)
+  end
+
+  def get_registered_archived_notifications(page_size)
+    @responsible_person.notifications
+      .archived
       .order(notification_complete_at: :desc)
       .page(params[:page]).per(page_size)
   end
@@ -74,6 +129,11 @@ private
   def notification_params
     params.fetch(:notification, {})
       .permit(:product_name)
+  end
+
+  def archive_params
+    params.fetch(:notification, {})
+      .permit(:archive_reason)
   end
 
   def search_params

--- a/cosmetics-web/app/controllers/responsible_persons/search_notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/search_notifications_controller.rb
@@ -25,7 +25,7 @@ private
 
   # Any changes in these search params need to be also applied to ResponsiblePersons::NotificationsController#search_params
   def search_params
-    params.fetch(:notification_search_form, {}).permit(:q, :sort_by,
+    params.fetch(:notification_search_form, {}).permit(:q, :status, :sort_by,
                                                        { date_from: %i[day month year] },
                                                        { date_to: %i[day month year] })
   end
@@ -43,6 +43,7 @@ private
       category: @search_form.category,
       from_date: @search_form.date_from_for_search,
       to_date: @search_form.date_to_for_search,
+      status: @search_form.status,
       sort_by: @search_form.sort_by,
       match_similar: @search_form.match_similar,
       search_fields: @search_form.search_fields,

--- a/cosmetics-web/app/forms/notification_search_form.rb
+++ b/cosmetics-web/app/forms/notification_search_form.rb
@@ -25,6 +25,8 @@ class NotificationSearchForm < Form
   attribute :date_to, :govuk_date
   attribute :date_exact, :govuk_date
 
+  attribute :status, default: OpenSearchQuery::Notification::NOTIFIED_STATUS
+
   attribute :sort_by, default: OpenSearchQuery::Notification::SCORE_SORTING
 
   attribute :search_fields, default: OpenSearchQuery::Notification::SEARCH_ALL_FIELDS

--- a/cosmetics-web/app/forms/responsible_persons/notifications/delete_component_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/delete_component_form.rb
@@ -8,7 +8,7 @@ module ResponsiblePersons::Notifications
     def delete
       return false unless valid?
       raise("Can not remove item") if notification.components.count < 3
-      raise ActiveRecord::RecordNotFound if notification.notification_complete? || notification.deleted?
+      raise ActiveRecord::RecordNotFound if notification.notification_complete? || notification.archived? || notification.deleted?
 
       notification.components.find(component_id).destroy
       notification.try_to_complete_components!

--- a/cosmetics-web/app/forms/responsible_persons/notifications/delete_nano_material_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/delete_nano_material_form.rb
@@ -15,7 +15,7 @@ module ResponsiblePersons::Notifications
 
     def delete
       return false unless valid?
-      raise ActiveRecord::RecordNotFound if notification.notification_complete? || notification.deleted?
+      raise ActiveRecord::RecordNotFound if notification.notification_complete? || notification.archived? || notification.deleted?
 
       notification.nano_materials.find(nano_material_ids).each(&:destroy)
       notification.reload.try_to_complete_nanomaterials!

--- a/cosmetics-web/app/helpers/date_helper.rb
+++ b/cosmetics-web/app/helpers/date_helper.rb
@@ -6,4 +6,9 @@ module DateHelper
   def display_date(date)
     date&.strftime("%d/%m/%Y")
   end
+
+  def display_date_time(date)
+    date = Time.zone.parse(date) if date.is_a?(String)
+    date&.strftime("%d/%m/%Y %H:%M")
+  end
 end

--- a/cosmetics-web/app/helpers/notification_properties_helper.rb
+++ b/cosmetics-web/app/helpers/notification_properties_helper.rb
@@ -35,6 +35,10 @@ module NotificationPropertiesHelper
     SPECIAL_APPLICATOR[special_applicator&.to_sym]
   end
 
+  def get_archive_reason_name(archive_reason)
+    ARCHIVE_REASON[archive_reason&.to_sym]
+  end
+
   NOTIFICATION_TYPE = {
     predefined: "Frame formulation",
     exact: "Exact concentration",
@@ -151,5 +155,15 @@ module NotificationPropertiesHelper
     pressurised_spray_container: "Pressurised spray",
     pressurised_container_non_spray_product: "Pressurised non-spray",
     other_special_applicator: "Other",
+  }.freeze
+
+  ARCHIVE_REASON = {
+    product_no_longer_available_on_the_market: "Product no longer available on the market",
+    product_no_longer_manufactured: "Product no longer manufactured",
+    change_of_responsible_person: "Change of Responsible Person",
+    change_of_manufacturer: "Change of manufacturer",
+    significant_change_to_the_formulation: "Significant change to the formulation",
+    product_notified_but_did_not_get_placed_on_the_market: "Product notified but did not get placed on the market",
+    error_in_the_notification: "Error in the notification",
   }.freeze
 end

--- a/cosmetics-web/app/models/concerns/searchable.rb
+++ b/cosmetics-web/app/models/concerns/searchable.rb
@@ -65,6 +65,12 @@ module Searchable
     opensearch_log "#{self.class} with id=#{id} indexed with result #{result}"
   end
 
+  def update_document
+    result = __elasticsearch__.update_document
+
+    opensearch_log "#{self.class} with id=#{id} updated with result #{result}"
+  end
+
   def delete_document_from_index
     result = __elasticsearch__.delete_document
 

--- a/cosmetics-web/app/policies/responsible_person_notification_policy.rb
+++ b/cosmetics-web/app/policies/responsible_person_notification_policy.rb
@@ -33,6 +33,18 @@ class ResponsiblePersonNotificationPolicy < ApplicationPolicy
     user_member_of_associated_responsible_person? && record.can_be_deleted?
   end
 
+  def choose_archive_reason?
+    user_member_of_associated_responsible_person?
+  end
+
+  def archive?
+    user_member_of_associated_responsible_person?
+  end
+
+  def unarchive?
+    user_member_of_associated_responsible_person?
+  end
+
 private
 
   def pundit_user

--- a/cosmetics-web/app/services/notification_delete_service.rb
+++ b/cosmetics-web/app/services/notification_delete_service.rb
@@ -10,7 +10,7 @@ class NotificationDeleteService
     end
 
     ActiveRecord::Base.transaction do
-      create_notification_delete_log! if @notification.notification_complete?
+      create_notification_delete_log! if @notification.notification_complete? || @notification.archived?
       @notification.soft_delete!
     end
   end

--- a/cosmetics-web/app/views/poison_centres/notifications_search/_search_form.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_search_form.html.erb
@@ -57,6 +57,31 @@
               ) %>
         </fieldset>
       </div>
+      <%= govukRadios(
+            form: form,
+            key: :status,
+            idPrefix: "status",
+            hint: { text: "You can filter the search results to show only notified or archived notifications.", classes: "govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1" },
+            fieldset: { classes: "govuk-fieldset opss-grouping", legend: { text: "Notification status", classes: "govuk-fieldset__legend govuk-fieldset__legend--s opss-grouping__legend--s opss-grouping__heading--norm" } },
+            classes: "govuk-radios--inline govuk-radios--small",
+            items: [
+              {
+                value: OpenSearchQuery::Notification::NOTIFIED_STATUS,
+                text: "Notified",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+              {
+                value: OpenSearchQuery::Notification::ARCHIVED_STATUS,
+                text: "Archived",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+              {
+                value: OpenSearchQuery::Notification::BOTH_STATUS,
+                text: "Both",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+            ],
+            ) %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset govuk-!-padding-bottom-5 opss-grouping" aria-describedby="notified-date">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s opss-grouping__legend--s opss-grouping__heading--norm">

--- a/cosmetics-web/app/views/responsible_persons/drafts/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/drafts/index.html.erb
@@ -15,9 +15,7 @@
         </p>
       </div>
       <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
-        <a href="<%= new_responsible_person_draft_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset">
-          Add a cosmetic product
-        </a>
+        <%= govukButton(text: "Create a new product notification", href: new_responsible_person_draft_path(@responsible_person)) %>
       </div>
     </div>
   </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/_archived_notifications_table.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_archived_notifications_table.html.erb
@@ -1,12 +1,12 @@
 <table class="govuk-table govuk-!-margin-top-6 govuk-!-margin-bottom-0 opss-table opss-table--last-two-cols-right opss-table--first-col-normal">
-  <caption class="govuk-table__caption govuk-visually-hidden">List of notified products</caption>
+  <caption class="govuk-table__caption govuk-visually-hidden">List of archived products</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Product</th>
       <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
       <th scope="col" class="govuk-table__header"><abbr>UKCP</abbr> number</th>
       <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View</span></th>
-      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
+      <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Unarchive</span></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -20,7 +20,7 @@
           </a>
         </td>
         <td class="govuk-table__cell">
-          <a href="<%= responsible_person_notification_choose_archive_reason_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">Archive<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
+          <a href="<%= responsible_person_notification_unarchive_path(@responsible_person, notification, page: params[:page]) %>" class="govuk-link govuk-link--no-visited-state">Unarchive<span class="govuk-visually-hidden"> <%= notification.product_name %></span>
           </a>
         </td>
       </tr>
@@ -33,7 +33,7 @@
         <th scope="col" class="govuk-table__header"><abbr>UK</abbr> notified</th>
         <th scope="col" class="govuk-table__header"><abbr>UKCP</abbr> number</th>
         <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">View</span></th>
-        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Archive</span></th>
+        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Unarchive</span></th>
       </tr>
     </tfoot>
   <% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/_notification_nav.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_notification_nav.html.erb
@@ -3,14 +3,19 @@
     Skip to the main content
   </a>
   <ul class="govuk-list opss-left-nav">
-    <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/notifications" %>">
-      <a href="<%= responsible_person_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/notifications" %>>
+    <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/notifications" && params[:action] == "index" %>">
+      <a href="<%= responsible_person_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/notifications" && params[:action] == "index" %>>
         Product notifications
       </a>
     </li>
-    <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/drafts" %> govuk-!-margin-bottom-6">
+    <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/drafts" %>">
       <a href="<%= responsible_person_draft_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/drafts" %>>
         Draft notifications
+      </a>
+    </li>
+    <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %> govuk-!-margin-bottom-6">
+      <a href="<%= responsible_person_archived_notifications_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state" <%= 'aria-current="page"' if params[:controller] == "responsible_persons/notifications" && params[:action] == "archived" %>>
+        Archived notifications
       </a>
     </li>
     <li class="<%= "opss-left-nav__active" if params[:controller] == "responsible_persons/search_notifications" %>">

--- a/cosmetics-web/app/views/responsible_persons/notifications/archived.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/archived.html.erb
@@ -1,0 +1,46 @@
+<% content_for :page_title, "Cosmetic products" %>
+<% content_for :after_header do %>
+  <%= render "layouts/navbar" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-top-4 govuk-!-margin-bottom-6">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds opss-desktop-min-height--xs">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-2" aria-describedby="cosmetic-products-hint">
+          Archived notifications
+        </h1>
+        <p id="cosmetic-products-hint" class="govuk-body opss-secondary-text govuk-!-margin-bottom-1">
+          These are your archived notified cosmetic products.<br>
+          These products are no longer being actively sold on the <abbr>GB</abbr> market.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
+        <%= govukButton(text: "Create a new product notification", href: new_responsible_person_draft_path(@responsible_person)) %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <%= render 'responsible_persons/notifications/notification_nav' %>
+  <section id="page-content" class="govuk-grid-column-three-quarters" role="region" aria-label="Archived products">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body govuk-!-margin-bottom-0">
+          There are currently <%= (count = @registered_notifications.total_count) > 0 ? count : 'no' %> archived cosmetic products.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <div class="opss-text-align-right">
+          <% if @registered_notifications.present? %>
+            <%= govukButton(html: '<span class="opss-download-link-sm"></span>Download a <abbr title="Comma-Separated Values">CSV</abbr> file'.html_safe, href: responsible_person_archived_notifications_path(@responsible_person, format: :csv), classes: "govuk-button--secondary") %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <%= render 'archived_notifications_table' if @registered_notifications.present? %>
+    <%= paginate @registered_notifications, views_prefix: 'pagination', nav_class: 'opss-pagination-link--no-top-border' %>
+  </section>
+</div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/choose_archive_reason.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/choose_archive_reason.html.erb
@@ -1,0 +1,22 @@
+<% archive_reasons = Notification.archive_reasons.map { |key, value| { text: get_archive_reason_name(key), value: value } } %>
+
+<% page_title safe_join(["Choose a reason for archiving ", @notification.product_name]), errors: @notification.errors.any? %>
+<% content_for :after_header do %>
+  <%= render 'responsible_persons/shared/back_links' %>
+<% end %>
+
+<%= form_with model: @notification, url: responsible_person_notification_archive_path(@notification.responsible_person, @notification), method: :patch do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= error_summary_for(@notification) %>
+      <%= govukRadios(
+            form: form,
+            key: :archive_reason,
+            hint: { text: "Select from one of the options below to provide a reason for archiving this product notification." },
+            fieldset: { legend: { text: "Reason for archiving", classes: "govuk-fieldset__legend--l", isPageHeading: true } },
+            items: archive_reasons,
+          ) %>
+      <%= govukButton text: "Continue" %>
+    </div>
+  </div>
+<% end %>

--- a/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/index.html.erb
@@ -3,6 +3,24 @@
   <%= render "layouts/navbar" %>
 <% end %>
 
+<% if flash[:success_banner] %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-top-4 govuk-!-margin-bottom-6">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full opss-desktop-min-height--xs">
+        <% notification_html = capture do %>
+        <h3 class="govuk-notification-banner__heading">
+          <%= flash[:success_banner]["heading"] %>
+        </h3>
+        <% if flash[:success_banner]["body"] %><p class="govuk-body"><%= flash[:success_banner]["body"].html_safe %></p><% end %>
+        <% end %>
+        <%= govukNotificationBanner(html: notification_html, type: "success") %>
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-top-4 govuk-!-margin-bottom-6">
     <div class="govuk-grid-row">
@@ -15,9 +33,7 @@
         </p>
       </div>
       <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
-        <a href="<%= new_responsible_person_draft_path(@responsible_person) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset">
-          Add a cosmetic product
-        </a>
+        <%= govukButton(text: "Create a new product notification", href: new_responsible_person_draft_path(@responsible_person)) %>
       </div>
     </div>
   </div>
@@ -46,9 +62,7 @@
       <div class="govuk-grid-column-one-third">
         <div class="opss-text-align-right">
           <% if @registered_notifications.present? %>
-            <a href="<%= responsible_person_notifications_path(@responsible_person, format: :csv) %>" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-14 opss-text-underline-offset" download="">
-              <span class="opss-download-link-sm"></span>Download a <abbr title="Comma-Separated Values">CSV</abbr> file
-            </a>
+            <%= govukButton(html: '<span class="opss-download-link-sm"></span>Download a <abbr title="Comma-Separated Values">CSV</abbr> file'.html_safe, href: responsible_person_notifications_path(@responsible_person, format: :csv), classes: "govuk-button--secondary") %>
           <% end %>
         </div>
       </div>

--- a/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/show.html.erb
@@ -10,20 +10,14 @@
         <h1 class="govuk-heading-l">
           <span class="govuk-caption-l">Notified product: </span>
           <%= @notification.product_name %>
+          <% if @notification.archived? %>
+            <%= govukTag(text: "Archived", classes: "govuk-tag--grey") %>
+          <% end %>
         </h1>
       </div>
       <div class="govuk-grid-column-one-third">
         <div class="opss-text-align-right govuk-!-margin-bottom-8">
-          <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-14 opss-text-underline-offset" href="<%= new_responsible_person_notification_clone_path(@responsible_person, @notification) %>">
-            Create a draft notification using<br class="opss-br-desktop"> this notification as a template
-          </a>
-        </div>
-        <div class="opss-text-align-right govuk-!-margin-bottom-8">
-        <% if @notification.can_be_deleted? %>
-          <%= link_to "Delete this notification",
-              delete_responsible_person_delete_notification_path(@responsible_person, @notification),
-              class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-align-right opss-text-underline-offset" %>
-        <% end %>
+          <%= govukButton(text: "Copy this notification", href: new_responsible_person_notification_clone_path(@responsible_person, @notification), classes: "govuk-button--secondary") %>
         </div>
       </div>
     </div>
@@ -47,3 +41,61 @@
 
   <%= render("aside_responsible_person_details", responsible_person: @responsible_person) %>
 </div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-top-4">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <% if @notification.archived? %>
+          <%= govukButton(text: "Unarchive this notification", href: responsible_person_notification_unarchive_path(@responsible_person, @notification), classes: "govuk-button--secondary") %>
+        <% else %>
+          <%= govukButton(text: "Archive this notification", href: responsible_person_notification_choose_archive_reason_path(@responsible_person, @notification, back_to: "notification"), classes: "govuk-button--secondary") %>
+        <% end %>
+        <% if @notification.can_be_deleted? %>
+          <%= govukButton(text: "Delete this notification", href: delete_responsible_person_delete_notification_path(@responsible_person, @notification), classes: "govuk-button--warning") %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% if @history_entries.length > 0 %>
+<div class="govuk-grid-row">
+  <article class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-m">Archive history</h2>
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-visually-hidden">List of archive and un-archive events</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Date &amp; time</th>
+          <th scope="col" class="govuk-table__header">Archive action</th>
+          <th scope="col" class="govuk-table__header">Team member</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @history_entries.each do |entry| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= display_date_time(entry["object"]["updated_at"]) %></td>
+          <td class="govuk-table__cell">
+            <% if entry["object"]["state"] == "archived" %>
+              <strong>Archived:</strong> <%= get_archive_reason_name(entry["object"]["archive_reason"]) %>
+            <% else %>
+              <strong>Unarchived</strong>
+            <% end %>
+          <td class="govuk-table__cell"><%= entry["whodunnit"] %></td>
+        </tr>
+      <% end %>
+      </tbody>
+      <% if @history_entries.length > 11 %>
+        <tfoot class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Date &amp; time</th>
+          <th scope="col" class="govuk-table__header">Archive action</th>
+          <th scope="col" class="govuk-table__header">Team member</th>
+        </tr>
+        </tfoot>
+      <% end %>
+    </table>
+  </article>
+</div>
+<% end %>

--- a/cosmetics-web/app/views/responsible_persons/search_notifications/_search_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/search_notifications/_search_form.html.erb
@@ -16,6 +16,32 @@
         </div>
       </div>
 
+      <%= govukRadios(
+            form: form,
+            key: :status,
+            idPrefix: "status",
+            hint: { text: "You can filter the search results to show only notified or archived notifications.", classes: "govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1" },
+            fieldset: { classes: "govuk-fieldset opss-grouping", legend: { text: "Notification status", classes: "govuk-fieldset__legend govuk-fieldset__legend--s opss-grouping__legend--s opss-grouping__heading--norm" } },
+            classes: "govuk-radios--inline govuk-radios--small",
+            items: [
+              {
+                value: OpenSearchQuery::Notification::NOTIFIED_STATUS,
+                text: "Notified",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+              {
+                value: OpenSearchQuery::Notification::ARCHIVED_STATUS,
+                text: "Archived",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+              {
+                value: OpenSearchQuery::Notification::BOTH_STATUS,
+                text: "Both",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+            ],
+            ) %>
+
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset govuk-!-padding-bottom-5 opss-grouping" aria-describedby="notified-date">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s opss-grouping__legend--s opss-grouping__heading--norm">
@@ -52,31 +78,31 @@
         </fieldset>
       </div>
 
-        <%= govukRadios(
-              form: form,
-              key: :sort_by,
-              idPrefix: "sort-by",
-              hint: { text: "You can sort the ordering of how the notifications will be displayed.", classes: "govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1" },
-              fieldset: { classes: "govuk-fieldset opss-grouping", legend: { text: "Sorting order", classes: "govuk-fieldset__legend govuk-fieldset__legend--s opss-grouping__legend--s opss-grouping__heading--norm" } },
-              classes: "govuk-radios--inline govuk-radios--small",
-              items: [
-                {
-                  value: OpenSearchQuery::Notification::SCORE_SORTING,
-                  text: 'Relevance',
-                  label: { classes: 'govuk-label govuk-radios__label' }
-                },
-                {
-                  value: OpenSearchQuery::Notification::DATE_DESCENDING_SORTING,
-                  text: "Newest",
-                  label: { classes: 'govuk-label govuk-radios__label' }
-                },
-                {
-                  value: OpenSearchQuery::Notification::DATE_ASCENDING_SORTING,
-                  text: 'Oldest',
-                  label: { classes: 'govuk-label govuk-radios__label' }
-                },
-              ],
-              ) %>
+      <%= govukRadios(
+            form: form,
+            key: :sort_by,
+            idPrefix: "sort-by",
+            hint: { text: "You can sort the ordering of how the notifications will be displayed.", classes: "govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1" },
+            fieldset: { classes: "govuk-fieldset opss-grouping", legend: { text: "Sorting order", classes: "govuk-fieldset__legend govuk-fieldset__legend--s opss-grouping__legend--s opss-grouping__heading--norm" } },
+            classes: "govuk-radios--inline govuk-radios--small",
+            items: [
+              {
+                value: OpenSearchQuery::Notification::SCORE_SORTING,
+                text: "Relevance",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+              {
+                value: OpenSearchQuery::Notification::DATE_DESCENDING_SORTING,
+                text: "Newest",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+              {
+                value: OpenSearchQuery::Notification::DATE_ASCENDING_SORTING,
+                text: "Oldest",
+                label: { classes: "govuk-label govuk-radios__label" }
+              },
+            ],
+            ) %>
     </div>
   </div>
 

--- a/cosmetics-web/app/views/responsible_persons/shared/_back_links.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/shared/_back_links.html.erb
@@ -2,6 +2,10 @@
   <%= govukBackLink text: "Back", href: responsible_person_search_notifications_path(notification_search_form: search_params, page: params[:page]) %>
 <% elsif params[:back_to] == "ingredients_search" %>
   <%= govukBackLink text: "Back", href: responsible_person_search_ingredients_path(ingredient_search_form: search_params, page: params[:page]) %>
+<% elsif params[:back_to] == "notification" %>
+  <%= govukBackLink text: "Back", href: responsible_person_notification_path(@responsible_person, @notification) %>
+<% elsif @notification.archived? %>
+  <%= govukBackLink text: "Back", href: responsible_person_archived_notifications_path(@responsible_person, page: params[:page]) %>
 <% else %>
   <%= govukBackLink text: "Back", href: responsible_person_notifications_path(@responsible_person, page: params[:page]) %>
 <% end %>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -136,6 +136,7 @@ Rails.application.routes.draw do
 
       resource :draft, controller: "responsible_persons/drafts", only: %i[new]
       get "draft-notifications", to: "responsible_persons/drafts#index", as: :draft_notifications
+      get "archived-notifications", to: "responsible_persons/notifications#archived", as: :archived_notifications
       resources :notifications, param: :reference_number, controller: "responsible_persons/notifications", only: %i[index show new edit create] do
         resources :product, controller: "responsible_persons/notifications/product", only: %i[show update new]
         resources :product_kit, controller: "responsible_persons/notifications/product_kit", only: %i[show update new]
@@ -165,6 +166,10 @@ Rails.application.routes.draw do
             get :confirm
           end
         end
+
+        get :choose_archive_reason
+        patch :archive
+        get :unarchive # This action should be `PATCH` once we no longer have bare links to it
       end
 
       resources :delete_notification, param: :reference_number, controller: "responsible_persons/delete_notification", only: [] do

--- a/cosmetics-web/db/migrate/20230330095014_add_archive_reason_to_notifications.rb
+++ b/cosmetics-web/db/migrate/20230330095014_add_archive_reason_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddArchiveReasonToNotifications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :notifications, :archive_reason, :string
+  end
+end

--- a/cosmetics-web/db/migrate/20230330095558_create_versions.rb
+++ b/cosmetics-web/db/migrate/20230330095558_create_versions.rb
@@ -1,0 +1,31 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, null: false
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.jsonb    :object
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_23_110110) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_30_095558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -228,6 +228,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_110110) do
     t.jsonb "routing_questions_answers"
     t.string "previous_state"
     t.integer "source_notification_id"
+    t.string "archive_reason"
     t.index ["cpnp_reference", "responsible_person_id"], name: "index_notifications_on_cpnp_reference_and_rp_id", unique: true
     t.index ["reference_number"], name: "index_notifications_on_reference_number", unique: true
     t.index ["responsible_person_id"], name: "index_notifications_on_responsible_person_id"
@@ -356,6 +357,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_110110) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["type", "email"], name: "index_users_on_type_and_email", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.datetime "created_at"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     sign_out(:submit_user)
   end
 
-  describe "GET #index" do
+  describe "GET /" do
     it "assigns the correct Responsible Person" do
       get :index, params: { responsible_person_id: responsible_person.id }
       expect(assigns(:responsible_person)).to eq(responsible_person)
@@ -27,6 +27,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
 
     it "gets the correct number of submitted notifications" do
       create(:registered_notification, responsible_person:)
+      create(:registered_notification, :archived, responsible_person:)
       get :index, params: { responsible_person_id: responsible_person.id }
       expect(assigns(:registered_notifications).count).to eq(1)
     end
@@ -38,20 +39,51 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
     end
   end
 
+  describe "GET /archived-notifications" do
+    it "assigns the correct Responsible Person" do
+      get :archived, params: { responsible_person_id: responsible_person.id }
+      expect(assigns(:responsible_person)).to eq(responsible_person)
+    end
+
+    it "renders the archived template" do
+      get :archived, params: { responsible_person_id: responsible_person.id }
+      expect(response).to render_template("responsible_persons/notifications/archived")
+    end
+
+    it "gets the correct number of archived notifications" do
+      create(:registered_notification, responsible_person:)
+      create(:registered_notification, :archived, responsible_person:)
+      get :archived, params: { responsible_person_id: responsible_person.id }
+      expect(assigns(:registered_notifications).count).to eq(1)
+    end
+
+    it "does not allow the user to access another Responsible Person's dashboard" do
+      other_responsible_person = create(:responsible_person)
+      expect { get :archived, params: { responsible_person_id: other_responsible_person.id } }
+          .to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
   describe "GET /show" do
     let(:notification) { create(:registered_notification, responsible_person:) }
+    let(:archived_notification) { create(:registered_notification, :archived, responsible_person:) }
 
     it "assigns the correct notification" do
       get :show, params: { responsible_person_id: responsible_person.id, reference_number: notification.reference_number }
       expect(assigns(:notification)).to eq(notification)
     end
 
-    it "renders the index template" do
+    it "renders the show template" do
       get :show, params: { responsible_person_id: responsible_person.id, reference_number: notification.reference_number }
       expect(response).to render_template("responsible_persons/notifications/show")
     end
 
-    it "does not allow the user to show a notification for a Responsible Person they not belong to" do
+    it "shows an archived notification" do
+      get :show, params: { responsible_person_id: responsible_person.id, reference_number: archived_notification.reference_number }
+      expect(response).to render_template("responsible_persons/notifications/show")
+    end
+
+    it "does not allow the user to show a notification for a Responsible Person they do not belong to" do
       other_responsible_person = create(:responsible_person)
       other_notification = create(:registered_notification, responsible_person: other_responsible_person)
       expect {
@@ -59,7 +91,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "does not shows deleted notification" do
+    it "does not show a deleted notification" do
       reference_number = notification.reference_number
       notification.destroy!
       get :show, params: { responsible_person_id: responsible_person.id, reference_number: }
@@ -83,7 +115,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
       expect(response).to render_template("responsible_persons/notifications/new")
     end
 
-    it "does not allow the user to create a new notification for a Responsible Person they not belong to" do
+    it "does not allow the user to create a new notification for a Responsible Person they do not belong to" do
       other_responsible_person = create(:responsible_person)
       expect {
         get :new, params: { responsible_person_id: other_responsible_person.id }
@@ -99,7 +131,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
       expect(assigns(:notification)).to eq(draft_notification)
     end
 
-    it "does not allow the user to edit notification for a Responsible Person they not belong to" do
+    it "does not allow the user to edit notification for a Responsible Person they do not belong to" do
       other_responsible_person = create(:responsible_person)
       other_notification = create(:draft_notification, responsible_person: other_responsible_person)
       expect {
@@ -107,7 +139,7 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
-    it "does not shows deleted notification" do
+    it "does not show a deleted notification" do
       reference_number = draft_notification.reference_number
       draft_notification.destroy!
       get :edit, params: { responsible_person_id: responsible_person.id, reference_number: }
@@ -122,6 +154,77 @@ RSpec.describe ResponsiblePersons::NotificationsController, :with_stubbed_antivi
       it "redirects to the notifications page" do
         expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
       end
+    end
+  end
+
+  describe "GET /choose_archive_reason" do
+    let(:notification) { create(:registered_notification, responsible_person:) }
+
+    before do
+      notification
+      Notification.import_to_opensearch(force: true)
+    end
+
+    it "renders the choose_archive_reason template" do
+      get :choose_archive_reason, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
+      expect(response).to render_template("responsible_persons/notifications/choose_archive_reason")
+    end
+  end
+
+  describe "PATCH /archive" do
+    let(:notification) { create(:registered_notification, responsible_person:) }
+
+    before do
+      notification
+      Notification.import_to_opensearch(force: true)
+    end
+
+    it "archives the notification" do
+      patch :archive, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number, notification: { archive_reason: "change_of_manufacturer" } }
+      get :index, params: { responsible_person_id: responsible_person.id, reference_number: notification.reference_number }
+      expect(assigns(:registered_notifications).count).to eq(0)
+    end
+
+    it "redirects to the index page" do
+      patch :archive, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number, notification: { archive_reason: "change_of_manufacturer" } }
+      expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications")
+    end
+
+    it "sets the archive reason" do
+      patch :archive, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number, notification: { archive_reason: "change_of_manufacturer" } }
+      expect(notification.reload.archive_reason).to eq("change_of_manufacturer")
+    end
+
+    context "when an archive reason is not provided" do
+      it "renders the choose_archive_reason template" do
+        patch :archive, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
+        expect(response).to render_template("responsible_persons/notifications/choose_archive_reason")
+      end
+    end
+  end
+
+  describe "GET /unarchive" do
+    let(:archived_notification) { create(:registered_notification, :archived, responsible_person:) }
+
+    before do
+      archived_notification
+      Notification.import_to_opensearch(force: true)
+    end
+
+    it "unarchives the notification and redirects to the index page" do
+      get :unarchive, params: { responsible_person_id: responsible_person.id, notification_reference_number: archived_notification.reference_number }
+      get :index, params: { responsible_person_id: responsible_person.id, reference_number: archived_notification.reference_number }
+      expect(assigns(:registered_notifications).count).to eq(1)
+    end
+
+    it "redirects to the index page" do
+      get :unarchive, params: { responsible_person_id: responsible_person.id, notification_reference_number: archived_notification.reference_number }
+      expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications")
+    end
+
+    it "clears the archive reason" do
+      get :unarchive, params: { responsible_person_id: responsible_person.id, notification_reference_number: archived_notification.reference_number }
+      expect(archived_notification.reload.archive_reason).to be_nil
     end
   end
 

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     end
 
     factory :registered_notification, traits: [:registered]
+    factory :archived_notification, traits: %i[registered archived]
 
     trait :registered do
       state { NotificationStateConcern::NOTIFICATION_COMPLETE }
@@ -22,6 +23,11 @@ FactoryBot.define do
 
     trait :draft_complete do
       state { NotificationStateConcern::COMPONENTS_COMPLETE }
+    end
+
+    trait :archived do
+      state { NotificationStateConcern::ARCHIVED }
+      archive_reason { "significant_change_to_the_formulation" }
     end
 
     trait :ph_values do

--- a/cosmetics-web/spec/features/search/notification_search_spec.rb
+++ b/cosmetics-web/spec/features/search/notification_search_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
   let(:cream) { create(:notification, :registered, :with_component, notification_complete_at: 1.day.ago, product_name: "Cream", responsible_person:) }
   let(:shower_bubbles) { create(:notification, :registered, :with_component, notification_complete_at: 2.days.ago, product_name: "Shower Bubbles", responsible_person: other_responsible_person) }
   let(:bath_bubbles) { create(:notification, :registered, :with_component, notification_complete_at: 3.days.ago, product_name: "Bath Bubbles", category: :face_care_products_other_than_face_mask) }
+  let(:powder) { create(:archived_notification, :with_component, notification_complete_at: 1.day.ago, product_name: "Bath Bubbles Powder", responsible_person:) }
 
   before do
     configure_requests_for_search_domain
@@ -19,6 +20,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     cream
     shower_bubbles
     bath_bubbles
+    powder
 
     Notification.import_to_opensearch(force: true)
 
@@ -40,6 +42,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     expect(page).not_to have_link("Cream")
     expect(page).to have_link("Shower Bubbles")
     expect(page).to have_link("Bath Bubbles")
+    expect(page).not_to have_link("Bath Bubbles Powder")
 
     click_on "Edit your search"
     choose "Skin products"
@@ -50,6 +53,19 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     expect(page).not_to have_link("Cream")
     expect(page).not_to have_link("Shower Bubbles")
     expect(page).to have_link("Bath Bubbles")
+    expect(page).not_to have_link("Bath Bubbles Powder")
+  end
+
+  scenario "Searching for archived notifications" do
+    expect(page).to have_h1("Cosmetic products search")
+    fill_in "notification_search_form_q", with: "Bubbles"
+    choose "Archived"
+    click_on "Search"
+
+    expect(page).not_to have_link("Cream")
+    expect(page).not_to have_link("Shower Bubbles")
+    expect(page).not_to have_link("Bath Bubbles", exact: true)
+    expect(page).to have_link("Bath Bubbles Powder")
   end
 
   scenario "Sorting search results" do
@@ -76,6 +92,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     expect(page).to have_link("View Cream")
     expect(page).to have_link("View Shower Bubbles")
     expect(page).to have_link("View Bath Bubbles")
+    expect(page).not_to have_link("View Bath Bubbles Powder")
 
     click_on "Edit your search"
     fill_in "date_from_day",   with: bath_bubbles.notification_complete_at.day
@@ -93,6 +110,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     expect(page).not_to have_link("Cream")
     expect(page).not_to have_link("Shower Bubbles")
     expect(page).to have_link("Bath Bubbles")
+    expect(page).not_to have_link("Bath Bubbles Powder")
   end
 
   describe "Reference number search" do
@@ -103,6 +121,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
       expect(page).to have_link("View Cream")
       expect(page).to have_link("View Shower Bubbles")
       expect(page).to have_link("View Bath Bubbles")
+      expect(page).not_to have_link("View Bath Bubbles Powder")
 
       click_on "Edit your search"
       fill_in "notification_search_form_q", with: cream.reference_number
@@ -114,6 +133,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
       expect(page).to have_link("View Cream")
       expect(page).not_to have_link("View Shower Bubbles")
       expect(page).not_to have_link("View Bath Bubbles")
+      expect(page).not_to have_link("View Bath Bubbles Powder")
     end
 
     scenario "Searching by partial number" do
@@ -123,6 +143,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
       expect(page).to have_link("View Cream")
       expect(page).to have_link("View Shower Bubbles")
       expect(page).to have_link("View Bath Bubbles")
+      expect(page).not_to have_link("View Bath Bubbles Powder")
 
       click_on "Edit your search"
       fill_in "notification_search_form_q", with: cream.reference_number.to_s[0..5]
@@ -134,6 +155,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
       expect(page).not_to have_link("View Cream")
       expect(page).not_to have_link("View Shower Bubbles")
       expect(page).not_to have_link("View Bath Bubbles")
+      expect(page).not_to have_link("View Bath Bubbles Powder")
     end
 
     context "when reference number is small" do
@@ -146,6 +168,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
         expect(page).to have_link("View Cream")
         expect(page).to have_link("View Shower Bubbles")
         expect(page).to have_link("View Bath Bubbles")
+        expect(page).not_to have_link("View Bath Bubbles Powder")
 
         click_on "Edit your search"
         fill_in "notification_search_form_q", with: cream.reference_number_for_display

--- a/cosmetics-web/spec/features/submit/notification_wizard/adding_and_removing_label_images_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/adding_and_removing_label_images_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
     before do
       visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-      click_on "Add a cosmetic product"
+      click_on "Create a new product notification"
       click_on "Create the product"
       answer_product_name_with "Product"
       answer_do_you_want_to_give_an_internal_reference_with "No"

--- a/cosmetics-web/spec/features/submit/notification_wizard/blocked_nano_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/blocked_nano_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Notification with one nano materials and two items" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product one nano two items", items_count: 2, nano_materials_count: 1)
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/completing_items_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/completing_items_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Completing one item of two for a product notification" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2)
     expect_progress(1, 4)
@@ -42,7 +42,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Completing a single item for a product notification" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 1)
     expect_progress(1, 3)

--- a/cosmetics-web/spec/features/submit/notification_wizard/completing_nano_material_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/completing_nano_material_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Completing a standard nanomaterial for a product notification" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product one nano one item", items_count: 1, nano_materials_count: 1)
     expect_progress(1, 4)
@@ -91,7 +91,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
                                        responsible_person:)
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product one nano one item", items_count: 1, nano_materials_count: 1)
     expect_progress(1, 4)

--- a/cosmetics-web/spec/features/submit/notification_wizard/correct_status_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/correct_status_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when updating nano after multi-item kit completed" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product with nano and two items", items_count: 2, nano_materials_count: 2)
 
@@ -93,7 +93,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when updating nano after single item product completed" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano no items", nano_materials_count: 1)
 
@@ -131,7 +131,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when adding first nano after single item product completed" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano no items")
 
@@ -167,7 +167,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when adding extra item after single item product completed" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano no items")
 
@@ -215,7 +215,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when adding extra item after two items product completed" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2)
 
@@ -265,7 +265,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when changing formulation type in a completed component" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2)
 
@@ -313,7 +313,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when adding items after adding nanos" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Some product")
 
@@ -389,7 +389,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when adding items after interrupted nano wizard" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product with nano and two items", items_count: 2, nano_materials_count: 2)
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Adding ingredients to components", :with_stubbed_antivirus, type
     sign_in_as_member_of_responsible_person(responsible_person, user)
 
     visit "/responsible_persons/#{responsible_person.id}/notifications"
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
     complete_product_wizard(name: "FooProduct")
     expect_progress(1, 3)
     expect_product_details_task_not_started

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Adding ingredients to components using a CSV file", :with_stubbe
     sign_in_as_member_of_responsible_person(responsible_person, user)
 
     visit "/responsible_persons/#{responsible_person.id}/notifications"
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
     complete_product_wizard(name: "FooProduct")
     expect_progress(1, 3)
     expect_product_details_task_not_started

--- a/cosmetics-web/spec/features/submit/notification_wizard/no_nano_no_items_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/no_nano_no_items_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Simple notification" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano no items")
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/no_nano_two_items_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/no_nano_two_items_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Notification with two items" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2)
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/notification_cloning_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/notification_cloning_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Simple notification cloning" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano no items")
 
@@ -45,8 +45,8 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
 
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Product no nano no items"
-    click_on "Create a draft notification using this notification as a template"
+    click_on "View Product no nano no items"
+    click_on "Copy this notification"
 
     fill_in "What is the product name?", with: "Product no nano no items copy"
     click_button "Save"

--- a/cosmetics-web/spec/features/submit/notification_wizard/one_nano_two_items_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/one_nano_two_items_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Notification with one nano materials and two items" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2, nano_materials_count: 1)
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/removing_items_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/removing_items_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Removing one out of three" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 3)
 
@@ -84,7 +84,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Removing one out of three - correct status change on delete" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 3)
 
@@ -163,7 +163,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "When only 2 items left it should not be able to delete them" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2)
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/removing_nano_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/removing_nano_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
     scenario "when removing before completing product details" do
       visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-      click_on "Add a cosmetic product"
+      click_on "Create a new product notification"
 
       complete_product_wizard(name: "Product for nano removal test", nano_materials_count: 2)
 
@@ -42,7 +42,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Adding and removing nano status" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2)
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/single_to_multi_item_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/single_to_multi_item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Notification changing from single to multi item" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product single to multi item")
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/state_dependent_access_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/state_dependent_access_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Checking correct status - when updating nano after multi-item kit completed" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product with nano and two items", items_count: 2, nano_materials_count: 2)
 

--- a/cosmetics-web/spec/features/submit/notification_wizard/two_nano_two_item_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/two_nano_two_item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Submit notifications", :with_stubbed_antivirus, type: :feature d
   scenario "Notification with two nano materials and two items" do
     visit "/responsible_persons/#{responsible_person.id}/notifications"
 
-    click_on "Add a cosmetic product"
+    click_on "Create a new product notification"
 
     complete_product_wizard(name: "Product no nano two items", items_count: 2, nano_materials_count: 2)
 

--- a/cosmetics-web/spec/features/submit/notifications_archiving_spec.rb
+++ b/cosmetics-web/spec/features/submit/notifications_archiving_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe "Notifications archiving", type: :feature do
+  let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+  let(:user) { responsible_person.responsible_person_users.first.user }
+  let(:notification) { create(:registered_notification, responsible_person:) }
+  let(:archived_notification) { create(:archived_notification, responsible_person:) }
+
+  before do
+    configure_requests_for_submit_domain
+    sign_in user
+  end
+
+  scenario "archiving a notification from the notifications dashboard" do
+    notification
+    Notification.import_to_opensearch(force: true)
+
+    visit "/responsible_persons/#{responsible_person.id}/notifications"
+    click_link("Archive #{notification.product_name}")
+
+    choose "Significant change to the formulation"
+    click_button "Continue"
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css("h3", text: "#{notification.product_name} (#{notification.reference_number_for_display}) has been archived.")
+    end
+    expect(page).not_to have_link("View #{notification.product_name}")
+  end
+
+  scenario "archiving a notification from the notification page" do
+    notification
+    Notification.import_to_opensearch(force: true)
+
+    visit "/responsible_persons/#{responsible_person.id}/notifications"
+    click_link "View #{notification.product_name}"
+
+    expect(page).to have_h1("Notified product: #{notification.product_name}")
+    click_link "Archive this notification"
+
+    choose "Significant change to the formulation"
+    click_button "Continue"
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css("h3", text: "#{notification.product_name} (#{notification.reference_number_for_display}) has been archived.")
+    end
+    expect(page).not_to have_link("View #{notification.product_name}")
+
+    visit "/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}"
+    expect(page).to have_css("h2", text: "Archive history")
+    expect(page).to have_css("td.govuk-table__cell", text: "Archived: Significant change to the formulation")
+  end
+
+  scenario "unarchiving a notification from the notifications archive dashboard" do
+    travel_to Time.zone.local(2020, 1, 1, 12, 0, 0) do
+      archived_notification
+      Notification.import_to_opensearch(force: true)
+    end
+    visit "/responsible_persons/#{responsible_person.id}/archived-notifications"
+    click_link("Unarchive #{archived_notification.product_name}")
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css(
+        "h3",
+        text: "#{archived_notification.product_name} (#{archived_notification.reference_number_for_display}) has been unarchived.",
+      )
+    end
+    expect(page).to have_link("View #{archived_notification.product_name}")
+    # Notification can be archived again
+    expect(page).to have_link("Archive #{archived_notification.product_name}")
+    # Notification original 'UK notified' date is kept
+    title = page.find("th", text: archived_notification.product_name, exact_text: true)
+    expect(title).to have_sibling("td", text: "1 January 2020", exact_text: true)
+  end
+
+  scenario "unarchiving a notification from the notification page" do
+    travel_to Time.zone.local(2020, 1, 1, 12, 0, 0) do
+      archived_notification
+      Notification.import_to_opensearch(force: true)
+    end
+    visit "/responsible_persons/#{responsible_person.id}/archived-notifications"
+    click_link "View #{archived_notification.product_name}"
+
+    expect(page).to have_h1("Notified product: #{archived_notification.product_name} Archived")
+    click_link("Unarchive this notification")
+
+    expect_to_be_on__your_cosmetic_products_page
+    within("div.govuk-notification-banner--success") do
+      expect(page).to have_css("h2", text: "Success")
+      expect(page).to have_css(
+        "h3",
+        text: "#{archived_notification.product_name} (#{archived_notification.reference_number_for_display}) has been unarchived.",
+      )
+    end
+    expect(page).to have_link("View #{archived_notification.product_name}")
+    # Notification can be archived again
+    expect(page).to have_link("Archive #{archived_notification.product_name}")
+    # Notification original 'UK notified' date is kept
+    title = page.find("th", text: archived_notification.product_name, exact_text: true)
+    expect(title).to have_sibling("td", text: "1 January 2020", exact_text: true)
+
+    visit "/responsible_persons/#{responsible_person.id}/notifications/#{archived_notification.reference_number}"
+    expect(page).to have_css("h2", text: "Archive history")
+    expect(page).to have_css("td.govuk-table__cell", text: "Unarchived")
+  end
+end

--- a/cosmetics-web/spec/features/submit/notifications_deletion_spec.rb
+++ b/cosmetics-web/spec/features/submit/notifications_deletion_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe "Notifications delete", type: :feature do
     assert_text "#{draft_notification.product_name} notification deleted"
   end
 
-  scenario "deleting submited notification" do
+  scenario "deleting submitted notification" do
     notification
     visit "/responsible_persons/#{responsible_person.id}/notifications"
-    click_on notification.product_name
+    click_on "View #{notification.product_name}"
     click_on "Delete this notification"
 
     expect(page).to have_h1("Do you want to delete this notification?")
@@ -55,7 +55,7 @@ RSpec.describe "Notifications delete", type: :feature do
                           responsible_person:,
                           notification_complete_at: 1.month.ago)
     visit "/responsible_persons/#{responsible_person.id}/notifications"
-    click_on notification.product_name
-    expect(page).not_to have_link("Delete this cosmetic product notification")
+    click_on "View #{notification.product_name}"
+    expect(page).not_to have_link("Delete this notification")
   end
 end

--- a/cosmetics-web/spec/helpers/date_helper_spec.rb
+++ b/cosmetics-web/spec/helpers/date_helper_spec.rb
@@ -24,4 +24,21 @@ RSpec.describe DateHelper, type: :helper do
       expect(helper.display_date(date)).to be_nil
     end
   end
+
+  describe "#display_date_time" do
+    it "returns a Date string" do
+      date = Date.new(2022, 2, 1)
+      expect(helper.display_date_time(date)).to eq("01/02/2022 00:00")
+    end
+
+    it "converts the input to a Date if a String and returns a Date string" do
+      date = "2022-02-01 13:12:01"
+      expect(helper.display_date_time(date)).to eq("01/02/2022 13:12")
+    end
+
+    it "returns nil when passed nil" do
+      date = nil
+      expect(helper.display_date_time(date)).to be_nil
+    end
+  end
 end

--- a/cosmetics-web/spec/search/poison_centre_search_spec.rb
+++ b/cosmetics-web/spec/search/poison_centre_search_spec.rb
@@ -52,6 +52,7 @@ def keyword_search(keyword)
                                             category: nil,
                                             from_date: nil,
                                             to_date: nil,
+                                            status: nil,
                                             sort_by: nil,
                                             match_similar: nil,
                                             search_fields: nil,


### PR DESCRIPTION
JIRA tickets: https://regulatorydelivery.atlassian.net/browse/COSBETA-1832 and https://regulatorydelivery.atlassian.net/browse/COSBETA-1876

## Description

Adds functionality to enable responsible persons to archive notifications for one of a number of set reasons. Archived notifications are displayed separately but are otherwise identical to non-archived ones. Archived notifications can also be unarchived at any time. A history is kept of each archival/unarchival along with the selected reason and this is displayed to any team member of the RP.

## Review apps

https://cosmetics-pr-2873-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2873-search-web.london.cloudapps.digital/