### PR TITLE
Avoid displaying sub_sub_categories when there is only one option

### DIFF
--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -121,7 +121,7 @@ FactoryBot.define do
     end
 
     trait :with_other_category do
-      sub_sub_category { "other_skin_care_products_child" }
+      sub_sub_category { "other_skin_products_child" }
     end
 
     trait :with_range_ingredients do

--- a/cosmetics-web/spec/features/submit/notification_wizard/category_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/category_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Categories", :with_stubbed_antivirus, type: :feature do
+  let(:responsible_person) { create(:responsible_person_with_user, :with_a_contact_person) }
+  let(:user) { responsible_person.responsible_person_users.first.user }
+
+  before do
+    sign_in_as_member_of_responsible_person(responsible_person, user)
+
+    visit "/responsible_persons/#{responsible_person.id}/notifications"
+
+    click_on "Create a new product notification"
+
+    complete_product_wizard
+    complete_product_details
+    click_link "Product details"
+    click_button "Continue"
+    click_button "Continue"
+    click_button "Continue"
+    click_button "Continue"
+  end
+
+  scenario "When there is more than one sub_sub_category" do
+    choose "Oral hygiene products"
+    click_button "Continue"
+
+    choose "Tooth care products"
+    click_button "Continue"
+
+    # we display the select_sub_sub_category page
+    choose "Toothpaste"
+    click_button "Continue"
+
+    expect(page.current_path).to end_with("/build/select_formulation_type")
+    click_link "Back"
+
+    # and go back to the sub_sub_category page
+    expect(page.current_path).to end_with("/select_sub_sub_category")
+  end
+
+  scenario "When there is only one sub_sub_category and we don't want to display that page" do
+    choose "Oral hygiene products"
+    click_button "Continue"
+
+    choose "Other oral hygiene products"
+    click_button "Continue"
+
+    # we skip the select_sub_sub_category page
+    expect(page.current_path).to end_with("/build/select_formulation_type")
+    click_link "Back"
+
+    # and go back to the sub_category page
+    expect(page.current_path).to end_with("/select_sub_category")
+  end
+end


### PR DESCRIPTION
## Description

Avoid displaying the sub_sub_categories page when there is only one option to be displayed:
- Instead, we store the default sub_sub_category and the user proceeds to the next step
- We also check the back button action and choose whether to display the sub_category or the sub_sub_category page

## JIRA ticket(s)
https://regulatorydelivery.atlassian.net/browse/COSBETA-1845

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-2955-submit-web.london.cloudapps.digital/ 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
