### PR TITLE
Fix Scout APM instrumentation issue

### DIFF
--- a/cosmetics-web/config/scout_apm.yml
+++ b/cosmetics-web/config/scout_apm.yml
@@ -20,6 +20,12 @@ common: &defaults
   # - Valid Options: true, false
   monitor: true
 
+  # Scout APM and Sentry both try to instrument `Net:HTTP` which causes a conflict
+  # and results in `StackLevelTooDeep` exceptions. Disable Scout APM instrumentation
+  # since they have not released a fix.
+  disabled_instruments:
+    - "NetHttp"
+
 production:
   <<: *defaults
 


### PR DESCRIPTION
## Description

Disable Scout APM instrumentation of `Net::HTTP` to prevent a conflict with Sentry.

See https://github.com/getsentry/sentry-ruby/issues/1427#issuecomment-932677359 for more information.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-1991

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-2930-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2930-search-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

No
