### PR TITLE
Prefer N/A on summary page when the pH is not required

### DIFF
--- a/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
+++ b/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
@@ -212,6 +212,11 @@ private
           key: { html: "<abbr title='Power of hydrogen'>pH</abbr>".html_safe },
           value: { text: t(component.ph, scope: %i[component_ph check_your_answers]) },
         }
+      elsif !component.ph_required?
+        {
+          key: { html: "<abbr title='Power of hydrogen'>pH</abbr>".html_safe },
+          value: { text: "N/A" },
+        }
       elsif component.minimum_ph == component.maximum_ph
         {
           key: { html: "Exact <abbr title='Power of hydrogen'>pH</abbr>".html_safe },


### PR DESCRIPTION
## Description

When the pH is not required, we display:
`pH` = `N/A` on the notification summary page

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2030

## Screenshots/video


<img width="700" alt="Screenshot 2023-05-30 at 15 23 02" src="https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/5799/9d5c1456-8449-4bab-aad8-2602dbd28d59">

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-2977-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2977-search-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
