### PR TITLE
Fix display of maximum concentration

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/_ingredients.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_ingredients.html.erb
@@ -7,7 +7,7 @@
           <dd><abbr>CAS</abbr>: <%= ingredient.cas_number %> </dd>
         <% end %>
         <% if ingredient.exact_concentration.present? %>
-          <dd><% if ingredient.used_for_multiple_shades? %>Maximum concentration: <% end %><%= ingredient.exact_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
+          <dd><% if ingredient.multi_shade? && ingredient.used_for_multiple_shades? %>Maximum concentration: <% end %><%= ingredient.exact_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
         <%
           # range_concentration will be removed when the legacy data has been migrated
           # to minimum / maximum
@@ -27,7 +27,7 @@
         %>
         <% elsif ingredient.range? %>
           <% if ingredient.minimum_concentration == ingredient.maximum_concentration %>
-            <dd><% if ingredient.used_for_multiple_shades? %>Maximum concentration: <% end %> <%= ingredient.maximum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
+            <dd><% if ingredient.multi_shade? && ingredient.used_for_multiple_shades? %>Maximum concentration: <% end %> <%= ingredient.maximum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
           <% else %>
             <dd>Minimum range: <%= ingredient.minimum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>
             <dd>Maximum range: <%= ingredient.maximum_concentration %>%&nbsp;<abbr>w/w</abbr></dd>


### PR DESCRIPTION
## Description

Prevents ingredients marked as multi-shade from being shown as “maximum concentration” where the product is later changed to non-multi-shade.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2203

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-3086-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3086-search-web.london.cloudapps.digital/
https://cosmetics-pr-3086-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

No
