### PR TITLE
add validation for gov.uk email addresses

### DIFF
--- a/cosmetics-web/app/forms/invite_support_user_form.rb
+++ b/cosmetics-web/app/forms/invite_support_user_form.rb
@@ -1,9 +1,16 @@
 class InviteSupportUserForm < Form
   include StripWhitespace
-  include EmailFormValidation
 
   attribute :name
 
+  attribute :email
+
+  validates :email,
+            email: {
+              message: I18n.t(:wrong_format_gov_uk, scope: :email_form_validation),
+              if: ->(form) { form.email.present? },
+            }
+  validates_presence_of :email, message: I18n.t(:blank, scope: :email_form_validation)
   validates_presence_of :name
   validates :name, length: { maximum: User::NAME_MAX_LENGTH }, user_name_format: { message: :invalid }
 end

--- a/cosmetics-web/app/validators/email_validator.rb
+++ b/cosmetics-web/app/validators/email_validator.rb
@@ -20,7 +20,7 @@ private
   end
 
   def gov_uk_email_required?(record, value)
-    (for_support_user?(record) && value.match?(/[\W\w]*.gov.uk$/)) || !for_support_user?(record)
+    (for_support_user?(record) && value.match?(/[\W\w]*\.gov\.uk$/)) || !for_support_user?(record)
   end
 
   def for_support_user?(record)

--- a/cosmetics-web/app/validators/email_validator.rb
+++ b/cosmetics-web/app/validators/email_validator.rb
@@ -20,7 +20,7 @@ private
   end
 
   def gov_uk_email_required?(record, value)
-    (for_support_user?(record) && value.match?(/[\W\w]*gov.uk$/)) || !for_support_user?(record)
+    (for_support_user?(record) && value.match?(/[\W\w]*.gov.uk$/)) || !for_support_user?(record)
   end
 
   def for_support_user?(record)

--- a/cosmetics-web/app/validators/email_validator.rb
+++ b/cosmetics-web/app/validators/email_validator.rb
@@ -2,7 +2,7 @@ class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     mail = Mail::Address.new(value)
 
-    unless email_accepted?(mail, value)
+    unless email_accepted?(mail, record, value)
       record.errors.add(attribute, options[:message])
     end
   rescue Mail::Field::ParseError
@@ -11,10 +11,19 @@ class EmailValidator < ActiveModel::EachValidator
 
 private
 
-  def email_accepted?(parsed_email, value)
+  def email_accepted?(parsed_email, record, value)
     parsed_email.address == value && # Parsed address corresponds to introduced value
       URI::MailTo::EMAIL_REGEXP.match?(value) && # Valid email format
       parsed_email.domain.split(".").length > 1 && # Exclude local domains (eg: user@example)
-      /[a-zA-Z]/.match?(value[-1]) # Last character of the Top Level Domain is a letter
+      /[a-zA-Z]/.match?(value[-1]) && # Last character of the Top Level Domain is a letter
+      gov_uk_email_required?(record, value) # Only accept gov.uk email addresses for SupportUser
+  end
+
+  def gov_uk_email_required?(record, value)
+    (for_support_user?(record) && value.match?(/[\W\w]*gov.uk$/)) || !for_support_user?(record)
+  end
+
+  def for_support_user?(record)
+    [SupportUser, InviteSupportUserForm].include?(record.class)
   end
 end

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -125,11 +125,15 @@ en:
             password_confirmation:
               confirmation: "Password and confirmation does not match"
         support_user:
-              attributes:
-                password:
-                  blank: "Enter a password"
-                password_confirmation:
-                  confirmation: "Password and confirmation does not match"
+          attributes:
+            email:
+              invalid: &invalid_gov_uk_email "Enter an email address in the correct format and end in gov.uk"
+            new_email:
+              invalid: *invalid_gov_uk_email
+            password:
+              blank: "Enter a password"
+            password_confirmation:
+              confirmation: "Password and confirmation does not match"
         user:
           attributes:
             email:
@@ -382,6 +386,8 @@ en:
           attributes:
             name:
               blank: "Enter the full name"
+            email:
+              invalid: *invalid_gov_uk_email
   enquiries_email: "opss.enquiries@beis.gov.uk"
   errors:
     format: "%{message}"
@@ -426,6 +432,7 @@ en:
   email_form_validation:
     wrong_email_or_password: *invalid_email
     wrong_format: *invalid_email
+    wrong_format_gov_uk: *invalid_gov_uk_email
     blank: *empty_email
   user_password_check_form_validation:
     invalid: "Password is incorrect"

--- a/cosmetics-web/db/seeds.rb
+++ b/cosmetics-web/db/seeds.rb
@@ -79,7 +79,7 @@ ActiveRecord::Base.transaction do
     mobile_number_verified: true,
     name: "John Doe",
     has_accepted_declaration: true,
-    email: "support@example.org",
+    email: "support@example.gov.uk",
     password: "testpassword",
     failed_attempts: 0,
     second_factor_attempts_count: 0,

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -133,6 +133,7 @@ FactoryBot.define do
     end
 
     factory :support_user, class: "SupportUser" do
+      sequence(:email) { |n| "john.doe#{n}@example.gov.uk" }
       invitation_token { Devise.friendly_token }
       invited_at { Time.zone.now }
 

--- a/cosmetics-web/spec/features/account/change_email_spec.rb
+++ b/cosmetics-web/spec/features/account/change_email_spec.rb
@@ -166,14 +166,14 @@ RSpec.describe "Changing email address", :with_2fa, :with_stubbed_mailer, :with_
     context "when the email change is fine" do
       it "changes email properly" do
         fill_in "Password", with: user.password
-        fill_in "New email", with: "new@example.org"
+        fill_in "New email", with: "new@example.gov.uk"
         click_on "Continue"
 
         expect_to_be_on_my_account_page
         expect(page).to have_css("h1", text: "Check your email")
         expect(page).to have_text(/A message with a confirmation link has been sent to your email address/)
         email = delivered_emails.first
-        expect(email.recipient).to eq "new@example.org"
+        expect(email.recipient).to eq "new@example.gov.uk"
 
         confirm_url = email.personalization[:verify_email_url]
         expect(confirm_url).to include("/my_account/email/confirm?confirmation_token=")
@@ -185,10 +185,21 @@ RSpec.describe "Changing email address", :with_2fa, :with_stubbed_mailer, :with_
         email = delivered_emails.last
         expect(email.recipient).to eq old_email
         expect(email.personalization[:old_email_address]).to eq old_email
-        expect(email.personalization[:new_email_address]).to eq "new@example.org"
+        expect(email.personalization[:new_email_address]).to eq "new@example.gov.uk"
 
         expect(page).to have_text(/Email changed successfully/)
-        expect(user.reload.email).to eq("new@example.org")
+        expect(user.reload.email).to eq("new@example.gov.uk")
+      end
+    end
+
+    context "when trying to change email to a non gov.uk email" do
+      it "changes email properly" do
+        fill_in "Password", with: user.password
+        fill_in "New email", with: "new@example.com"
+        click_on "Continue"
+
+        expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
+        expect(page).to have_link("", href: "#new_email")
       end
     end
   end

--- a/cosmetics-web/spec/features/support/invite_support_user_spec.rb
+++ b/cosmetics-web/spec/features/support/invite_support_user_spec.rb
@@ -3,7 +3,7 @@ require "support/feature_helpers"
 
 RSpec.feature "Invite support user", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, :with_2fa_app, type: :feature do
   let(:user) { create(:support_user, :with_sms_secondary_authentication) }
-  let(:new_user_email) { "new-support-user@example.com" }
+  let(:new_user_email) { "new-support-user@example.gov.uk" }
 
   before do
     configure_requests_for_support_domain

--- a/cosmetics-web/spec/forms/invite_support_user_form_spec.rb
+++ b/cosmetics-web/spec/forms/invite_support_user_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InviteSupportUserForm do
                         name:)
   end
 
-  let(:email) { "invited.user@example.com" }
+  let(:email) { "invited.user@example.gov.uk" }
   let(:name) { "Invited User" }
 
   describe "#valid?" do
@@ -55,7 +55,7 @@ RSpec.describe InviteSupportUserForm do
 
       it "populates an error message" do
         expect(form.errors.full_messages_for(:email))
-          .to eq(["Enter an email address in the correct format, like name@example.com"])
+          .to eq(["Enter an email address in the correct format and end in gov.uk"])
       end
     end
   end

--- a/cosmetics-web/spec/models/search_user_spec.rb
+++ b/cosmetics-web/spec/models/search_user_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe SearchUser, type: :model do
 
   include_examples "common user tests"
 
+  it "validates the format of new_email" do
+    user.new_email = "wrongformat"
+    expect(user).not_to be_valid
+    expect(user.errors[:new_email])
+      .to include("Enter an email address in the correct format, like name@example.com")
+  end
+
   describe "#can_view_product_ingredients?" do
     it "is false for OPSS General users" do
       user.role = :opss_general

--- a/cosmetics-web/spec/models/submit_user_spec.rb
+++ b/cosmetics-web/spec/models/submit_user_spec.rb
@@ -10,4 +10,11 @@ RSpec.describe SubmitUser, type: :model do
       expect(described_class.confirm_by_token("foobar")).to be_nil
     end
   end
+
+  it "validates the format of new_email" do
+    user.new_email = "wrongformat"
+    expect(user).not_to be_valid
+    expect(user.errors[:new_email])
+      .to include("Enter an email address in the correct format, like name@example.com")
+  end
 end

--- a/cosmetics-web/spec/models/support_user_spec.rb
+++ b/cosmetics-web/spec/models/support_user_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe SupportUser, type: :model do
 
   include_examples "common user tests"
 
+  it "validates the format of new_email" do
+    user.new_email = "wrongformat"
+    expect(user).not_to be_valid
+    expect(user.errors[:new_email])
+      .to include("Enter an email address in the correct format and end in gov.uk")
+  end
+
+  it "validates that the new email is a gov.uk address" do
+    user.new_email = "new@example.com"
+    expect(user).not_to be_valid
+    expect(user.errors[:new_email])
+      .to include("Enter an email address in the correct format and end in gov.uk")
+  end
+
   describe ".opss?" do
     context "when user is part of opss" do
       it "returns true" do

--- a/cosmetics-web/spec/support/shared_examples/common_user_tests.rb
+++ b/cosmetics-web/spec/support/shared_examples/common_user_tests.rb
@@ -85,13 +85,6 @@ RSpec.shared_examples "common user tests" do
       expect(user.errors[:new_email]).to be_empty
     end
 
-    it "validates the format of new_email" do
-      user.new_email = "wrongformat"
-      expect(user).not_to be_valid
-      expect(user.errors[:new_email])
-        .to include("Enter an email address in the correct format, like name@example.com")
-    end
-
     it "does not require the secondary authentication methods when user didn't completete account security" do
       user.account_security_completed = false
       user.secondary_authentication_methods = nil


### PR DESCRIPTION
## Description

Add validation for gov.uk email addresses and implement for support users

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2136
https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2167

## Screenshots/video
![Screenshot 2023-08-07 at 12-55-26 Invite a team member - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/24bad166-5022-4566-8077-064e655ab0e2)
![Screenshot 2023-08-07 at 12-55-08 Invite a team member - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/a9d09c41-b8ee-425f-8e5f-1ab94987a2ec)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3078-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3078-search-web.london.cloudapps.digital/
https://cosmetics-pr-3078-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
