### PR TITLE
remove name and mobile number rows from my account section

### DIFF
--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -57,19 +57,6 @@
         classes: "govuk-!-margin-bottom-9",
         rows: [
           {
-            key: { text: "Full name" },
-            value: { text: current_user.name },
-            actions: {
-              items: [
-                {
-                  href: edit_my_account_name_path,
-                  text: "Change",
-                  visuallyHiddenText: "name"
-                }
-              ]
-            }
-          },
-          {
             key: { text: "Email address" },
             value: { text: current_user.email },
             actions: {
@@ -78,19 +65,6 @@
                   href: edit_my_account_email_path,
                   text: "Change",
                   visuallyHiddenText: "email address"
-                }
-              ]
-            }
-          },
-          {
-            key: { text: "Mobile number" },
-            value: { text: current_user.mobile_number },
-            actions: {
-              items: [
-                {
-                  href: "#",
-                  text: "Change",
-                  visuallyHiddenText: "phone number"
                 }
               ]
             }

--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -57,6 +57,19 @@
         classes: "govuk-!-margin-bottom-9",
         rows: [
           {
+            key: { text: "Full name" },
+            value: { text: current_user.name },
+            actions: {
+              items: [
+                {
+                  href: edit_my_account_name_path,
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
             key: { text: "Email address" },
             value: { text: current_user.email },
             actions: {

--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -129,7 +129,7 @@
     <% end %>
 
     <h2 class="govuk-heading-l">Your security preferences</h2>
-    <p class="govuk-body opss-secondary-text">This is how you get access codes.</p>
+    <p class="govuk-body opss-secondary-text">This is how you get access codes</p>
       <%= govukSummaryList(
         classes: "govuk-!-margin-bottom-9",
         rows: [


### PR DESCRIPTION
## Description

Removes name and mobile number rows for SupportUsers in MyAccount section

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2110

## Screenshots/video

![Screenshot 2023-08-07 at 09-13-18 Your account - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/d870fc16-e581-48be-95d6-886f92d66eb4)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3075-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3075-search-web.london.cloudapps.digital/
https://cosmetics-pr-3075-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
