### PR TITLE
Make all cookies secure and HttpOnly

### DIFF
--- a/cosmetics-web/app/controllers/application_controller.rb
+++ b/cosmetics-web/app/controllers/application_controller.rb
@@ -42,7 +42,7 @@ private
 
   def prepare_logger_data
     RequestStore.store[:logger_request_id] = request.request_id
-    cookies[:journey_uuid] ||= request.request_id
+    cookies[:journey_uuid] ||= { value: request.request_id, secure: Rails.env.production?, httponly: true }
   end
 
   def user_class

--- a/cosmetics-web/app/controllers/concerns/cookies_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/cookies_concern.rb
@@ -44,6 +44,6 @@ module CookiesConcern
   end
 
   def set_analytics_cookies(accept_analytics_cookies)
-    cookies[:accept_analytics_cookies] = { value: accept_analytics_cookies, expires: 1.year.from_now }
+    cookies[:accept_analytics_cookies] = { value: accept_analytics_cookies, expires: 1.year.from_now, secure: Rails.env.production?, httponly: true }
   end
 end

--- a/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
@@ -61,7 +61,7 @@ module SecondaryAuthenticationConcern
     user_id = (session[:secondary_authentication_user_id] || user_id_for_secondary_authentication)
     return if user_id.blank?
 
-    cookies.signed["two-factor-#{user_id}"] = { value: timestamp, expiry: 0 }
+    cookies.signed["two-factor-#{user_id}"] = { value: timestamp, secure: Rails.env.production?, httponly: true }
   end
 
   def get_secondary_authentication_time

--- a/cosmetics-web/config/initializers/devise.rb
+++ b/cosmetics-web/config/initializers/devise.rb
@@ -182,7 +182,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = { secure: Rails.env.production?, httponly: true }
 
   # ==> Configuration for :validatable
   # Range for password length.


### PR DESCRIPTION
## Description

Adds the `secure` and `httponly` flags to all cookies to limit how they can be read.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-1930

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-2912-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2912-search-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

No
