### PR TITLE
Generate and display recovery codes for existing users

### DIFF
--- a/cosmetics-web/app/controllers/secondary_authentication/recovery_code/setup_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/recovery_code/setup_controller.rb
@@ -21,6 +21,7 @@ module SecondaryAuthentication
 
       def continue_path
         return my_account_path if params[:back_to] == "my_account"
+        return root_path if params[:back_to] == "home"
 
         invitation_id = session.delete(:registered_from_responsible_person_invitation_id)
         if (invitation = PendingResponsiblePersonUser.find_by(id: invitation_id))

--- a/cosmetics-web/lib/feature_flags.rb
+++ b/cosmetics-web/lib/feature_flags.rb
@@ -1,5 +1,5 @@
 class FeatureFlags
-  def self.csv_upload_exact_with_shades_enabled?(user)
-    Flipper.enabled?(:csv_upload_exact_with_shades, user)
+  def self.recovery_codes_for_existing_users_enabled?(user)
+    Flipper.enabled?(:recovery_codes_for_existing_users, user)
   end
 end


### PR DESCRIPTION
## Description

Detects if a user signing in does not have any recovery codes, and generates and displays them.

Uses a feature flag to control rollout.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2105

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [x] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

No
