### PR TITLE
Fix failed antivirus check error

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/drafts_controller.rb
@@ -22,7 +22,7 @@ class ResponsiblePersons::DraftsController < SubmitApplicationController
   def accept
     unless @notification.submit_notification!
       flash[:alert] = "Notification could not be submitted"
-      redirect_to edit_responsible_person_notification_path(@responsible_person, @notification, submit_failed: true)
+      redirect_to edit_responsible_person_notification_path(@responsible_person, @notification)
     end
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications_controller.rb
@@ -51,10 +51,6 @@ class ResponsiblePersons::NotificationsController < SubmitApplicationController
     return redirect_to responsible_person_notification_path(@notification.responsible_person, @notification) if @notification.notification_complete? || @notification.archived?
 
     authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
-
-    if params[:submit_failed]
-      add_image_upload_errors
-    end
   end
 
   def choose_archive_reason
@@ -114,16 +110,6 @@ private
       .archived
       .order(notification_complete_at: :desc)
       .page(params[:page]).per(page_size)
-  end
-
-  def add_image_upload_errors
-    if @notification.images_failed_anti_virus_check?
-      @notification.errors.add :image_uploads, "failed anti virus check"
-    end
-
-    if @notification.images_pending_anti_virus_check?
-      @notification.errors.add :image_uploads, "waiting for files to pass anti virus check. Refresh to update"
-    end
   end
 
   def notification_params


### PR DESCRIPTION
## Description

Fixes an issue where a failed antivirus check for an image results in a non-existant method being called.

Removing this path allows the `AcceptAndSubmitValidator` to return error messages in this instance.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-1936

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-2906-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2906-search-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

No
