### PR TITLE
add invite support user functionality

### DIFF
--- a/cosmetics-web/app/forms/invite_support_user_form.rb
+++ b/cosmetics-web/app/forms/invite_support_user_form.rb
@@ -1,0 +1,9 @@
+class InviteSupportUserForm < Form
+  include StripWhitespace
+  include EmailFormValidation
+
+  attribute :name
+
+  validates_presence_of :name
+  validates :name, length: { maximum: User::NAME_MAX_LENGTH }, user_name_format: { message: :invalid }
+end

--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -210,7 +210,7 @@
               actions: {
                 items: [
                   {
-                    href: "#",
+                    href: support_portal.new_invite_support_user_path,
                     text: "Invite",
                     visuallyHiddenText: "invite team member"
                   }

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -378,6 +378,10 @@ en:
           attributes:
             password:
               blank: "Enter your password"
+        invite_support_user_form:
+          attributes:
+            name:
+              blank: "Enter the full name"
   enquiries_email: "opss.enquiries@beis.gov.uk"
   errors:
     format: "%{message}"

--- a/cosmetics-web/spec/features/support/invite_support_user_spec.rb
+++ b/cosmetics-web/spec/features/support/invite_support_user_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+require "support/feature_helpers"
+
+RSpec.feature "Invite support user", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :with_2fa_app, type: :feature do
+  let(:user) { create(:support_user, :with_sms_secondary_authentication) }
+  let(:new_user_email) { "new-support-user@example.com" }
+
+  before do
+    configure_requests_for_support_domain
+    sign_in user
+  end
+
+  scenario "inviting a new team member" do
+    expect(page).to have_h1("Dashboard")
+
+    click_link "Your account"
+
+    expect(page).to have_h1("Your account")
+
+    expect(page).to have_h2("User Management")
+
+    click_link "Invite"
+
+    expect(page).to have_h1("Invite a team member")
+
+    fill_in "Full name", with: "John Doe"
+    fill_in "Email", with: new_user_email
+    click_on "Send invitation"
+
+    expect(page).to have_current_path("/invite-support-user/new")
+
+    expect(page).to have_css(
+      "div.govuk-notification-banner__heading",
+      text: "Invitation sent to John Doe at #{new_user_email}",
+    )
+
+    new_user = SupportUser.where(email: new_user_email).first
+
+    expect(delivered_emails.size).to eq 1
+    email = delivered_emails.first
+    expect(email).to have_attributes(
+      recipient: new_user_email,
+      template: SupportNotifyMailer::TEMPLATES[:invitation],
+      personalization: { invitation_url: "http://#{ENV['SUPPORT_HOST']}/users/#{new_user.id}/complete-registration?invitation=#{new_user.invitation_token}" },
+    )
+  end
+end

--- a/cosmetics-web/spec/forms/invite_support_user_form_spec.rb
+++ b/cosmetics-web/spec/forms/invite_support_user_form_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe InviteSupportUserForm do
+  subject(:form) do
+    described_class.new(email:,
+                        name:)
+  end
+
+  let(:email) { "invited.user@example.com" }
+  let(:name) { "Invited User" }
+
+  describe "#valid?" do
+    before { form.validate }
+
+    context "when all the data is present" do
+      it "is valid" do
+        expect(form).to be_valid
+      end
+
+      it "has no error messages" do
+        expect(form.errors).to be_empty
+      end
+    end
+
+    context "when the name is blank" do
+      let(:name) { "" }
+
+      it "is not valid" do
+        expect(form).to be_invalid
+      end
+
+      it "populates an error message" do
+        expect(form.errors.full_messages_for(:name)).to eq(["Enter the full name"])
+      end
+    end
+
+    context "when the email is blank" do
+      let(:email) { "" }
+
+      it "is not valid" do
+        expect(form).to be_invalid
+      end
+
+      it "populates an error message" do
+        expect(form.errors.full_messages_for(:email)).to eq(["Enter an email address"])
+      end
+    end
+
+    context "when the email format is wrong" do
+      let(:email) { "email.address.wrongly.formatted" }
+
+      it "is not valid" do
+        expect(form).to be_invalid
+      end
+
+      it "populates an error message" do
+        expect(form.errors.full_messages_for(:email))
+          .to eq(["Enter an email address in the correct format, like name@example.com"])
+      end
+    end
+  end
+end

--- a/cosmetics-web/support_portal/app/controllers/support_portal/invite_support_users_controller.rb
+++ b/cosmetics-web/support_portal/app/controllers/support_portal/invite_support_users_controller.rb
@@ -1,0 +1,26 @@
+module SupportPortal
+  class InviteSupportUsersController < ApplicationController
+    def new
+      @invite_support_user_form = InviteSupportUserForm.new
+    end
+
+    def create
+      @invite_support_user_form = InviteSupportUserForm.new(support_user_params)
+
+      if @invite_support_user_form.valid?
+        InviteSupportUser.call(support_user_params)
+
+        redirect_to(new_invite_support_user_path,
+                    notice: "Invitation sent to #{@invite_support_user_form.name} at #{@invite_support_user_form.email}")
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def support_user_params
+      params.require(:invite_support_user_form).permit(:name, :email)
+    end
+  end
+end

--- a/cosmetics-web/support_portal/app/views/support_portal/invite_support_users/new.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/invite_support_users/new.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, "Invite a team member" %>
+<% @back_link_href = main_app.my_account_path %>
+
+<% content_for :after_header do %>
+  <%= link_to "Back", "#", class: "govuk-back-link" %>
+<% end %>
+
+<%= form_with model: @invite_support_user_form, url: invite_support_user_path, method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+  <% if @errors %><h1 class="govuk-heading-l"><%= yield :page_title %></h1><% end %>
+  <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>Inviting a team member will allow them to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Manage support issues</li>
+      <li>View, delete and recover cosmetic product notifications across the service</li>
+      <li>Invite other team members</li>
+      <li>View the history / audit log of the SCPN services</li>
+      <li>View a list of all users within the search and submit service</li>
+    </ul>
+    <%= f.govuk_text_field :name, label: { text: "Full name" } %>
+    <%= f.govuk_email_field :email, label: { text: "Email address" } %>
+    <%= f.govuk_submit "Send invitation" %>
+  </div>
+  </div>
+<% end %>

--- a/cosmetics-web/support_portal/config/routes.rb
+++ b/cosmetics-web/support_portal/config/routes.rb
@@ -31,6 +31,8 @@ SupportPortal::Engine.routes.draw do
     end
   end
 
+  resource :invite_support_user, path: "invite-support-user", only: %i[new create]
+
   resources :responsible_persons, path: "responsible-persons", only: %i[index show] do
     member do
       get "edit-name"


### PR DESCRIPTION
## Description

Adds ability for support users to invite new support users

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2142

## Screenshots/video

![Screenshot 2023-08-01 at 12-32-36 Invite a team member - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/e8b41313-c770-45b0-9f78-047f3734af33)
![Screenshot 2023-08-01 at 12-32-25 Invite a team member - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/6338613d-7e6f-4b3b-8f11-e6b9bbf8a5be)


## Review apps

https://cosmetics-pr-3073-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3073-search-web.london.cloudapps.digital/
https://cosmetics-pr-3073-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
