### PR TITLE
Remove CSV upload link for range ingredients

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/_add_ingredient_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/_add_ingredient_concentration.html.erb
@@ -17,13 +17,15 @@
   <% end %>
 </div>
 
+<% if local_assigns[:show_csv_upload_link] %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-three-quarters">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-3">
     <%= link_to("Upload ingredients using CSV file",
                 responsible_person_notification_component_build_path(@notification.responsible_person, @notification, @component, :upload_ingredients_file),
                 class: "govuk-link govuk-link--no-visited-state govuk-!-font-size-19 opss-text-underline-offset") %>
+  </div>
 </div>
-</div>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_exact_concentration.html.erb
@@ -7,7 +7,7 @@
 
 <%= error_summary(@ingredient_concentration_form.errors, map_errors: { used_for_multiple_shades: "used_for_multiple_shades_true" }) %>
 
-<%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form do |form| %>
+<%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form, show_csv_upload_link: true do |form| %>
   <%= render "ingredient_exact_concentration_fields", component: @component, model: @ingredient_concentration_form, form: form %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_npis_needs_to_know.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_npis_needs_to_know.html.erb
@@ -9,7 +9,8 @@
            title: "Add an ingredient the <abbr>NPIS</abbr> needs to know about".html_safe,
            component: @component,
            model: @ingredient_concentration_form,
-           poisonous: true do |form| %>
+           poisonous: true,
+           show_csv_upload_link: true do |form| %>
   <%= render "ingredient_exact_concentration_fields", component: @component, model: @ingredient_concentration_form, form: form %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_range_concentration.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_ingredient_range_concentration.html.erb
@@ -10,7 +10,7 @@
                   %i[name cas_number poisonous exact_concentration range_concentration],
                   map_errors: { range_concentration: ingredient_range_concentration_items.first[:id], poisonous: "poisonous_true" }) %>
 
-<%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form do |form| %>
+<%= render "add_ingredient_concentration", title: title, component: @component, model: @ingredient_concentration_form, show_csv_upload_link: false do |form| %>
   <%= govukInput(form: form,
                  id: "name",
                  key: :name,

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/components/build_controller_spec.rb
@@ -152,6 +152,7 @@ RSpec.describe ResponsiblePersons::Notifications::Components::BuildController, t
       # rubocop:disable RSpec/MultipleExpectations
       it "shows the page for adding ingredients with exact concentration" do
         expect(response.body).to match(/<title>Add the ingredients .+<\/title>/)
+        expect(response.body).to have_link("Upload ingredients using CSV file")
         expect(response.body).not_to include("Is it used for different shades?")
         expect(response.body).to include("What is the exact concentration?")
         expect(response.body).not_to include("What is the concentration range?")
@@ -186,10 +187,13 @@ RSpec.describe ResponsiblePersons::Notifications::Components::BuildController, t
 
       render_views
 
+      # rubocop:disable RSpec/MultipleExpectations
       it "shows the page for adding ingredients with exact concentration" do
         expect(response.body).to match(/<title>Add the ingredients .+<\/title>/)
+        expect(response.body).not_to have_link("Upload ingredients using CSV file")
         expect(response.body).to include("What is the concentration range?")
       end
+      # rubocop:enable RSpec/MultipleExpectations
 
       it "links to the select formulation type page" do
         expect(response.body).to have_back_link_to(


### PR DESCRIPTION
JIRA ticket: https://regulatorydelivery.atlassian.net/browse/COSBETA-1889

## Description

Removes the link to upload an ingredients CSV if the ingredient is a range ingredient since these are not yet supported for CSV upload.

## Review apps

https://cosmetics-pr-2881-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2881-search-web.london.cloudapps.digital/