### PR TITLE
Remove CSV link from footer

### DIFF
--- a/cosmetics-web/app/views/layouts/_footer.html.erb
+++ b/cosmetics-web/app/views/layouts/_footer.html.erb
@@ -17,9 +17,6 @@
         <li class="govuk-footer__list-item">
           <%= link_to "Set up your authenticator app", how_to_set_up_authenticator_app_path, class: "govuk-footer__link", target: :_blank  %>
         </li>
-        <li class="govuk-footer__list-item">
-          <%= link_to "How to create an ingredient <abbr>CSV</abbr>".html_safe, "/help/csv", class: "govuk-footer__link", target: :_blank  %>
-        </li>
       </ul>
     </div>
 


### PR DESCRIPTION
## Description

Removes the “how to create an ingredient CSV” help link from the footer since it is already included on relevant pages.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-1884

## Screenshots/video

### Before

![Screenshot 2023-04-13 at 16 07 20](https://user-images.githubusercontent.com/444232/231803502-204649da-9ee8-4fa8-aa15-0ef2325f6429.png)

### After

![Screenshot 2023-04-13 at 16 07 59](https://user-images.githubusercontent.com/444232/231803563-2c66ce93-e734-4619-b69d-f81d1d6db62d.png)

## Review apps

https://cosmetics-pr-2893-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2893-search-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

No
