### PR TITLE
Feature/2044 reset account

### DIFF
--- a/cosmetics-web/spec/features/support/account_administration_spec.rb
+++ b/cosmetics-web/spec/features/support/account_administration_spec.rb
@@ -191,4 +191,29 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     expect(page).to have_h1("#{submit_user2.name} - Remove access")
     expect(page).to have_text("#{submit_user2.name} cannot be removed from the Responsible Person because #{responsible_person_user4.responsible_person.name} does not have any other user accounts with access.")
   end
+
+  scenario "Resetting an account" do
+    visit "/account-admin/#{submit_user2.id}"
+
+    expect(page).to have_h1(submit_user2.name)
+
+    click_link "Reset"
+
+    #select_secondary_authentication_app
+
+    #expect_to_be_on_secondary_authentication_app_page
+    #complete_secondary_authentication_app
+
+    expect(page).to have_h1("Reset account")
+    click_link("Cancel")
+
+    expect(page).not_to have_css("div.govuk-notification-banner", text: "The account has been reset")
+
+    click_link "Reset"
+
+    expect(page).to have_h1("Reset account")
+    click_button("Reset account")
+
+    expect(page).to have_css("div.govuk-notification-banner", text: "The account has been reset")
+  end
 end

--- a/cosmetics-web/spec/features/support/account_administration_spec.rb
+++ b/cosmetics-web/spec/features/support/account_administration_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "support/feature_helpers"
 
 RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :with_2fa_app, type: :feature do
-  let(:user) { create(:support_user, :with_sms_secondary_authentication) }
+  let(:user) { create(:support_user, :with_all_secondary_authentication_methods) }
   let(:search_user1) { create(:search_user) }
   let(:search_user2) { create(:search_user) }
   let(:search_user3) { create(:search_user, name: search_user1.name) }
@@ -27,6 +27,8 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     responsible_person_user4
 
     sign_in user
+    select_secondary_authentication_app
+    complete_secondary_authentication_app
   end
 
   scenario "Searching for an account that exists" do
@@ -195,14 +197,18 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
   scenario "Resetting an account" do
     visit "/account-admin/#{submit_user2.id}"
 
+    future_time = 30.seconds.from_now
+    past_time = 2.seconds.ago
+
+    travel_to(future_time)
+
     expect(page).to have_h1(submit_user2.name)
 
     click_link "Reset"
-
-    #select_secondary_authentication_app
-
-    #expect_to_be_on_secondary_authentication_app_page
-    #complete_secondary_authentication_app
+    select_secondary_authentication_app
+    expect_to_be_on_secondary_authentication_app_page
+    travel_to(past_time)
+    complete_secondary_authentication_app
 
     expect(page).to have_h1("Reset account")
     click_link("Cancel")

--- a/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
+++ b/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
@@ -57,7 +57,13 @@ module SupportPortal
 
     # DELETE /:id/reset
     # TODO(ruben): Add functionality
-    def reset; end
+    def reset
+      if @user.reset_secondary_authentication!
+        redirect_to account_administration_path(@user, q: params[:q]), notice: "The account has been reset"
+      else
+        redirect_to reset_account_path(@user, q: params[:q]), notice: "The account failed to reset"
+      end
+    end
 
     # GET /:id/edit-responsible-persons
     def edit_responsible_persons; end

--- a/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
+++ b/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
@@ -3,6 +3,7 @@ module SupportPortal
     before_action :set_user, except: %i[index]
     before_action :set_responsible_persons, only: %i[show edit_responsible_persons]
     before_action :set_responsible_person, only: %i[delete_responsible_person_user_confirm delete_responsible_person_user]
+    before_action :reenforce_secondary_authentication, only: :reset_account
 
     # GET /
     def index

--- a/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
+++ b/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
@@ -53,11 +53,9 @@ module SupportPortal
     end
 
     # GET /:id/reset-account
-    # TODO(ruben): Add functionality
     def reset_account; end
 
     # DELETE /:id/reset
-    # TODO(ruben): Add functionality
     def reset
       if @user.reset_secondary_authentication!
         redirect_to account_administration_path(@user, q: params[:q]), notice: "The account has been reset"

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/reset_account.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/reset_account.html.erb
@@ -7,7 +7,7 @@
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive">Warning</span>
-        Resetting a user account will reset the user's authhenticator app, telephone number for text messaging, recovery codes and their password.
+        Resetting a user account will reset the user's authenticator app, telephone number for text messaging, recovery codes and their password.
       </strong>
       <br>
       <strong class="govuk-warning-text__text">

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/reset_account.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/reset_account.html.erb
@@ -3,20 +3,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        Resetting a user account will reset the user's authenticator app, telephone number for text messaging, recovery codes and their password.
-      </strong>
-      <br>
-      <strong class="govuk-warning-text__text">
-        The user will need to follow login instructions as per the email they receive
-      </strong>
-    </div>
+  <%= govuk_warning_text do %>
+    Resetting a user account will reset the user's authenticator app, telephone number for text messaging, recovery codes and their password.
+    <br>
+    <br>
+    The user will need to follow login instructions as per the email they receive
+  <% end %>
     <%= form_with model: @user, url: reset_account_administration_path, method: :delete do |f| %>
       <%= f.govuk_submit "Reset account" %>
-      <%= link_to "Cancel", account_administration_path(@user, q: params[:q]), class: "govuk-button govuk-button--secondary" %>
+      <%= govuk_button_link_to "Cancel", account_administration_path(@user, q: params[:q]), secondary: true %>
     <% end %>
   </div>
 </div>

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/reset_account.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/reset_account.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "Reset account" %>
+<% @back_link_href = account_administration_path(@user, q: params[:q]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        Resetting a user account will reset the user's authhenticator app, telephone number for text messaging, recovery codes and their password.
+      </strong>
+      <br>
+      <strong class="govuk-warning-text__text">
+        The user will need to follow login instructions as per the email they receive
+      </strong>
+    </div>
+    <%= form_with model: @user, url: reset_account_administration_path, method: :delete do |f| %>
+      <%= f.govuk_submit "Reset account" %>
+      <%= link_to "Cancel", account_administration_path(@user, q: params[:q]), class: "govuk-button govuk-button--secondary" %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
## Description

Adds ability to reset users' secondary authentication in the support portal

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2044

## Screenshots/video

![Screenshot 2023-07-11 at 13-02-33 Reset account - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/fb938f93-a0f2-4c83-b077-e251891f2eb6)

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3046-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3046-search-web.london.cloudapps.digital/
https://cosmetics-pr-3046-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated