### PR TITLE
add validation for file type on bulk upload

### DIFF
--- a/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
@@ -64,8 +64,7 @@ module ResponsiblePersons::Notifications::Components
     def file_is_csv_file_validation
       return if file_too_large?
 
-      errors.add(:file, "The selected file must be a CSV file") if file_type_incorrect?
-      return if file_type_incorrect?
+      errors.add(:file, "The selected file must be a CSV file") && return if file_type_incorrect?
 
       parse_csv_file
     rescue CSV::MalformedCSVError, ArgumentError

--- a/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
+++ b/cosmetics-web/app/forms/responsible_persons/notifications/components/bulk_ingredient_upload_form.rb
@@ -64,6 +64,9 @@ module ResponsiblePersons::Notifications::Components
     def file_is_csv_file_validation
       return if file_too_large?
 
+      errors.add(:file, "The selected file must be a CSV file") if file_type_incorrect?
+      return if file_type_incorrect?
+
       parse_csv_file
     rescue CSV::MalformedCSVError, ArgumentError
       errors.add(:file)
@@ -125,6 +128,10 @@ module ResponsiblePersons::Notifications::Components
 
     def file_too_large?
       file&.tempfile&.size.to_i > MAX_FILE_SIZE
+    end
+
+    def file_type_incorrect?
+      file&.content_type != "text/csv"
     end
 
     def multiple_shades?

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe "Adding ingredients to components using a CSV file", :with_stubbe
     expect_to_be_on_add_csv_ingredients_page
     expect_form_to_have_errors(file: { message: "The selected file must be a CSV file", id: "file", href: "responsible_persons_notifications_components_bulk_ingredient_upload_form_file" })
 
+    page.attach_file "spec/fixtures/files/testText.txt"
+    click_on "Continue"
+
+    expect_to_be_on_add_csv_ingredients_page
+    expect_form_to_have_errors(file: { message: "The selected file must be a CSV file", id: "file", href: "responsible_persons_notifications_components_bulk_ingredient_upload_form_file" })
+
     page.attach_file "spec/fixtures/files/exact_ingredients.csv"
     click_on "Continue"
 


### PR DESCRIPTION
## Description

Adds validation for file type on ingredient. bulk upload.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2036

## Screenshots/video
![Screenshot 2023-07-04 at 11-22-57 Error Upload ingredients file - Submit cosmetic product notifications](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/d5120c38-b0a5-4c66-a431-730861dd58be)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3032-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3032-search-web.london.cloudapps.digital/
https://cosmetics-pr-3032-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [x] Documentation has been added or updated
