### PR TITLE
Fix smoke test assertion

### DIFF
--- a/cosmetics-web/spec/smoke/search_smoke_test_spec.rb
+++ b/cosmetics-web/spec/smoke/search_smoke_test_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Search smoke test" do
       session.click_on("Search")
       expect(session).to have_content(product_name)
 
-      session.find("a", text: "View").first.click
+      session.find("a", text: product_name).click
 
       # Poison Centre or OPSS user role view
       expect(session).to have_css("h2", text: "Product details")


### PR DESCRIPTION
So it clicks on the particular product name on search results.
