### PR TITLE
Support User logs into cosmetics-support

### DIFF
--- a/cosmetics-web/app/controllers/application_controller.rb
+++ b/cosmetics-web/app/controllers/application_controller.rb
@@ -67,6 +67,8 @@ private
     stored_location_for(resource) ||
       if submit_domain?
         dashboard_path
+      elsif support_domain?
+        root_path
       else
         poison_centre_notifications_search_path
       end
@@ -84,34 +86,64 @@ private
   end
 
   def current_user
-    current_submit_user || current_search_user
+    current_submit_user || current_search_user || current_support_user
   end
 
   def user_signed_in?
-    submit_user_signed_in? || search_user_signed_in?
+    submit_user_signed_in? || search_user_signed_in? || support_user_signed_in?
   end
 
   def new_user_session_path(*args)
-    submit_domain? ? new_submit_user_session_path(*args) : new_search_user_session_path(*args)
+    if submit_domain?
+      new_submit_user_session_path(*args)
+    elsif support_domain?
+      new_support_user_session_path(*args)
+    else
+      new_search_user_session_path(*args)
+    end
   end
   helper_method :new_user_session_path
 
   def authenticate_user!
-    submit_domain? ? authenticate_submit_user! : authenticate_search_user!
+    if submit_domain?
+      authenticate_submit_user!
+    elsif support_domain?
+      authenticate_support_user!
+    else
+      authenticate_search_user!
+    end
   end
 
   def destroy_user_session_path
-    submit_domain? ? destroy_submit_user_session_path : destroy_search_user_session_path
+    if submit_domain?
+      destroy_submit_user_session_path
+    elsif support_domain?
+      destroy_support_user_session_path
+    else
+      destroy_search_user_session_path
+    end
   end
   helper_method :destroy_user_session_path
 
   def user_session_path
-    submit_domain? ? submit_user_session_path : search_user_session_path
+    if submit_domain?
+      submit_user_session_path
+    elsif support_domain?
+      support_user_session_path
+    else
+      search_user_session_path
+    end
   end
   helper_method :user_session_path
 
   def user_password_path
-    submit_domain? ? submit_user_password_path : search_user_password_path
+    if submit_domain?
+      submit_user_password_path
+    elsif support_domain?
+      support_user_password_path
+    else
+      search_user_password_path
+    end
   end
   helper_method :user_password_path
 end

--- a/cosmetics-web/app/controllers/concerns/domain_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/domain_concern.rb
@@ -33,13 +33,14 @@ module DomainConcern
 private
 
   def set_service_name
-    @service_name = if submit_domain?
-                      "Submit cosmetic product notifications"
-                    elsif support_domain?
-                      "OSU Support"
-                    else
-                      "Search cosmetic product notifications"
-                    end
+    @service_name =
+      if support_domain?
+        "OSU Portal"
+      elsif search_domain?
+        "Search cosmetic product notifications"
+      else
+        "Submit cosmetic product notifications"
+      end
   end
 
   def submit_domains

--- a/cosmetics-web/app/controllers/support/landing_page_controller.rb
+++ b/cosmetics-web/app/controllers/support/landing_page_controller.rb
@@ -1,0 +1,5 @@
+class Support::LandingPageController < SupportApplicationController
+  layout "landing_page"
+
+  def index; end
+end

--- a/cosmetics-web/app/controllers/support_application_controller.rb
+++ b/cosmetics-web/app/controllers/support_application_controller.rb
@@ -1,0 +1,13 @@
+class SupportApplicationController < ApplicationController
+  before_action :allow_only_support_domain
+
+private
+
+  def allow_only_support_domain
+    raise "Not a support domain" unless support_domain?
+  end
+
+  def authorize_user!
+    redirect_to invalid_account_path if current_user && !current_user.is_a?(SupportUser)
+  end
+end

--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -135,6 +135,8 @@ module Users
         return SearchUser
       elsif params.key?("submit_user")
         return SubmitUser
+      elsif params.key?("support_user")
+        return SupportUser
       end
 
       raise ArgumentError

--- a/cosmetics-web/app/mailers/notify_mailer.rb
+++ b/cosmetics-web/app/mailers/notify_mailer.rb
@@ -1,8 +1,10 @@
 class NotifyMailer < GovukNotifyRails::Mailer
-  # TODO(ruben): Add support domain
   def self.get_mailer(user)
     return SubmitNotifyMailer if user.is_a? SubmitUser
     return SearchNotifyMailer if user.is_a? SearchUser
+
+    # TODO(ruben): Replace with support domain mailer
+    return SearchNotifyMailer if user.is_a? SupportUser
 
     raise "No Mailer for #{user.class}"
   end
@@ -16,6 +18,8 @@ class NotifyMailer < GovukNotifyRails::Mailer
                   edit_submit_user_password_url(reset_password_token: token, host: @host)
                 when SearchUser
                   edit_search_user_password_url(reset_password_token: token, host: @host)
+                when SupportUser
+                  edit_support_user_password_url(reset_password_token: token, host: @host)
                 end
     set_personalisation(
       name: user.name,
@@ -75,6 +79,9 @@ private
     end
     if user.is_a? SearchUser
       @host = ENV["SEARCH_HOST"]
+    end
+    if user.is_a? SupportUser
+      @host = ENV["SUPPORT_HOST"]
     end
   end
 

--- a/cosmetics-web/app/models/concerns/privileges/support_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/support_concern.rb
@@ -1,0 +1,9 @@
+module Privileges
+  module SupportConcern
+    include AbstractConcern
+
+    def opss_general_user?
+      true
+    end
+  end
+end

--- a/cosmetics-web/app/models/support_user.rb
+++ b/cosmetics-web/app/models/support_user.rb
@@ -1,0 +1,30 @@
+class SupportUser < User
+  include Privileges::SupportConcern
+
+  INVITATION_EXPIRATION_DAYS = 14
+  ALLOW_INTERNATIONAL_PHONE_NUMBER = false
+  TOTP_ISSUER = "Support Cosmetics".freeze
+
+  attribute :skip_password_validation, :boolean, default: false
+
+  validates :mobile_number,
+            phone: { message: :invalid, allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
+            if: -> { mobile_number.present? }
+
+  def resend_account_setup_link
+    SupportNotifyMailer.invitation_email(self).deliver_later
+  end
+
+  def invitation_expired?
+    invited_at <= INVITATION_EXPIRATION_DAYS.days.ago
+  end
+
+private
+
+  # Overwrites Devise::Models::Validatable#password_required?
+  def password_required?
+    return false if skip_password_validation
+
+    super
+  end
+end

--- a/cosmetics-web/app/views/layouts/_header.html.erb
+++ b/cosmetics-web/app/views/layouts/_header.html.erb
@@ -21,6 +21,7 @@
     <div class="govuk-header__content">
       <%= render partial: ("search/header_link") if search_domain? %>
       <%= render partial: ("submit/header_link") if submit_domain? %>
+      <%= render partial: ("support/header_link") if support_domain? %>
       <button class="govuk-header__menu-button govuk-js-header-toggle no-print" role="button" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
       <nav>
         <ul id="navigation" class="govuk-header__navigation no-print" aria-label="Top Level Navigation">

--- a/cosmetics-web/app/views/support/_header_link.html.erb
+++ b/cosmetics-web/app/views/support/_header_link.html.erb
@@ -1,0 +1,3 @@
+<a class="govuk-header__link govuk-header__link--service-name" href="#" %>
+<%= @service_name %>
+</a>

--- a/cosmetics-web/app/views/support/landing_page/index.html
+++ b/cosmetics-web/app/views/support/landing_page/index.html
@@ -1,0 +1,1 @@
+<h1>Support landing page</h1>

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -96,7 +96,7 @@ Rails.application.routes.draw do
   end
 
   # All requests besides "Search" host ones will default to "Submit" pages.
-  constraints DomainExclusionConstraint.new(ENV.fetch("SEARCH_HOST")) do
+  constraints DomainInclusionConstraint.new(ENV.fetch("SUBMIT_HOST")) do
     devise_for :submit_users,
                path: "",
                path_names: { sign_in: "sign-in", sign_out: "sign-out" },
@@ -205,6 +205,18 @@ Rails.application.routes.draw do
       end
     end
     resource :dashboard, controller: "submit/dashboard", only: %i[show]
+  end
+
+  constraints DomainInclusionConstraint.new(ENV.fetch("SUPPORT_HOST")) do
+    devise_for :support_users,
+               path: "",
+               path_names: { sign_up: "sign-up", sign_in: "sign-in", sign_out: "sign-out" },
+               controllers: { passwords: "users/passwords", registrations: "users/registrations", sessions: "users/sessions", unlocks: "users/unlocks" }
+    devise_scope :support_user do
+      resource :check_your_email, path: "check-your-email", only: :show, controller: "users/check_your_email"
+      post "sign-out-before-resetting-password", to: "users/passwords#sign_out_before_resetting_password"
+    end
+    root "support/landing_page#index", as: :support_root
   end
 
   resource :my_account, only: [:show], controller: :my_account do

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -95,6 +95,9 @@ FactoryBot.define do
       end
     end
 
+    factory :support_user, class: "SupportUser" do
+    end
+
     factory :search_user, class: "SearchUser" do
       role {}
       invitation_token { Devise.friendly_token }

--- a/cosmetics-web/spec/features/account/sign_in_spec.rb
+++ b/cosmetics-web/spec/features/account/sign_in_spec.rb
@@ -674,4 +674,26 @@ RSpec.feature "Signing in as a user", :with_2fa, :with_stubbed_mailer, :with_stu
       include_examples "sign in"
     end
   end
+
+  describe "for support" do
+    before do
+      configure_requests_for_support_domain
+    end
+
+    describe "for user with both app and sms secondary authentication", :with_2fa, :with_2fa_app do
+      let(:user) { create(:support_user, :with_all_secondary_authentication_methods) }
+
+      scenario "user signs in selecting app authentication" do
+        visit "/sign-in"
+        fill_in_credentials
+        select_secondary_authentication_app
+
+        expect_to_be_on_secondary_authentication_app_page
+        complete_secondary_authentication_app
+
+        expect(page).to have_current_path("/")
+        expect(page).to have_link("OSU Portal", href: "#")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Barebones implementation to enable a SupportUser to log into the cosmetic-support domain

Outstanding:
- Integrate with Support Notify
- Enable Support User to log into cosmetics-search

## JIRA ticket(s)
https://regulatorydelivery.atlassian.net/browse/COSBETA-2082
Note: This PR does not complete the ticket


## Screenshots/video

<!-- Add "before" and "after" screenshots for frontend changes, and a walkthrough video if that helps explain your changes -->

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-2980-submit-web.london.cloudapps.digital/
https://cosmetics-pr-2980-search-web.london.cloudapps.digital/
https://cosmetics-pr-2980-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
