### PR TITLE
Remove notification clone naming restrictions

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -90,8 +90,6 @@ class Notification < ApplicationRecord
   validate :max_ph_is_greater_than_min_ph
   validate :difference_between_maximum_and_minimum_ph, on: :ph_range
 
-  validate :product_name_uniqueness, on: :cloning
-
   validates_with AcceptAndSubmitValidator, on: :accept_and_submit
 
   validates :archive_reason, presence: { on: :archive, message: "A reason for archiving must be selected" }
@@ -378,14 +376,6 @@ private
 
     if (ph_max_value - ph_min_value).round(2) > 1.0
       errors.add(:ph_max_value, "The maximum pH cannot be greater than 1 above the minimum pH")
-    end
-  end
-
-  def product_name_uniqueness
-    raise ArgumentError if responsible_person.nil?
-
-    if Notification.where(responsible_person_id:).where("TRIM(LOWER(product_name))=TRIM(LOWER(?))", product_name).count.positive?
-      errors.add(:product_name, :taken)
     end
   end
 

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -46,8 +46,6 @@ en:
               blank: "Enter the minimum\u00A0pH"
             ph_max_value:
               blank: "Enter the maximum\u00A0pH"
-            product_name:
-              taken: "Enter a name which has not been used in your active notifications"
         component:
           attributes:
             name:

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -589,20 +589,19 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
     end
   end
 
-  describe "product name uniqueness validation on clone" do
+  describe "product name duplication validation on clone" do
     let(:name) { "Some notification" }
     let(:notification) { create(:notification, product_name: name) }
     let(:responsible_person) { notification.responsible_person }
     let(:new_notification) { build(:notification, responsible_person:, product_name: new_name) }
-    let(:validation_result) { false }
 
     shared_examples_for "product name validation" do
       before do
         notification
       end
 
-      it "validates uniqueness of name" do
-        expect(new_notification.valid?(:cloning)).to eq validation_result
+      it "allows a duplicate name" do
+        expect(new_notification.valid?(:cloning)).to eq true
       end
     end
 
@@ -618,7 +617,7 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
       it_behaves_like "product name validation"
     end
 
-    context "when new name is the same but with differen case" do
+    context "when new name is the same but with different case" do
       let(:new_name) { "some Notification" }
 
       it_behaves_like "product name validation"
@@ -627,18 +626,8 @@ RSpec.describe Notification, :with_stubbed_antivirus, type: :model do
     context "when responsible person is different" do
       let(:new_name) { name }
       let(:responsible_person) { create(:responsible_person) }
-      let(:validation_result) { true }
 
       it_behaves_like "product name validation"
-    end
-
-    context "when new record has no responsible person" do
-      let(:new_name) { name }
-      let(:responsible_person) { nil }
-
-      it "raises ArgumentError" do
-        expect { new_notification.valid?(:cloning) }.to raise_error(ArgumentError)
-      end
     end
   end
 


### PR DESCRIPTION
## Description

Removes the requirement to choose a unique product name when cloning a notification.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2190

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-3079-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3079-search-web.london.cloudapps.digital/
https://cosmetics-pr-3079-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

No
