### PR TITLE
Add change links and user management on account page

### DIFF
--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -50,7 +50,69 @@
           }
         ]
       ) %>
-    <% else %>
+    <% end %>
+
+  <% if support_domain? %>
+      <%= govukSummaryList(
+        classes: "govuk-!-margin-bottom-9",
+        rows: [
+          {
+            key: { text: "Full name" },
+            value: { text: current_user.name },
+            actions: {
+              items: [
+                {
+                  href: edit_my_account_name_path,
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: { text: "Email address" },
+            value: { text: current_user.email },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "email address"
+                }
+              ]
+            }
+          },
+          {
+            key: { text: "Mobile number" },
+            value: { text: current_user.mobile_number },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "phone number"
+                }
+              ]
+            }
+          },
+          {
+            key: { text: "Password" },
+            value: { text: "********" },
+            actions: {
+              items: [
+                {
+                  href: edit_my_account_password_path,
+                  text: "Change",
+                  visuallyHiddenText: "password"
+                }
+              ]
+            }
+          }
+        ]
+      ) %>
+    <% end %>
+
+    <% if search_domain? %>
       <%= govukSummaryList(
         classes: "govuk-!-margin-bottom-9",
         rows: [
@@ -139,6 +201,36 @@
       ) %>
 
     <% if support_domain? %>
+      <h2 class="govuk-heading-l">User Management</h2>
+        <%= govukSummaryList(
+          classes: "govuk-!-margin-bottom-9",
+          rows: [
+            {
+              key: { text: "Add a team member" },
+              actions: {
+                items: [
+                  {
+                    href: "#",
+                    text: "Invite",
+                    visuallyHiddenText: "invite team member"
+                  }
+                ]
+              }
+            },
+            {
+              key: { text: "Remove team member" },
+              actions: {
+                items: [
+                  {
+                    href: "#",
+                    text: "View team members",
+                    visuallyHiddenText: "rView team members"
+                  }
+                ]
+              }
+            },
+          ]
+        ) %>
       <%= govukButton(text: "Go to Cosmetic products search", href: main_app.new_support_on_search_user_session_url(host: ENV['SEARCH_HOST']), classes: "govuk-button--secondary", attributes: { target: "_blank" }) %>
     <% end %>
 

--- a/cosmetics-web/spec/features/account/sign_in_spec.rb
+++ b/cosmetics-web/spec/features/account/sign_in_spec.rb
@@ -688,4 +688,160 @@ RSpec.feature "Signing in as a user", :with_2fa, :with_stubbed_mailer, :with_stu
       include_examples "sign in"
     end
   end
+
+  describe "for support" do
+    before do
+      configure_requests_for_support_domain
+    end
+
+    describe "for user with both app and sms secondary authentication", :with_2fa, :with_2fa_app do
+      let(:user) { create(:support_user, :with_all_secondary_authentication_methods) }
+
+      scenario "user signs in selecting app authentication" do
+        visit "/sign-in"
+        fill_in_credentials
+        select_secondary_authentication_app
+
+        expect_to_be_on_secondary_authentication_app_page
+        complete_secondary_authentication_app
+
+        expect(page).to have_current_path("/")
+        expect(page).to have_css("h1", text: "Dashboard")
+      end
+
+      scenario "user signs in selecting sms authentication" do
+        visit "/sign-in"
+        fill_in_credentials
+        select_secondary_authentication_sms
+
+        expect_to_be_on_secondary_authentication_sms_page
+        expect(page).to have_link("Back", href: "/two-factor/method")
+        expect_back_link_to("/two-factor/method")
+        complete_secondary_authentication_sms_with("#{otp_code} ")
+
+        expect(page).to have_current_path("/")
+        expect(page).to have_css("h1", text: "Dashboard")
+      end
+
+      context "when using a recovery code" do
+        let(:used_recovery_code) { user.secondary_authentication_recovery_codes.sample }
+
+        before do
+          user.secondary_authentication_recovery_codes.delete(used_recovery_code)
+          user.secondary_authentication_recovery_codes_used = [used_recovery_code]
+          user.save!
+        end
+
+        scenario "user signs in with a correct recovery code" do
+          visit "/sign-in"
+          fill_in_credentials
+          select_secondary_authentication_recovery_code
+
+          expect_to_be_on_secondary_authentication_recovery_code_page(back_to: "app")
+          complete_secondary_authentication_recovery_code(user.secondary_authentication_recovery_codes.sample)
+
+          expect(page).to have_current_path("/two-factor/recovery-code/interstitial")
+          click_link "Continue to your account"
+
+          expect(page).to have_current_path("/")
+          expect(page).to have_css("h1", text: "Dashboard")
+        end
+
+        scenario "user signs in with a correct recovery code that contains spaces" do
+          visit "/sign-in"
+          fill_in_credentials
+          select_secondary_authentication_recovery_code
+
+          expect_to_be_on_secondary_authentication_recovery_code_page(back_to: "app")
+          complete_secondary_authentication_recovery_code("#{user.secondary_authentication_recovery_codes.sample.unpack('a4a*').join(' ')} ")
+
+          expect(page).to have_current_path("/two-factor/recovery-code/interstitial")
+          click_link "Continue to your account"
+
+          expect(page).to have_current_path("/")
+          expect(page).to have_css("h1", text: "Dashboard")
+        end
+
+        scenario "user attempts to sign in with an incorrect recovery code" do
+          visit "/sign-in"
+          fill_in_credentials
+          select_secondary_authentication_recovery_code
+
+          expect_to_be_on_secondary_authentication_recovery_code_page(back_to: "app")
+          complete_secondary_authentication_recovery_code("00000000")
+
+          expect_to_be_on_secondary_authentication_recovery_code_page
+          expect(page).to have_css("div.govuk-error-summary__body", text: "Incorrect recovery code")
+        end
+
+        scenario "user attempts to sign in with a recovery code that is too short" do
+          visit "/sign-in"
+          fill_in_credentials
+          select_secondary_authentication_recovery_code
+
+          expect_to_be_on_secondary_authentication_recovery_code_page(back_to: "app")
+          complete_secondary_authentication_recovery_code("1234")
+
+          expect_to_be_on_secondary_authentication_recovery_code_page
+          expect(page).to have_css("p.govuk-error-message", text: "You haven’t entered enough numbers")
+        end
+
+        scenario "user attempts to sign in with a recovery code that is too long" do
+          visit "/sign-in"
+          fill_in_credentials
+          select_secondary_authentication_recovery_code
+
+          expect_to_be_on_secondary_authentication_recovery_code_page(back_to: "app")
+          complete_secondary_authentication_recovery_code("123456789")
+
+          expect_to_be_on_secondary_authentication_recovery_code_page
+          expect(page).to have_css("p.govuk-error-message", text: "You’ve entered too many numbers")
+        end
+
+        scenario "user attempts to sign in with a recovery code that has already been used" do
+          visit "/sign-in"
+          fill_in_credentials
+          select_secondary_authentication_recovery_code
+
+          expect_to_be_on_secondary_authentication_recovery_code_page(back_to: "app")
+          complete_secondary_authentication_recovery_code(used_recovery_code)
+
+          expect_to_be_on_secondary_authentication_recovery_code_page
+          expect(page).to have_css("p.govuk-error-message", text: "The recovery code has already been used")
+        end
+
+        context "when there are no remaining recovery codes for a user" do
+          before do
+            user.secondary_authentication_recovery_codes = []
+            user.secondary_authentication_recovery_codes_used = []
+            user.save!
+          end
+
+          scenario "user attempts to sign in" do
+            visit "/sign-in"
+            fill_in_credentials
+            select_secondary_authentication_recovery_code
+
+            expect(page).to have_current_path("/two-factor/recovery-code?back_to=app")
+            expect(page).to have_css("h2", text: "There is a problem")
+            expect(page).to have_css("div.govuk-error-summary__body", text: "All recovery codes have been used")
+          end
+        end
+
+        scenario "user attempts to sign in with an empty recovery code" do
+          visit "/sign-in"
+          fill_in_credentials
+          select_secondary_authentication_recovery_code
+
+          expect_to_be_on_secondary_authentication_recovery_code_page(back_to: "app")
+          complete_secondary_authentication_recovery_code("")
+
+          expect_to_be_on_secondary_authentication_recovery_code_page
+          expect(page).to have_css("p.govuk-error-message", text: "Enter the recovery code")
+        end
+
+        include_examples "sign in"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Adds non-functional links to support user account management page

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2110

## Screenshots/video

![Screenshot 2023-07-28 at 09-03-33 Your account - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/4d859557-ce0a-4d81-85a3-1f0bba09832c)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
