### PR TITLE
Fix error message alignment on CMRs page

### DIFF
--- a/cosmetics-web/app/assets/stylesheets/component_build.scss
+++ b/cosmetics-web/app/assets/stylesheets/component_build.scss
@@ -18,4 +18,10 @@
       flex: 1 0 auto;
     }
   }
+
+  // cancels the `margin-left` on `govuk-grid-row` when a half-width child
+  // item has an error, otherwise it does not align with full-width siblings
+  .multi-field-item.govuk-form-group--error {
+    margin-left: 15px;
+  }
 }


### PR DESCRIPTION
## Description

Fixes an alignment issue on the CMRs page where half-width fields have errors.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-1979

## Screenshots/video

### Before

![image-20230425-084411](https://user-images.githubusercontent.com/444232/234291751-f4702ff3-c5e7-4984-9319-9cf92f6d2561.png)

### After

![Screenshot 2023-04-25 at 14 25 36](https://user-images.githubusercontent.com/444232/234291614-f178e0ad-2b8d-4b80-88f4-8676df100e66.png)

## Review apps

https://cosmetics-pr-2918-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2918-search-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

No
