### PR TITLE
add history page for support users

### DIFF
--- a/cosmetics-web/app/models/responsible_person.rb
+++ b/cosmetics-web/app/models/responsible_person.rb
@@ -16,6 +16,8 @@ class ResponsiblePerson < ApplicationRecord
 
   has_many :nanomaterial_notifications, dependent: :destroy
 
+  has_paper_trail
+
   enum account_type: { business: "business", individual: "individual" }
 
   validates :account_type, presence: true

--- a/cosmetics-web/spec/factories/versions.rb
+++ b/cosmetics-web/spec/factories/versions.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :version, class: "PaperTrail::Version" do
+  end
+end

--- a/cosmetics-web/spec/features/support/history_spec.rb
+++ b/cosmetics-web/spec/features/support/history_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+require "support/feature_helpers"
+
+RSpec.feature "History", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :with_2fa_app, type: :feature do
+  let(:user) { create(:support_user, :with_sms_secondary_authentication) }
+  let(:other_support_user) { create(:support_user, name: "Max Mustermann") }
+  let(:responsible_person) { create(:responsible_person) }
+  let(:notification) { create(:notification) }
+  let(:notification_version) do
+    create(:version,
+           event: "delete",
+           item: notification,
+           whodunnit: user.id,
+           object: notification.attributes,
+           created_at: Time.zone.local(2022, 3, 1))
+  end
+
+  let(:responsible_person_version) do
+    create(:version,
+           event: "update",
+           item: responsible_person,
+           whodunnit: other_support_user.id,
+           object_changes: { "name" => ["Company A", "Company B"] },
+           object: responsible_person.attributes,
+           created_at: Time.zone.local(2023, 3, 1))
+  end
+
+  before do
+    configure_requests_for_support_domain
+    notification_version
+    responsible_person_version
+    sign_in user
+  end
+
+  scenario "Searching for changes made by support users using a search term" do
+    expect(page).to have_h1("Dashboard")
+
+    click_link "History/Audit log"
+
+    expect(page).to have_h1("History/Audit Log")
+
+    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text(other_support_user.name)
+    expect(page).to have_text("Change from: Company A")
+
+    fill_in "Enter a search term", with: user.name
+    click_on "Search"
+
+    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text(other_support_user.name)
+    expect(page).not_to have_text("Change from: Company A")
+
+    fill_in "Enter a search term", with: notification.reference_number
+    click_on "Search"
+
+    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text(other_support_user.name)
+    expect(page).not_to have_text("Change from: Company A")
+
+    fill_in "Enter a search term", with: other_support_user.name
+    click_on "Search"
+
+    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text(other_support_user.name)
+    expect(page).to have_text("Change from: Company A")
+  end
+
+  scenario "Searching for changes made by support users using a date range" do
+    expect(page).to have_h1("Dashboard")
+
+    click_link "History/Audit log"
+
+    expect(page).to have_h1("History/Audit Log")
+
+    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text(other_support_user.name)
+    expect(page).to have_text("Change from: Company A")
+
+    fill_in "history_search_date_from_3i", with: 1
+    fill_in "history_search_date_from_2i", with: 1
+    fill_in "history_search_date_from_1i", with: 2023
+    fill_in "history_search_date_to_3i", with: 1
+    fill_in "history_search_date_to_2i", with: 4
+    fill_in "history_search_date_to_1i", with: 2023
+    click_on "Search"
+
+    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text(other_support_user.name)
+    expect(page).to have_text("Change from: Company A")
+
+    fill_in "history_search_date_from_3i", with: 1
+    fill_in "history_search_date_from_2i", with: 1
+    fill_in "history_search_date_from_1i", with: 2022
+    fill_in "history_search_date_to_3i", with: 1
+    fill_in "history_search_date_to_2i", with: 4
+    fill_in "history_search_date_to_1i", with: 2022
+    click_on "Search"
+
+    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text(other_support_user.name)
+    expect(page).not_to have_text("Change from: Company A")
+  end
+
+  scenario "Searching for changes made by support users using an action" do
+    expect(page).to have_h1("Dashboard")
+
+    click_link "History/Audit log"
+
+    expect(page).to have_h1("History/Audit Log")
+
+    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text(other_support_user.name)
+    expect(page).to have_text("Change from: Company A")
+
+    select "Change to Notification", from: "Display by action"
+    click_on "Search"
+
+    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text(other_support_user.name)
+    expect(page).not_to have_text("Change from: Company A")
+
+    select "Change to Responsible Person Name", from: "Display by action"
+    click_on "Search"
+
+    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text(other_support_user.name)
+    expect(page).to have_text("Change from: Company A")
+
+    select "Change to Responsible Person Address", from: "Display by action"
+    click_on "Search"
+
+    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text(other_support_user.name)
+    expect(page).not_to have_text("Change from: Company A")
+  end
+end

--- a/cosmetics-web/support_portal/app/controllers/support_portal/history_controller.rb
+++ b/cosmetics-web/support_portal/app/controllers/support_portal/history_controller.rb
@@ -1,0 +1,27 @@
+module SupportPortal
+  class HistoryController < ApplicationController
+    def index
+      @history_search = HistorySearch.new(**search_params.to_h.symbolize_keys)
+
+      changes = if @history_search.valid?
+                  @history_search.search
+                else
+                  HistorySearch.new.search
+                end
+
+      @records_count = changes.size
+      @pagy, @records = pagy(changes)
+    end
+
+    def search_params
+      params.fetch(:history_search, {}).permit(
+        :query,
+        :action,
+        :sort_by,
+        :sort_direction,
+        :date_from,
+        :date_to,
+      )
+    end
+  end
+end

--- a/cosmetics-web/support_portal/app/helpers/support_portal/history_helper.rb
+++ b/cosmetics-web/support_portal/app/helpers/support_portal/history_helper.rb
@@ -1,0 +1,60 @@
+module SupportPortal
+  module HistoryHelper
+    NOTIFICATION_ACTIONS = {
+      "delete": "Deletion",
+      "undelete": "Recovery",
+    }.freeze
+
+    NOTIFICATION_ACTIONS_PAST_TENSE = {
+      "delete": "Deleted",
+      "undelete": "Recovered",
+    }.freeze
+
+    RESPONSIBLE_PERSON_ACTIONS = {
+      "name": "Name",
+      "account_type": "Business type",
+      "address_line_1": "Address",
+      "address_line_2": "Address",
+      "postal_code": "Address",
+      "county": "Address",
+      "city": "Address",
+    }.freeze
+
+    def display_action(action)
+      case action.item_type
+      when "Notification"
+        display_notification_action(action)
+      when "ResponsiblePerson"
+        display_responsible_person_action(action.object_changes)
+      end
+    end
+
+    def display_action_change(action)
+      return display_notification_action_details(action) if action.item_type == "Notification"
+
+      display_responsible_person_action_details(action.object_changes)
+    end
+
+    def display_responsible_person_action(object_changes)
+      change = object_changes.except("updated_at").keys.first
+
+      "RP (#{RESPONSIBLE_PERSON_ACTIONS[change.to_sym]}) Change"
+    end
+
+    def display_responsible_person_action_details(object_changes)
+      changes = object_changes.except("updated_at").values
+
+      changes.map { |change|
+        "Change from: #{change[0]}<br>To: #{change[1]}"
+      }.join("<br>")
+    end
+
+    def display_notification_action(action)
+      "UKCP Number (#{action.item.reference_number}) #{NOTIFICATION_ACTIONS[action.event.to_sym]}"
+    end
+
+    def display_notification_action_details(action)
+      "#{action.whodunnit} #{NOTIFICATION_ACTIONS_PAST_TENSE[action.event.to_sym]} UKCP (#{action.item.reference_number})"
+    end
+  end
+end

--- a/cosmetics-web/support_portal/app/models/support_portal/history_search.rb
+++ b/cosmetics-web/support_portal/app/models/support_portal/history_search.rb
@@ -1,0 +1,47 @@
+module SupportPortal
+  class HistorySearch
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveRecord::AttributeAssignment
+
+    attribute :query, :string
+    attribute :date_from, :date
+    attribute :date_to, :date
+    attribute :sort_direction, :string, default: "desc"
+    attribute :sort_by, :string
+    attribute :action, :string
+
+    validates :date_from, presence: { message: "From date cannot be blank" }, if: -> { date_to.present? }
+    validates :date_to, presence: { message: "To date cannot be blank" }, if: -> { date_from.present? }
+
+    validate :date_from_is_before_date_to
+
+    RP_ACTIONS =
+      [
+        OpenStruct.new(id: :rp_name, name: "Change to Responsible Person Name"),
+        OpenStruct.new(id: :rp_address, name: "Change to Responsible Person Address"),
+        OpenStruct.new(id: :rp_account_type, name: "Change to Responsible Person business type"),
+      ].freeze
+
+    NOTIFICATION_ACTIONS =
+      [
+        OpenStruct.new(id: :notification, name: "Change to Notification"),
+      ].freeze
+
+    ACTIONS = RP_ACTIONS + NOTIFICATION_ACTIONS
+
+    def search
+      FindSupportUserChanges.call(**attributes.to_h.symbolize_keys)
+    end
+
+    def actions
+      ACTIONS
+    end
+
+  private
+
+    def date_from_is_before_date_to
+      errors.add(:date_from, "The from date must be before the to date") if date_from.present? && date_to.present? && date_from >= date_to
+    end
+  end
+end

--- a/cosmetics-web/support_portal/app/services/support_portal/find_support_user_changes.rb
+++ b/cosmetics-web/support_portal/app/services/support_portal/find_support_user_changes.rb
@@ -28,7 +28,7 @@ module SupportPortal
                                        .or(@changes.where("object_changes->>'city' IS NOT  NULL"))
                                        .or(@changes.where("object_changes->>'county' IS NOT  NULL"))
                    else
-                     @changes.where("object_changes->>? IS NOT NULL", @action.split('rp_').last)
+                     @changes.where("object_changes->>? IS NOT NULL", @action.split("rp_").last)
                    end
       end
 

--- a/cosmetics-web/support_portal/app/services/support_portal/find_support_user_changes.rb
+++ b/cosmetics-web/support_portal/app/services/support_portal/find_support_user_changes.rb
@@ -28,7 +28,7 @@ module SupportPortal
                                        .or(@changes.where("object_changes->>'city' IS NOT  NULL"))
                                        .or(@changes.where("object_changes->>'county' IS NOT  NULL"))
                    else
-                     @changes.where("object_changes->>'#{@action.split('rp_').last}' IS NOT NULL")
+                     @changes.where("object_changes->>? IS NOT NULL", @action.split('rp_').last)
                    end
       end
 

--- a/cosmetics-web/support_portal/app/services/support_portal/find_support_user_changes.rb
+++ b/cosmetics-web/support_portal/app/services/support_portal/find_support_user_changes.rb
@@ -1,0 +1,76 @@
+module SupportPortal
+  class FindSupportUserChanges
+    def initialize(query:, date_from:, date_to:, action:, sort_by:, sort_direction:)
+      @query = query
+      @date_from = date_from
+      @date_to = date_to
+      @action = action
+      @sort_by = sort_by
+      @sort_direction = sort_direction
+      @changes = changes
+    end
+
+    def call
+      @changes = @changes.where("item_type = ?", item_type) if @action.present?
+      if @query.present?
+        @changes = @changes.where("users.name ILIKE ?", "%#{@query}%")
+                        .or(@changes.where("users.email ILIKE ?", "%#{@query}%"))
+                        .or(@changes.where("object->>'name' ILIKE ?", "%#{@query}%"))
+                        .or(@changes.where("object->>'reference_number' LIKE ?", "%#{@query}%"))
+      end
+
+      if responsible_person_action?
+        @changes = if @action.match?(/address/)
+                     @changes.where("object_changes->>'address_line_1' IS NOT  NULL")
+                                       .or(@changes.where("object_changes->>'address_line_1' IS NOT  NULL"))
+                                       .or(@changes.where("object_changes->>'address_line_2' IS NOT  NULL"))
+                                       .or(@changes.where("object_changes->>'postal_code' IS NOT  NULL"))
+                                       .or(@changes.where("object_changes->>'city' IS NOT  NULL"))
+                                       .or(@changes.where("object_changes->>'county' IS NOT  NULL"))
+                   else
+                     @changes.where("object_changes->>'#{@action.split('rp_').last}' IS NOT NULL")
+                   end
+      end
+
+      @changes = @changes.where("versions.created_at <= ?", @date_to) if @date_to.present?
+      @changes = @changes.where("versions.created_at >= ?", @date_from) if @date_from.present?
+
+      @changes
+    end
+
+    def self.call(query: nil, date_from: nil, date_to: nil, action: nil, sort_by: nil, sort_direction: "desc")
+      new(query:, date_from:, date_to:, action:, sort_by:, sort_direction:).call
+    end
+
+  private
+
+    def changes
+      PaperTrail::Version
+                  .includes(:item)
+                  .joins("LEFT JOIN users ON users.id::text = versions.whodunnit")
+                  .where("users.type = ?", "SupportUser")
+                  .order(**sort_order)
+                  .select("versions.*, COALESCE(users.name, 'Unknown') AS whodunnit")
+    end
+
+    def sort_order
+      return { @sort_by => @sort_direction } if @sort_by.present?
+
+      { "created_at" => @sort_direction }
+    end
+
+    def item_type
+      return "ResponsiblePerson" if responsible_person_action?
+
+      "Notification" if notification_action?
+    end
+
+    def responsible_person_action?
+      HistorySearch::RP_ACTIONS.pluck(:id).include?(@action&.to_sym)
+    end
+
+    def notification_action?
+      HistorySearch::NOTIFICATION_ACTIONS.pluck(:id).include?(@action&.to_sym)
+    end
+  end
+end

--- a/cosmetics-web/support_portal/app/views/support_portal/dashboard/index.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/dashboard/index.html.erb
@@ -22,7 +22,7 @@
     </a>
   </div>
   <div class="govuk-grid-column-one-half">
-    <a href="#" class="app-card">
+    <a href="<%= history_index_path %>" class="app-card">
       <h3 class="govuk-heading-s app-card__heading">History/Audit log</h3>
       <p class="govuk-body">Check the historical actions and events taken part in submit and search cosmetic product notifications.</p>
     </a>

--- a/cosmetics-web/support_portal/app/views/support_portal/history/index.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/history/index.html.erb
@@ -1,0 +1,67 @@
+<% content_for :page_title, "History/Audit Log" %>
+<% @back_link_href = support_root_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column opss-bordered-form-group govuk-!-padding-4">
+    <%= form_with model: @history_search, url: history_index_path, method: :get, id: "history-search-form" do |f| %>
+      <%= f.govuk_error_summary %>
+      <% if @errors %><h1 class="govuk-heading-l"><%= yield :page_title %></h1><% end %>
+      <div class="moj-search">
+        <div class="govuk-form-group">
+          <label for="query-field" class="govuk-label moj-search__label">Enter a search term</label>
+          <div class="govuk-hint moj-search__hint" id="query-hint">For example, name, email address, Responsible Person name or <abbr>UKCP</abbr> number</div>
+          <input id="query-field" class="govuk-input moj-search__input" aria-describedby="q-hint" type="search" name="history_search[query]" value="<%= params.dig(:history_search, :query) %>">
+        </div>
+      </div>
+      <div class="govuk-form-group">
+        <%= f.govuk_fieldset legend: {} do %>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third">
+              <%= f.govuk_date_field :date_from, legend: { text: "From" }, hint: { text: "For example, 27 9 2020" } %>
+            </div>
+            <div class="govuk-grid-column-two-thirds">
+              <%= f.govuk_date_field :date_to, legend: { text: "To" }, hint: { text: "&nbsp;".html_safe } %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <div class = "govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <%= f.govuk_collection_select :action, @history_search.actions, :id, :name, options: { include_blank: true }, label: { text: "Display by action" } %>
+        </div>
+        <div class="govuk-grid-column-one-half govuk-!-text-align-right govuk-!-padding-top-6">
+          <%= f.govuk_submit "Search" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column">
+    <%=
+      govuk_table do |table|
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(text: "Name")
+            row.with_cell(text: "Date/Time")
+            row.with_cell(text: "Action")
+            row.with_cell(text: "Details")
+          end
+        end
+        table.with_body do |body|
+          @records.each do |record|
+            body.with_row do |row|
+              row.with_cell(text: record.whodunnit)
+              row.with_cell(text: display_date_time(record.created_at))
+              row.with_cell(text: display_action(record))
+              row.with_cell(text: raw(display_action_change(record)))
+            end
+          end
+        end
+      end
+    %>
+  </div>
+</div>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/cosmetics-web/support_portal/config/routes.rb
+++ b/cosmetics-web/support_portal/config/routes.rb
@@ -13,6 +13,8 @@ SupportPortal::Engine.routes.draw do
     end
   end
 
+  resources :history, only: %i[index]
+
   resources :account_administration, path: "account-admin", only: %i[index show] do
     member do
       get "edit-name"


### PR DESCRIPTION
## Description

Add history page for SupportUsers to search. through changes to ResponsiblePersons and notifications made by other SupportUsers.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2150

## Screenshots/video

![Screenshot 2023-07-26 at 14-44-42 History_Audit Log - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/d0a1dd24-ecf4-4870-a8e5-c19b761bf5c0)

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3068-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3068-search-web.london.cloudapps.digital/
https://cosmetics-pr-3068-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
