### PR TITLE
Ensure a components does not have any blank shades

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -127,6 +127,7 @@ class Component < ApplicationRecord
   }
 
   before_save :remove_other_special_applicator, unless: :other_special_applicator?
+  before_save :remove_blank_shades
 
   # Deletes all the associated poisonous ingredients from predefined components when
   # "contains_poisonous_ingredients" is set to "false"
@@ -360,5 +361,9 @@ private
 
   def remove_poisonous_ingredients!
     ingredients.poisonous.destroy_all
+  end
+
+  def remove_blank_shades
+    shades.reject!(&:blank?) if shades
   end
 end

--- a/cosmetics-web/spec/features/submit/notification_wizard/shades_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/shades_spec.rb
@@ -29,8 +29,13 @@ RSpec.describe "Adding and removing shades", :with_stubbed_antivirus, type: :fea
 
     expect(page).to have_field("component_shades-0", with: "Red")
     expect(page).to have_field("component_shades-1", with: "Yellow")
+
+    click_on "Add another shade" # attempt to add a blank shade
+
     click_on "Continue"
 
     expect(page).to have_css("h1", text: "What is the physical form of the product?")
+
+    expect(Component.last.shades).to eq(%w[Red Yellow])
   end
 end


### PR DESCRIPTION
## Description

Before saving a component, we reject any blank shades.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2010

## Screenshots/video

<!-- Add "before" and "after" screenshots for frontend changes, and a walkthrough video if that helps explain your changes -->

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-2966-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2966-search-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
