### PR TITLE
Add OPSS IMT role

### DIFF
--- a/cosmetics-web/app/models/concerns/privileges/abstract_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/abstract_concern.rb
@@ -49,6 +49,10 @@ module Privileges
       false
     end
 
+    def opss_imt_user?
+      false
+    end
+
     def opss_science_user?
       false
     end

--- a/cosmetics-web/app/models/concerns/privileges/search_concern.rb
+++ b/cosmetics-web/app/models/concerns/privileges/search_concern.rb
@@ -3,7 +3,7 @@ module Privileges
     include AbstractConcern
 
     def can_view_product_ingredients?
-      poison_centre_user? || opss_enforcement_user? || opss_science_user?
+      poison_centre_user? || opss_enforcement_user? || opss_imt_user? || opss_science_user?
     end
 
     def can_view_ingredients_list?
@@ -23,7 +23,7 @@ module Privileges
     end
 
     def can_view_notification_history?
-      trading_standards_user? || opss_enforcement_user?
+      trading_standards_user? || opss_enforcement_user? || opss_imt_user?
     end
 
     def poison_centre_user?
@@ -31,7 +31,7 @@ module Privileges
     end
 
     def opss_user?
-      opss_general? || opss_enforcement? || opss_science?
+      opss_general? || opss_enforcement? || opss_imt? || opss_science?
     end
 
     def opss_general_user?
@@ -40,6 +40,10 @@ module Privileges
 
     def opss_enforcement_user?
       opss_enforcement?
+    end
+
+    def opss_imt_user?
+      opss_imt?
     end
 
     def opss_science_user?

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -11,6 +11,7 @@ class SearchUser < User
     poison_centre: "poison_centre",
     opss_general: "opss_general",
     opss_enforcement: "opss_enforcement",
+    opss_imt: "opss_imt",
     opss_science: "opss_science",
     trading_standards: "trading_standards",
   }

--- a/cosmetics-web/app/models/support_user.rb
+++ b/cosmetics-web/app/models/support_user.rb
@@ -14,6 +14,7 @@ class SupportUser < User
     poison_centre: "poison_centre",
     opss_general: "opss_general",
     opss_enforcement: "opss_enforcement",
+    opss_imt: "opss_imt",
     opss_science: "opss_science",
     trading_standards: "trading_standards",
   }

--- a/cosmetics-web/app/views/errors/wrong_service_for_search_user.html.erb
+++ b/cosmetics-web/app/views/errors/wrong_service_for_search_user.html.erb
@@ -2,7 +2,7 @@
   title = "You cannot submit notifications with this account"
   role_wording = case user_role
                  when "poison_centre" then "the National Poisons Information Service"
-                 when "opss_general", "opss_enforcement", "opss_science" then "the Office for Product Safety and Standards"
+                 when "opss_general", "opss_enforcement", "opss_imt", "opss_science" then "the Office for Product Safety and Standards"
                  when "trading_standards" then "Trading Standards"
                  end
 

--- a/cosmetics-web/db/migrate/20230807095619_add_opss_imt_to_user_roles.rb
+++ b/cosmetics-web/db/migrate/20230807095619_add_opss_imt_to_user_roles.rb
@@ -1,0 +1,9 @@
+class AddOpssImtToUserRoles < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      ActiveRecord::Base.connection.execute <<-SQL
+        ALTER TYPE user_roles ADD VALUE 'opss_imt'
+      SQL
+    end
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_14_133328) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_095619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_14_133328) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "ingredient_range_concentration", ["less_than_01_percent", "greater_than_01_less_than_1_percent", "greater_than_1_less_than_5_percent", "greater_than_5_less_than_10_percent", "greater_than_10_less_than_25_percent", "greater_than_25_less_than_50_percent", "greater_than_50_less_than_75_percent", "greater_than_75_less_than_100_percent"]
-  create_enum "user_roles", ["poison_centre", "market_surveilance_authority", "opss_science", "opss_general", "opss_enforcement", "trading_standards"]
+  create_enum "user_roles", ["poison_centre", "market_surveilance_authority", "opss_science", "opss_general", "opss_enforcement", "trading_standards", "opss_imt"]
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/cosmetics-web/docs/users_and_roles.md
+++ b/cosmetics-web/docs/users_and_roles.md
@@ -36,11 +36,12 @@ See [secondary authentication](secondary_authentication.md).
 
 Only search users have roles.
 
-There are five roles:
+There are six roles:
 
 * Poison centre
 * OPSS General
 * OPSS Enforcement
+* OPSS IMT
 * OPSS Science
 * Trading Standards
 

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
@@ -226,6 +226,95 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do
     end
   end
 
+  describe "When signed in as an OPSS IMT user" do
+    before do
+      sign_in_as_opss_imt_user
+    end
+
+    describe "GET #show" do
+      let(:notification) { notifications.first }
+      let(:reference_number) { notification.reference_number }
+
+      before { get :show, params: { reference_number: } }
+
+      it "renders the show template" do
+        expect(response).to render_template("notifications/show_msa")
+      end
+
+      describe "displayed information" do
+        let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions) }
+        let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+        let(:notification) { create(:notification, :registered, :ph_values, components: [component], responsible_person:) }
+
+        render_views
+
+        it "renders contact person overview" do
+          expect(response.body).to match(/Assigned contact/)
+        end
+
+        it "renders component formulations" do
+          expect(response.body).to match(/Formulation given as/)
+          expect(response.body).to match(/Frame formulation/)
+        end
+
+        it "does not render acute poisoning info" do
+          expect(response.body).not_to match(/Acute poisoning information/)
+        end
+
+        it "does not render poisonous ingredients" do
+          expect(response.body).not_to match(/Contains poisonous ingredients/)
+        end
+
+        it "does not render trigger questions" do
+          expect(response.body).not_to match(/<tr class="govuk-table__row trigger-question">/)
+        end
+
+        it "renders minimum pH" do
+          expect(response.body).to match(/Minimum pH value/)
+        end
+
+        it "renders maximum pH" do
+          expect(response.body).to match(/Maximum pH value/)
+        end
+
+        it "does not render still on the market" do
+          expect(response.body).not_to match(/Still on the market/)
+        end
+
+        it "renders nanomaterials" do
+          expect(response.body).to match(/Nanomaterials/)
+        end
+
+        it "renders physical form" do
+          expect(response.body).to match(/Physical form/)
+        end
+      end
+
+      describe "displayed information for archived notifications", versioning: true do
+        let(:reference_number) { archived_notification.reference_number }
+
+        render_views
+
+        it "renders the history" do
+          expect(response.body).to match(/History/)
+        end
+      end
+
+      describe "Notification with CMRS substances" do
+        let(:cmr) { create(:cmr) }
+        let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions, cmrs: [cmr]) }
+        let(:responsible_person) { create(:responsible_person, :with_a_contact_person) }
+        let(:notification) { create(:notification, :registered, :ph_values, components: [component], responsible_person:) }
+
+        render_views
+
+        it "renders CMR substances" do
+          expect(response.body).to match(/Contains CMR substances/)
+        end
+      end
+    end
+  end
+
   describe "When signed in as an Trading Standards user" do
     before do
       sign_in_as_trading_standards_user

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_search_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_search_controller_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe PoisonCentres::NotificationsSearchController, type: :controller d
     end
   end
 
+  describe "When signed in as an OPSS IMT user" do
+    before do
+      sign_in_as_opss_imt_user
+    end
+
+    describe "GET #show" do
+      it "renders the show template" do
+        get :show
+        expect(response).to render_template("notifications_search/show")
+      end
+    end
+  end
+
   describe "When signed in as a Trading Standards user" do
     before do
       sign_in_as_trading_standards_user

--- a/cosmetics-web/spec/controllers/search/dashboard_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/search/dashboard_controller_spec.rb
@@ -52,6 +52,23 @@ RSpec.describe Search::DashboardController, type: :controller do
     end
   end
 
+  describe "When signed in as an OPSS IMT user" do
+    before do
+      sign_in_as_opss_imt_user
+    end
+
+    after do
+      sign_out(:search_user)
+    end
+
+    describe "GET #show" do
+      it "redirects to the correct notifications index page" do
+        get :show
+        expect(response).to redirect_to(poison_centre_notifications_search_path)
+      end
+    end
+  end
+
   describe "When signed in as a Trading Standards user" do
     before do
       sign_in_as_trading_standards_user

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -116,6 +116,10 @@ FactoryBot.define do
         role { :opss_enforcement }
       end
 
+      factory :opss_imt_user do
+        role { :opss_imt }
+      end
+
       factory :opss_science_user do
         role { :opss_science }
       end

--- a/cosmetics-web/spec/features/search/notification_search_result_nanomaterial_details_spec.rb
+++ b/cosmetics-web/spec/features/search/notification_search_result_nanomaterial_details_spec.rb
@@ -81,6 +81,23 @@ RSpec.feature "Search result nanomaterial details", :with_stubbed_notify, :with_
     end
   end
 
+  context "with an opss imt user" do
+    let(:user) { create(:opss_imt_user, :with_sms_secondary_authentication) }
+
+    scenario "user can see the nanomaterial details with review period section but without link to nanomaterial pdf file" do
+      expect(page).to have_h1("Cosmetic products search")
+      click_on "Search"
+      click_link("View Cream")
+
+      expect(page).to have_h1("Cream")
+      expect(page).to have_summary_item(key: "Nanomaterials", value: "#{nanomaterial_notification.ukn} - Zinc oxide")
+      expect(page).to have_summary_item(
+        key: "Nanomaterials review period end date",
+        value: "#{nanomaterial_notification.ukn} - Zinc oxide - 1 July 2022",
+      )
+    end
+  end
+
   context "with a trading standards user" do
     let(:user) { create(:trading_standards_user, :with_sms_secondary_authentication) }
 

--- a/cosmetics-web/spec/login_helpers.rb
+++ b/cosmetics-web/spec/login_helpers.rb
@@ -18,6 +18,11 @@ module LoginHelpers
     sign_in(user)
   end
 
+  def sign_in_as_opss_imt_user(user: create(:opss_imt_user))
+    configure_requests_for_search_domain
+    sign_in(user)
+  end
+
   def sign_in_as_opss_science_user(user: create(:opss_science_user))
     configure_requests_for_search_domain
     sign_in(user)

--- a/cosmetics-web/spec/models/search_user_spec.rb
+++ b/cosmetics-web/spec/models/search_user_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe SearchUser, type: :model do
       expect(user).to be_can_view_product_ingredients
     end
 
+    it "is true for OPSS IMT users" do
+      user.role = :opss_imt
+      expect(user).to be_can_view_product_ingredients
+    end
+
     it "is false for Trading Standards users" do
       user.role = :trading_standards
       expect(user).not_to be_can_view_product_ingredients
@@ -40,6 +45,11 @@ RSpec.describe SearchUser, type: :model do
 
     it "is false for OPSS Enforcement users" do
       user.role = :opss_enforcement
+      expect(user).not_to be_can_view_ingredients_list
+    end
+
+    it "is false for OPSS IMT users" do
+      user.role = :opss_imt
       expect(user).not_to be_can_view_ingredients_list
     end
 
@@ -70,6 +80,11 @@ RSpec.describe SearchUser, type: :model do
       expect(user).not_to be_can_view_nanomaterial_notification_files
     end
 
+    it "is false for OPSS IMT users" do
+      user.role = :opss_imt
+      expect(user).not_to be_can_view_nanomaterial_notification_files
+    end
+
     it "is false for Trading Standards users" do
       user.role = :trading_standards
       expect(user).not_to be_can_view_nanomaterial_notification_files
@@ -94,6 +109,11 @@ RSpec.describe SearchUser, type: :model do
 
     it "is true for OPSS Enforcement users" do
       user.role = :opss_enforcement
+      expect(user).to be_can_view_nanomaterial_review_period_end_date
+    end
+
+    it "is true for OPSS IMT users" do
+      user.role = :opss_imt
       expect(user).to be_can_view_nanomaterial_review_period_end_date
     end
 
@@ -124,6 +144,11 @@ RSpec.describe SearchUser, type: :model do
       expect(user).not_to be_can_view_responsible_person_address_history
     end
 
+    it "is false for OPSS IMT users" do
+      user.role = :opss_imt
+      expect(user).not_to be_can_view_responsible_person_address_history
+    end
+
     it "is true for Trading Standards users" do
       user.role = :trading_standards
       expect(user).to be_can_view_responsible_person_address_history
@@ -148,6 +173,11 @@ RSpec.describe SearchUser, type: :model do
 
     it "is true for OPSS Enforcement users" do
       user.role = :opss_enforcement
+      expect(user).to be_can_view_notification_history
+    end
+
+    it "is true for OPSS IMT users" do
+      user.role = :opss_imt
       expect(user).to be_can_view_notification_history
     end
 

--- a/cosmetics-web/spec/models/support_user_spec.rb
+++ b/cosmetics-web/spec/models/support_user_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SupportUser, type: :model do
   subject(:user) { build_stubbed(:support_user, role:) }
 
-  let(:role) { "opss_enforcement" }
+  let(:role) { "opss_general" }
 
   include_examples "common user tests"
 

--- a/cosmetics-web/spec/policies/poison_centre_notification_policy_spec.rb
+++ b/cosmetics-web/spec/policies/poison_centre_notification_policy_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe PoisonCentreNotificationPolicy, type: :policy do
     it { is_expected.not_to permit(:destroy) }
   end
 
+  context "with an OPSS IMT user" do
+    let(:user) { build_stubbed(:opss_imt_user) }
+
+    it { is_expected.to permit(:index) }
+    it { is_expected.to permit(:show) }
+
+    it { is_expected.not_to permit(:create)  }
+    it { is_expected.not_to permit(:new)     }
+    it { is_expected.not_to permit(:update)  }
+    it { is_expected.not_to permit(:edit)    }
+    it { is_expected.not_to permit(:destroy) }
+  end
+
   context "with a Trading Standards user" do
     let(:user) { build_stubbed(:trading_standards_user) }
 
@@ -70,7 +83,7 @@ RSpec.describe PoisonCentreNotificationPolicy, type: :policy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context "with neither a poison centre/OPSS General/OPSS Enforcement/OPSS Science/Trading Standards user" do
+  context "with neither a poison centre/OPSS General/OPSS Enforcement/OPSS IMT/OPSS Science/Trading Standards user" do
     let(:user) { build_stubbed(:search_user) }
 
     it { is_expected.not_to permit(:index) }

--- a/cosmetics-web/spec/requests/declaration_requests_spec.rb
+++ b/cosmetics-web/spec/requests/declaration_requests_spec.rb
@@ -113,6 +113,43 @@ RSpec.describe "User declarations", :with_stubbed_antivirus, type: :request do
     end
   end
 
+  context "when signed in as an OPSS IMT user" do
+    let(:user) { create(:opss_imt_user, has_accepted_declaration: false) }
+
+    before do
+      sign_in_as_opss_imt_user(user:)
+    end
+
+    after do
+      sign_out(:search_user)
+    end
+
+    context "when viewing the declaration page" do
+      before do
+        get declaration_path
+      end
+
+      it "renders the page" do
+        expect(response.status).to be(200)
+        expect(response).to render_template("declaration/msa_user_declaration")
+      end
+    end
+
+    context "when submitting the declaration page" do
+      before do
+        post accept_declaration_path
+      end
+
+      it "redirects to the Search homepage" do
+        expect(response).to redirect_to(search_root_path)
+      end
+
+      it "updates the user attributes" do
+        expect(user.has_accepted_declaration?).to be true
+      end
+    end
+  end
+
   context "when signed in as a Trading Standards user" do
     let(:user) { create(:trading_standards_user, has_accepted_declaration: false) }
 

--- a/cosmetics-web/spec/requests/ingredient_list_spec.rb
+++ b/cosmetics-web/spec/requests/ingredient_list_spec.rb
@@ -286,6 +286,48 @@ RSpec.describe "Ingredient list", type: :request do
     end
   end
 
+  context "when signed in as an OPSS IMT user" do
+    before do
+      sign_in_as_opss_imt_user
+    end
+
+    describe "GET #index" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_path
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_persons" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_persons_path(ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+
+    describe "GET #responsible_person_notifications" do
+      context "when visiting the page" do
+        before do
+          get poison_centre_ingredients_responsible_person_notifications_path(responsible_person_id: ingredient2.component.responsible_person.id, ingredient_inci_name: "Aqua")
+        end
+
+        it "redirects to the root page" do
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+  end
+
   context "when signed in as an OPSS Science user" do
     before do
       sign_in_as_opss_science_user

--- a/cosmetics-web/spec/requests/poison_centre_page_spec.rb
+++ b/cosmetics-web/spec/requests/poison_centre_page_spec.rb
@@ -227,6 +227,67 @@ RSpec.describe "Poison centre page", type: :request do
       end
     end
 
+    context "with an OPSS IMT user" do
+      before do
+        sign_in_as_opss_imt_user
+      end
+
+      it "displays the cosmetics product name " do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to include(notification_exact.product_name)
+      end
+
+      it "displays the product ingredients" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to include("Foo Ingredient")
+      end
+
+      it "does not display the product frame formulations for a product with only exact or range ingredients" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to include("Frame formulation")
+      end
+
+      it "displays the product frame formulations for a product with only frame formulations" do
+        get poison_centre_notification_path(params_frame_formulation)
+        expect(response.body).to have_tag("section#item-2") do
+          with_tag("dt", text: /Frame formulation/)
+        end
+      end
+
+      it "displays the product CMRs" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: /Foo CMR/)
+      end
+
+      it "displays the product Nanomaterials" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: /Foo Nanomaterial/)
+      end
+
+      it "displays the Responsible Person" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("h2", text: "Responsible Person")
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.name))
+      end
+
+      it "displays the Responsible Person's current address" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.address_line_1))
+      end
+
+      it "does not display the Responsible Person's previous address(es)" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.first.line_1))
+        expect(response.body).not_to have_tag("dd", text: optional_spaces(responsible_person.address_logs.second.line_1))
+      end
+
+      it "displays the Contact Person" do
+        get poison_centre_notification_path(params_exact)
+        expect(response.body).to have_tag("h2", text: "Assigned contact")
+        expect(response.body).to have_tag("dd", text: optional_spaces(responsible_person.contact_persons.first.name))
+      end
+    end
+
     context "with an OPSS Science user" do
       before do
         sign_in_as_opss_science_user

--- a/cosmetics-web/spec/requests/root_path_spec.rb
+++ b/cosmetics-web/spec/requests/root_path_spec.rb
@@ -168,6 +168,23 @@ RSpec.describe "Root path", :with_stubbed_antivirus, type: :request do
       end
     end
 
+    context "when signed in as an OPSS IMT user" do
+      let(:user) { create(:opss_imt_user) }
+
+      before do
+        sign_in_as_opss_imt_user(user:)
+        get "/"
+      end
+
+      after do
+        sign_out(:search_user)
+      end
+
+      it "redirects to the notifications page" do
+        expect(response).to redirect_to("/notifications")
+      end
+    end
+
     context "when signed in as an OPSS Science user" do
       let(:user) { create(:opss_science_user) }
 

--- a/cosmetics-web/spec/requests/user_account_page_spec.rb
+++ b/cosmetics-web/spec/requests/user_account_page_spec.rb
@@ -113,6 +113,19 @@ RSpec.describe "User account page", type: :request do
     include_examples "can't download nanomaterials"
   end
 
+  context "with a Search OPSS IMT user" do
+    let(:user) { create(:opss_imt_user) }
+
+    before do
+      sign_in_as_opss_imt_user(user:)
+      get "/my_account"
+    end
+
+    include_examples "can change name and security"
+    include_examples "can't change email"
+    include_examples "can't download nanomaterials"
+  end
+
   context "with a Search OPSS Science user" do
     let(:user) { create(:opss_science_user) }
 


### PR DESCRIPTION
## Description

Adds a new search user role for OPSS IMT, with the same privileges as the OPSS Enforcement role.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2211

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-3076-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3076-search-web.london.cloudapps.digital/
https://cosmetics-pr-3076-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [x] Documentation has been added or updated
- [ ] Database seeds have been updated
- [x] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

No
