### PR TITLE
allow minimum and maximum ingredient concentration to be equal

### DIFF
--- a/cosmetics-web/app/models/ingredient.rb
+++ b/cosmetics-web/app/models/ingredient.rb
@@ -109,7 +109,7 @@ private
   def maximum_minimum_concentration_range
     return unless maximum_concentration && minimum_concentration
 
-    unless maximum_concentration > minimum_concentration
+    unless maximum_concentration >= minimum_concentration
       errors.add(:maximum_concentration,
                  message: "Maximum concentration must be greater than the minimum concentration")
     end

--- a/cosmetics-web/app/views/responsible_persons/notifications/_ingredients.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_ingredients.html.erb
@@ -26,8 +26,12 @@
           # Minimum/Maximum replaces range_concentation
         %>
         <% elsif ingredient.range? %>
-          <dd>Minimum range: <%= ingredient.minimum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
-          <dd>Maximum range: <%= ingredient.maximum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
+          <% if ingredient.minimum_concentration == ingredient.maximum_concentration %>
+            <dd><% if ingredient.used_for_multiple_shades? %>Maximum concentration: <% end %> <%= ingredient.maximum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
+          <% else %>
+            <dd>Minimum range: <%= ingredient.minimum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
+            <dd>Maximum range: <%= ingredient.maximum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
@@ -142,5 +142,7 @@ RSpec.describe "Adding ingredients to components using a CSV file", :with_stubbe
     expect(page).to have_css("dd", text: "CAS: 497-19-8")
     expect(page).to have_css("dt", text: "Eucalyptol")
     expect(page).to have_css("dd", text: "12.0% w/w")
+    expect(page).to have_css("dt", text: "Ethanol")
+    expect(page).to have_css("dd", text: "10.0% w/w")
   end
 end

--- a/cosmetics-web/spec/fixtures/files/range_ingredients.csv
+++ b/cosmetics-web/spec/fixtures/files/range_ingredients.csv
@@ -2,3 +2,4 @@ Ingredient name,Minimum % w/w,Maximum % w/w,Exact % w/w,CAS number,Does NPIS nee
 Sodium carbonate,10,30,,497-19-8,false
 Water,35,65,,7732-18-5,false
 Eucalyptol,,,12,,true
+Ethanol,10,10,,,false

--- a/cosmetics-web/spec/models/ingredient_spec.rb
+++ b/cosmetics-web/spec/models/ingredient_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe Ingredient, type: :model do
       context "when the maximum_concentration is equal to the minimum_concentration" do
         let(:maximum_concentration) { 1 }
 
-        it "is not valid" do
+        it "is valid" do
           ingredient.valid?
-          expect(ingredient.errors[:maximum_concentration]).to include(error_message)
+          expect(ingredient).to be_valid
         end
       end
 


### PR DESCRIPTION
## Description

Validation for minimum and maximum range for ingredients now only applies if the maximum is set to less than the minimum

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2114

## Screenshots/video

![Screenshot 2023-07-04 at 10-25-29 Accept and submit - review - Submit cosmetic product notifications](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/b008d71e-b2a9-4a56-91a0-79d9a025a8d3)


## Review apps

https://cosmetics-pr-3031-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3031-search-web.london.cloudapps.digital/
https://cosmetics-pr-3031-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
