### PR TITLE
Fix ingredient CSV upload success banner

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/upload_ingredients_file.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/upload_ingredients_file.html.erb
@@ -9,6 +9,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group <%= "govuk-form-group--error" if @bulk_ingredients_form.errors.any? %>">
+        <% if @ingredients_imported %>
+          <%= govukNotificationBanner(type: "success") do %>
+            <h3 class="govuk-notification-banner__heading">
+              <%= @component.ingredients_file.filename %> uploaded successfully
+            </h3>
+          <% end %>
+        <% end %>
+
         <h1 class="govuk-label-wrapper">
           <label class="govuk-label govuk-label--l" for="csv-upload">
             Upload the ingredients <abbr>CSV</abbr> file
@@ -17,15 +25,6 @@
         <div id="csv-hint" class="govuk-hint govuk-!-margin-bottom-8">
           Your <abbr title="Comma Separated Values">CSV</abbr> file must follow the correct requirements for your chosen formulation type. Learn about <a href="/help/csv" class="govuk-link govuk-link--no-visited-state" rel="noreferrer noopener" target="_blank">ingredient <abbr>CSV</abbr> files (opens in a new tab)</a>.
         </div>
-
-        <% if @ingredients_imported %>
-          <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-top-4">
-            <h1 class="govuk-panel__title">Upload successful</h1>
-            <div class="govuk-panel__body">
-              <strong><%= @component.ingredients_file.filename %></strong>
-            </div>
-          </div>
-        <% end %>
 
         <% if @component.ingredients_file.present? %>
           <div class="govuk-warning-text">

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Adding ingredients to components using a CSV file", :with_stubbe
     page.attach_file "spec/fixtures/files/Exact_ingredients.csv"
     click_on "Continue"
 
-    expect_confirmation_banner_with_text "Upload successful"
+    expect_success_banner_with_text "Exact_ingredients.csv uploaded successful"
     click_on "Continue"
 
     expect_to_be_on__what_is_ph_range_of_product_page


### PR DESCRIPTION
## Description

Fixes the positioning and styling of the success banner shown when an ingredients CSV file is uploaded for consistency with other similar banners.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-1882

## Screenshots/video

### Before

![Screenshot 2023-04-13 at 16 31 43](https://user-images.githubusercontent.com/444232/231810254-d648413f-e4ae-4f5f-8401-34fad3ce87ef.png)

### After

![Screenshot 2023-04-13 at 16 33 02](https://user-images.githubusercontent.com/444232/231810422-e234b33f-2239-4f22-a184-195907f263b7.png)

## Review apps

https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

No
