### PR TITLE
Fix database seeds

### DIFF
--- a/cosmetics-web/.env.development.example
+++ b/cosmetics-web/.env.development.example
@@ -30,8 +30,8 @@ TWO_FACTOR_AUTHENTICATION_ENABLED=false
 WHITELISTED_DIRECT_OTP_CODE=11222
 WHITELISTED_TIME_OTP_CODE=111222
 
-# Use your own name and email address here to set up your account when running the `rails db:seed` command
-SEED_USERS=Name_Surname:user@example.com
+# Use your own name and email address here to set a SubmitUser account when running the `rails db:seed` command
+SEED_USERS='Name Surname:user@example.com'
 
 # PostgreSQL
 DATABASE_URL=postgres://localhost:5432/cosmetics_dev?user=postgres

--- a/cosmetics-web/db/seeds.rb
+++ b/cosmetics-web/db/seeds.rb
@@ -177,7 +177,6 @@ ActiveRecord::Base.transaction do
       confirmed_at: Time.zone.now,
       unique_session_id: Devise.friendly_token,
     }
-    SearchUser.create!(user_params.merge({ role: :poison_centre, invite: true }))
     u = SubmitUser.create!(user_params)
     u.responsible_persons << rp
   end


### PR DESCRIPTION
## Description

Remove SearchUser creation from seeds file
- If we try to create a SearchUser and a SubmitUser with the same email address,
we get a validation error

Ensure the suggested SEED_USER is valid
- We now validate that a user#name does not contain underscores
 