### PR TITLE
Allow minimum_concentration equal to zero

### DIFF
--- a/cosmetics-web/app/models/ingredient.rb
+++ b/cosmetics-web/app/models/ingredient.rb
@@ -55,7 +55,7 @@ class Ingredient < ApplicationRecord
 
   validates :minimum_concentration,
             presence: true,
-            numericality: { allow_blank: true, greater_than: 0, less_than_or_equal_to: 100 },
+            numericality: { allow_blank: true, less_than_or_equal_to: 100 },
             if: -> { range? && poisonous == false }
 
   validates :maximum_concentration,


### PR DESCRIPTION
## Description
- Sentry is alerting that the 'greater than 0' validation is preventing users from cloning some notifications

- So we are removing the validation rule

Sentry error: https://beis.sentry.io/issues/3989855730/?project=1398436

<!-- Describe your changes in detail -->

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2022

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
