### PR TITLE
Remember notification status field when editing search

### DIFF
--- a/cosmetics-web/app/views/poison_centres/notifications_search/_results.html.erb
+++ b/cosmetics-web/app/views/poison_centres/notifications_search/_results.html.erb
@@ -14,6 +14,7 @@
         <%= render partial: 'poison_centres/notifications_search/hidden_date_fields', locals: { attribute: :date_to, id: :sort_form, search_type: 'notification' } %>
         <%= form.hidden_field :sort_by, id: 'notification_search_form_sort_by_hidden' %>
         <%= form.hidden_field :category, id: :notification_search_form_category_hidden %>
+        <%= form.hidden_field :status, id: :notification_search_form_status_hidden %>
         <%= form.hidden_field :search_fields, id: :notification_search_form_search_fields_hidden %>
         <%= form.hidden_field :match_similar, id: :notification_search_form_match_similar_hidden %>
         <button class="govuk-button opss-button-link govuk-!-font-size-14">

--- a/cosmetics-web/app/views/responsible_persons/search_notifications/_results.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/search_notifications/_results.html.erb
@@ -13,6 +13,7 @@
         <%= render partial: 'poison_centres/notifications_search/hidden_date_fields', locals: { attribute: :date_from, id: :sort_form, search_type: 'notification' } %>
         <%= render partial: 'poison_centres/notifications_search/hidden_date_fields', locals: { attribute: :date_to, id: :sort_form, search_type: 'notification' } %>
         <%= form.hidden_field :sort_by, id: 'notification_search_form_sort_by_hidden' %>
+        <%= form.hidden_field :status, id: :notification_search_form_status_hidden %>
         <button class="govuk-button opss-button-link govuk-!-font-size-14">
           Edit your search
         </button>

--- a/cosmetics-web/spec/features/search/notification_search_spec.rb
+++ b/cosmetics-web/spec/features/search/notification_search_spec.rb
@@ -205,6 +205,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     expect(page).to have_h1("Cosmetic products search")
 
     choose "Notification name"
+    choose "Archived"
     choose "Skin products"
     choose "Newest"
     check "Include similar words"
@@ -216,6 +217,7 @@ RSpec.feature "Search", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :
     expect(page).to have_h1("Cosmetic products search")
 
     expect(page).to have_checked_field("Notification name")
+    expect(page).to have_checked_field("Archived")
     expect(page).to have_checked_field("Skin products")
     expect(page).to have_checked_field("Newest")
     expect(page).to have_checked_field("Include similar words")

--- a/cosmetics-web/spec/features/submit/responsible_person/search_notifications_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/search_notifications_spec.rb
@@ -79,10 +79,12 @@ RSpec.describe "Search notifications page", type: :feature do
     visit responsible_person_search_notifications_path(responsible_person.id)
 
     fill_in "notification_search_form[q]", with: "Cream"
+    choose "Archived"
     click_button "Search"
     click_button "Edit your search"
 
     expect(page).to have_field("notification_search_form[q]", with: "Cream")
+    expect(page).to have_checked_field("notification_search_form[status]", with: "archived")
   end
 
   scenario "Show the total number of results" do


### PR DESCRIPTION
## Description

Fixes remembering the selected notification status when editing a search query.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-1924

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-2894-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2894-search-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

No
