### PR TITLE
add alternative wording for opss support users on resend text message screen

### DIFF
--- a/cosmetics-web/app/models/support_user.rb
+++ b/cosmetics-web/app/models/support_user.rb
@@ -30,6 +30,10 @@ class SupportUser < User
     invited_at <= INVITATION_EXPIRATION_DAYS.days.ago
   end
 
+  def opss?
+    role&.match?(/opss_/)
+  end
+
 private
 
   # Overwrites Devise::Models::Validatable#password_required?

--- a/cosmetics-web/app/views/secondary_authentication/sms/resend/new.html.erb
+++ b/cosmetics-web/app/views/secondary_authentication/sms/resend/new.html.erb
@@ -26,7 +26,7 @@
                           type: "tel") %>
         <% end %>
       <% else %>
-        <% if @user.is_a?("SupportUser") && @user.opss? %>
+        <% if @user.is_a?(SupportUser) && @user.opss? %>
           <p class="govuk-body">Alternatively, log in using your authenticator app.</p>
         <% else %>
           <p class="govuk-body">If you no longer have access to the phone with the number you registered for this service, contact <%= mail_to t(:enquiries_email), nil, subject: "Update mobile number", class: "govuk-link" %> to reset the number.</p>

--- a/cosmetics-web/app/views/secondary_authentication/sms/resend/new.html.erb
+++ b/cosmetics-web/app/views/secondary_authentication/sms/resend/new.html.erb
@@ -26,7 +26,7 @@
                           type: "tel") %>
         <% end %>
       <% else %>
-        <% if @user.type == "SupportUser" && @user.opss? %>
+        <% if @user.is_a?("SupportUser") && @user.opss? %>
           <p class="govuk-body">Alternatively, log in using your authenticator app.</p>
         <% else %>
           <p class="govuk-body">If you no longer have access to the phone with the number you registered for this service, contact <%= mail_to t(:enquiries_email), nil, subject: "Update mobile number", class: "govuk-link" %> to reset the number.</p>

--- a/cosmetics-web/app/views/secondary_authentication/sms/resend/new.html.erb
+++ b/cosmetics-web/app/views/secondary_authentication/sms/resend/new.html.erb
@@ -17,16 +17,20 @@
       <% if @user.mobile_number_change_allowed? %>
         <%= govukDetails(summaryText: "Change where the text message is sent", open: @user.errors.any?) do %>
           <%= govukInput(key: :mobile_number,
-                         form: form,
-                         classes: "app-!-max-width-two-thirds",
-                         label: { text: "Mobile number" },
-                         value: @user.mobile_number,
-                         id: "mobile_number",
-                         autocomplete: "tel",
-                         type: "tel") %>
+                          form: form,
+                          classes: "app-!-max-width-two-thirds",
+                          label: { text: "Mobile number" },
+                          value: @user.mobile_number,
+                          id: "mobile_number",
+                          autocomplete: "tel",
+                          type: "tel") %>
         <% end %>
       <% else %>
-        <p class="govuk-body">If you no longer have access to the phone with the number you registered for this service, contact <%= mail_to t(:enquiries_email), nil, subject: "Update mobile number", class: "govuk-link" %> to reset the number.</p>
+        <% if @user.type == "SupportUser" && @user.opss? %>
+          <p class="govuk-body">Alternatively, log in using your authenticator app.</p>
+        <% else %>
+          <p class="govuk-body">If you no longer have access to the phone with the number you registered for this service, contact <%= mail_to t(:enquiries_email), nil, subject: "Update mobile number", class: "govuk-link" %> to reset the number.</p>
+        <% end %>
       <% end %>
 
       <%= govukButton(text: "Resend security code") %>

--- a/cosmetics-web/spec/models/support_user_spec.rb
+++ b/cosmetics-web/spec/models/support_user_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe SupportUser, type: :model do
+  subject(:user) { build_stubbed(:support_user, role:) }
+
+  let(:role) { "opss_enforcement" }
+
+  include_examples "common user tests"
+
+  describe ".opss?" do
+    context "for an opss user" do
+      it "returns true" do
+        expect(subject.opss?).to be true
+      end
+    end
+
+    context "for a non-opss user" do
+      let(:role) { "trading_standards" }
+
+      it "returns false" do
+        expect(subject.opss?).to be false
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/models/support_user_spec.rb
+++ b/cosmetics-web/spec/models/support_user_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe SupportUser, type: :model do
   include_examples "common user tests"
 
   describe ".opss?" do
-    context "for an opss user" do
+    context "when user is part of opss" do
       it "returns true" do
-        expect(subject.opss?).to be true
+        expect(user.opss?).to be true
       end
     end
 
-    context "for a non-opss user" do
+    context "when user is not part of opss" do
       let(:role) { "trading_standards" }
 
       it "returns false" do
-        expect(subject.opss?).to be false
+        expect(user.opss?).to be false
       end
     end
   end


### PR DESCRIPTION
## Description

Changes the message seen by OPSS support users on the resend. text message screen.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2121

## Screenshots/video

![Screenshot 2023-07-14 at 10-50-09 Resend security code - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/1232d3a5-ffd7-4952-8791-2dd344f862c7)

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3052-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3052-search-web.london.cloudapps.digital/
https://cosmetics-pr-3052-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [x] OSU Support service has been updated (if required in the ticket)
