### PR TITLE
Bugfix: Fix exception when uploading ingredients file with extra columns

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
@@ -85,7 +85,7 @@ module ResponsiblePersons::Notifications::Components
     def header_missing_validation
       return if csv_header.blank?
 
-      if row_to_ingredient(**csv_header.to_h).valid?
+      if row_to_ingredient(**csv_header.to_h)&.valid?
         errors.add(:file, "The supplied header row must be included in the file")
       end
     end
@@ -100,7 +100,7 @@ module ResponsiblePersons::Notifications::Components
 
       ingredients_from_csv&.each_with_index do |row, i|
         ingredient = row_to_ingredient(**row.to_h)
-        unless ingredient.valid?
+        unless ingredient&.valid?
           @error_rows << i + 2
         end
         @ingredients << ingredient
@@ -119,7 +119,9 @@ module ResponsiblePersons::Notifications::Components
       file&.tempfile&.size.to_i > MAX_FILE_SIZE
     end
 
-    def row_to_ingredient(inci_name:, cas_number:, concentration:, poisonous:)
+    def row_to_ingredient(inci_name:, cas_number:, concentration:, poisonous:, **unwanted)
+      return if unwanted.present?
+
       ingredient = Ingredient.new(
         inci_name:, cas_number:, poisonous: poisonous?(poisonous),
       )

--- a/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
@@ -123,7 +123,7 @@ module ResponsiblePersons::Notifications::Components
       return if unwanted.present?
 
       ingredient = Ingredient.new(
-        inci_name:, cas_number:, poisonous: poisonous?(poisonous),
+        component:, inci_name:, cas_number:, poisonous: poisonous?(poisonous),
       )
       if component.exact?
         ingredient.exact_concentration = concentration
@@ -131,7 +131,6 @@ module ResponsiblePersons::Notifications::Components
         ingredient.exact_concentration = concentration.to_f
         ingredient.poisonous = true
       end
-      ingredient.component = component
       ingredient
     end
 

--- a/cosmetics-web/spec/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form_spec.rb
@@ -287,6 +287,54 @@ RSpec.describe ResponsiblePersons::Notifications::Components::BulkIngredientUplo
         end
       end
     end
+
+    context "when the file has too many columns in the header but right row values" do
+      let(:csv) do
+        <<~CSV
+          Name,Concentration,CAS, Is poisonous?,Foo
+          Aqua,65,497-19-8,false
+        CSV
+      end
+
+      it { expect(form).to be_valid }
+    end
+
+    context "when the file has an extra empty column in the header but right row values" do
+      let(:csv) do
+        <<~CSV
+          Name,Concentration,CAS, Is poisonous?,
+          Aqua,65,497-19-8,false
+        CSV
+      end
+
+      it { expect(form).to be_valid }
+    end
+
+    context "when the file has an extra empty column" do
+      let(:csv) do
+        <<~CSV
+          Name,Concentration,CAS, Is poisonous?
+          Aqua,65,497-19-8,false,
+        CSV
+      end
+
+      include_examples "validation" do
+        let(:error_messages) { ["The file has error in row: 2"] }
+      end
+    end
+
+    context "when a row has an extra column" do
+      let(:csv) do
+        <<~CSV
+          Name,Concentration,CAS, Is poisonous?
+          Aqua,65,497-19-8,false,bar
+        CSV
+      end
+
+      include_examples "validation" do
+        let(:error_messages) { ["The file has error in row: 2"] }
+      end
+    end
   end
 
   context "when using CSV for adding ingredients" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->[
[Jira ticket](https://regulatorydelivery.atlassian.net/browse/COSBETA-1887)
## Description
While parsing the ingredient rows from the CSV file into individual ingredients, the parser method raised an exception if the row had more columns than expected, as we use a strict list of arguments for parsing.

Resolved by allowing any extra arguments when calling the parser. If any extra arguments are provided, the parser will return without attempting to build an Ingredient.

Based on that return, we will be able to return the error on the particular line.

If this happens on the header, we will just ignore it as long as the ingredient rows are ok. We do not care about what extra info may come in the header row.

## Review apps


<!--- Edit links after PR is created -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
