### PR TITLE
OSU Support Portal: invite search user and change role

### DIFF
--- a/cosmetics-web/app/models/responsible_person.rb
+++ b/cosmetics-web/app/models/responsible_person.rb
@@ -4,6 +4,8 @@ class ResponsiblePerson < ApplicationRecord
   ADDRESS_FIELDS = %i[address_line_1 address_line_2 city county postal_code].freeze
   NAME_MAX_LENGTH = 250
 
+  has_paper_trail
+
   has_many :notifications, dependent: :destroy
   has_many :responsible_person_users, dependent: :destroy
   has_many :pending_responsible_person_users, dependent: :destroy
@@ -15,8 +17,6 @@ class ResponsiblePerson < ApplicationRecord
            dependent: :destroy
 
   has_many :nanomaterial_notifications, dependent: :destroy
-
-  has_paper_trail
 
   enum account_type: { business: "business", individual: "individual" }
 

--- a/cosmetics-web/app/models/search_user.rb
+++ b/cosmetics-web/app/models/search_user.rb
@@ -5,7 +5,10 @@ class SearchUser < User
   ALLOW_INTERNATIONAL_PHONE_NUMBER = false
   TOTP_ISSUER = "Search Cosmetics".freeze
 
+  has_paper_trail on: %i[update], only: %i[role]
+
   attribute :skip_password_validation, :boolean, default: false
+  attribute :validate_role, :boolean, default: false
 
   enum role: {
     poison_centre: "poison_centre",
@@ -19,6 +22,7 @@ class SearchUser < User
   validates :mobile_number,
             phone: { message: :invalid, allow_international: ALLOW_INTERNATIONAL_PHONE_NUMBER },
             if: -> { mobile_number.present? }
+  validates :role, inclusion: { in: roles.keys }, if: -> { validate_role }
 
   def resend_account_setup_link
     SearchNotifyMailer.invitation_email(self).deliver_later

--- a/cosmetics-web/config/brakeman.ignore
+++ b/cosmetics-web/config/brakeman.ignore
@@ -1,6 +1,29 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "446e22fa1a1ecf3203beea97be5a1e54fcc2e9849db80017f8944bb39db66641",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "support_portal/app/controllers/support_portal/account_administration_controller.rb",
+      "line": 167,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:search_user).permit(:role)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SupportPortal::AccountAdministrationController",
+        "method": "update_role_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "Role cannot be used to escalate privileges beyond defined limits"
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "ac07c288ecf5a13ffef4861ad347f202af0c2d2e6f7d451fea9561c6f6ed4d2c",
@@ -22,8 +45,31 @@
         89
       ],
       "note": "Lock name is hardcoded in app"
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "f0efe779d02ae48d7c61c713095573f152f85d2ff21398dcb5ab4b0e3ba2becd",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "support_portal/app/controllers/support_portal/account_administration_controller.rb",
+      "line": 171,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:search_user).permit(:name, :email, :role)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SupportPortal::AccountAdministrationController",
+        "method": "invite_search_user_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "Role cannot be used to escalate privileges beyond defined limits"
     }
   ],
-  "updated": "2023-04-20 16:25:37 +0100",
-  "brakeman_version": "5.4.1"
+  "updated": "2023-08-14 14:10:41 +0100",
+  "brakeman_version": "6.0.1"
 }

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -122,6 +122,8 @@ en:
               blank: "Enter a password"
             password_confirmation:
               confirmation: "Password and confirmation does not match"
+            role:
+              inclusion: "Select a role type for the user account"
         support_user:
           attributes:
             email:

--- a/cosmetics-web/spec/features/support/account_administration_spec.rb
+++ b/cosmetics-web/spec/features/support/account_administration_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
   let(:user) { create(:support_user, :with_all_secondary_authentication_methods) }
   let(:search_user1) { create(:search_user) }
   let(:search_user2) { create(:search_user) }
-  let(:search_user3) { create(:search_user, name: search_user1.name) }
+  let(:search_user3) { create(:opss_general_user, name: search_user1.name) }
   let(:submit_user1) { create(:submit_user) }
   let(:submit_user2) { create(:submit_user) }
   let(:responsible_person_user1) { create(:responsible_person_user, user: submit_user1) }
@@ -35,6 +35,7 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     expect(page).to have_h1("Dashboard")
 
     click_link "Account administration"
+    click_link "Search for an account"
 
     expect(page).to have_h1("Search for an account")
 
@@ -53,6 +54,7 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     expect(page).to have_h1("Dashboard")
 
     click_link "Account administration"
+    click_link "Search for an account"
 
     expect(page).to have_h1("Search for an account")
 
@@ -71,6 +73,7 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     expect(page).to have_h1("Dashboard")
 
     click_link "Account administration"
+    click_link "Search for an account"
 
     expect(page).to have_h1("Search for an account")
 
@@ -88,12 +91,22 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     expect(page).to have_h1("Dashboard")
 
     click_link "Account administration"
+    click_link "Search for an account"
 
     expect(page).to have_h1("Search for an account")
 
     click_on "Search"
 
-    expect(page).to have_text("Enter a search term")
+    expect(page).to have_text(search_user1.name)
+    expect(page).to have_text(search_user1.email)
+    expect(page).to have_text(search_user2.name)
+    expect(page).to have_text(search_user2.email)
+    expect(page).to have_text(search_user3.name)
+    expect(page).to have_text(search_user3.email)
+    expect(page).to have_text(submit_user1.name)
+    expect(page).to have_text(submit_user1.email)
+    expect(page).to have_text(submit_user2.name)
+    expect(page).to have_text(submit_user2.email)
   end
 
   scenario "Viewing account details" do
@@ -153,6 +166,21 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     click_on "Save changes"
 
     expect(page).to have_css("div.govuk-notification-banner", text: "The email address has been updated from #{existing_email} to something@example.com")
+  end
+
+  scenario "Changing the role on an account" do
+    visit "/account-admin/#{search_user3.id}"
+
+    expect(page).to have_h1(search_user3.name)
+
+    click_link "Change role type"
+
+    expect(page).to have_h1("Change account role type")
+
+    choose "OPSS Incident Management Team (IMT)"
+    click_on "Save changes"
+
+    expect(page).to have_css("div.govuk-notification-banner", text: "The account role type has been updated from OPSS General to OPSS Incident Management Team (IMT)")
   end
 
   scenario "Removing a Responsible Person from an account" do
@@ -218,5 +246,28 @@ RSpec.feature "Account administration", :with_stubbed_mailer, :with_stubbed_noti
     click_button("Reset account")
 
     expect(page).to have_css("div.govuk-notification-banner", text: "The account has been reset")
+  end
+
+  scenario "Inviting a new search user" do
+    expect(page).to have_h1("Dashboard")
+
+    click_link "Account administration"
+    click_link "Add a new search user account"
+
+    expect(page).to have_h1("Invite a new search user")
+
+    click_on "Send invitation"
+
+    expect(page).to have_link("Name cannot be blank", href: "#search-user-name-field-error")
+    expect(page).to have_link("Enter an email", href: "#search-user-email-field-error")
+    expect(page).to have_link("Select a role type for the user account", href: "#search-user-role-field-error")
+
+    fill_in "Full name", with: "Fake faker"
+    fill_in "Email", with: "fake@example.com"
+    choose "OPSS Enforcement"
+
+    click_on "Send invitation"
+
+    expect(page).to have_text("New search user account invitation sent")
   end
 end

--- a/cosmetics-web/spec/features/support/history_spec.rb
+++ b/cosmetics-web/spec/features/support/history_spec.rb
@@ -39,28 +39,28 @@ RSpec.feature "History", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, 
 
     expect(page).to have_h1("History/Audit Log")
 
-    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).to have_text(other_support_user.name)
     expect(page).to have_text("Change from: Company A")
 
     fill_in "Enter a search term", with: user.name
     click_on "Search"
 
-    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).not_to have_text(other_support_user.name)
     expect(page).not_to have_text("Change from: Company A")
 
     fill_in "Enter a search term", with: notification.reference_number
     click_on "Search"
 
-    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).not_to have_text(other_support_user.name)
     expect(page).not_to have_text("Change from: Company A")
 
     fill_in "Enter a search term", with: other_support_user.name
     click_on "Search"
 
-    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).to have_text(other_support_user.name)
     expect(page).to have_text("Change from: Company A")
   end
@@ -72,7 +72,7 @@ RSpec.feature "History", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, 
 
     expect(page).to have_h1("History/Audit Log")
 
-    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).to have_text(other_support_user.name)
     expect(page).to have_text("Change from: Company A")
 
@@ -84,7 +84,7 @@ RSpec.feature "History", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, 
     fill_in "history_search_date_to_1i", with: 2023
     click_on "Search"
 
-    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).to have_text(other_support_user.name)
     expect(page).to have_text("Change from: Company A")
 
@@ -96,7 +96,7 @@ RSpec.feature "History", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, 
     fill_in "history_search_date_to_1i", with: 2022
     click_on "Search"
 
-    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).not_to have_text(other_support_user.name)
     expect(page).not_to have_text("Change from: Company A")
   end
@@ -108,28 +108,28 @@ RSpec.feature "History", :with_stubbed_mailer, :with_stubbed_notify, :with_2fa, 
 
     expect(page).to have_h1("History/Audit Log")
 
-    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).to have_text(other_support_user.name)
     expect(page).to have_text("Change from: Company A")
 
     select "Change to Notification", from: "Display by action"
     click_on "Search"
 
-    expect(page).to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).not_to have_text(other_support_user.name)
     expect(page).not_to have_text("Change from: Company A")
 
     select "Change to Responsible Person Name", from: "Display by action"
     click_on "Search"
 
-    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).to have_text(other_support_user.name)
     expect(page).to have_text("Change from: Company A")
 
     select "Change to Responsible Person Address", from: "Display by action"
     click_on "Search"
 
-    expect(page).not_to have_text("UKCP Number (#{notification.reference_number}) Deletion")
+    expect(page).not_to have_text("UKCP number (#{notification.reference_number}) deletion")
     expect(page).not_to have_text(other_support_user.name)
     expect(page).not_to have_text("Change from: Company A")
   end

--- a/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
+++ b/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
@@ -1,20 +1,29 @@
 module SupportPortal
   class AccountAdministrationController < ApplicationController
-    before_action :set_user, except: %i[index]
+    before_action :set_user, except: %i[index search search_results invite_search_user create_search_user]
     before_action :set_responsible_persons, only: %i[show edit_responsible_persons]
     before_action :set_responsible_person, only: %i[delete_responsible_person_user_confirm delete_responsible_person_user]
     before_action :reenforce_secondary_authentication, only: :reset_account
 
     # GET /
-    def index
+    def index; end
+
+    # GET /search
+    def search; end
+
+    # GET /search/results
+    def search_results
       @search_query = params[:q].presence
 
-      if @search_query
-        users = ::User.where("name ILIKE ?", "%#{@search_query}%").or(::User.where("email ILIKE ?", "%#{@search_query}%"))
-          .where(type: %w[SubmitUser SearchUser]).select(:id, :name, :email, :type).order(name: :asc).order(created_at: :desc)
-        @records_count = users.size
-        @pagy, @records = pagy(users)
-      end
+      users = if @search_query
+                ::User.where("name ILIKE ?", "%#{@search_query}%").or(::User.where("email ILIKE ?", "%#{@search_query}%"))
+                  .where(type: %w[SubmitUser SearchUser]).select(:id, :name, :email, :type).order(name: :asc).order(created_at: :desc)
+              else
+                ::User.where(type: %w[SubmitUser SearchUser]).select(:id, :name, :email, :type).order(name: :asc).order(created_at: :desc)
+              end
+
+      @records_count = users.size
+      @pagy, @records = pagy(users)
     end
 
     # GET /:id
@@ -64,6 +73,22 @@ module SupportPortal
       end
     end
 
+    # GET /:id/edit-role
+    def edit_role; end
+
+    # PATCH/PUT /:id/update-role
+    def update_role
+      existing_role = @user.role
+
+      return redirect_to account_administration_path if existing_role == params[:search_user][:role]
+
+      if @user.update(update_role_params)
+        redirect_to account_administration_path, notice: "The account role type has been updated from #{helpers.role_type(existing_role)} to #{helpers.role_type(params[:search_user][:role])}"
+      else
+        render :edit_role
+      end
+    end
+
     # GET /:id/edit-responsible-persons
     def edit_responsible_persons; end
 
@@ -81,6 +106,23 @@ module SupportPortal
       ::SupportNotifyMailer.removed_from_responsible_person_email(@user, @responsible_person.name).deliver_later
 
       redirect_to edit_responsible_persons_account_administration_path(@user, q: params[:q]), notice: "#{@user.name} has been removed from #{@responsible_person.name}"
+    end
+
+    # GET /invite-search-user
+    def invite_search_user
+      @user = ::SearchUser.new
+    end
+
+    # PATCH/PUT /create-search-user
+    def create_search_user
+      @user = ::SearchUser.new(invite_search_user_params.merge(skip_password_validation: true, validate_role: true))
+
+      if @user.valid?
+        ::InviteSearchUser.call(**invite_search_user_params.to_h)
+        redirect_to invite_search_user_account_administration_index_path, notice: "New search user account invitation sent"
+      else
+        render :invite_search_user
+      end
     end
 
   private
@@ -118,6 +160,14 @@ module SupportPortal
 
     def update_email_params(user)
       params.require(user_type_param(user)).permit(:email)
+    end
+
+    def update_role_params
+      params.require(:search_user).permit(:role)
+    end
+
+    def invite_search_user_params
+      params.require(:search_user).permit(:name, :email, :role)
     end
   end
 end

--- a/cosmetics-web/support_portal/app/helpers/support_portal/account_administration_helper.rb
+++ b/cosmetics-web/support_portal/app/helpers/support_portal/account_administration_helper.rb
@@ -8,5 +8,27 @@ module SupportPortal
         "Search account"
       end
     end
+
+    def role_type(role)
+      {
+        "opss_enforcement" => "OPSS Enforcement",
+        "opss_science" => "OPSS Science",
+        "opss_general" => "OPSS General",
+        "opss_imt" => "OPSS Incident Management Team (IMT)",
+        "trading_standards" => "Trading Standards",
+        "poison_centre" => "National Poisons Information Service (NPIS)",
+      }[role]
+    end
+
+    def role_radios
+      [
+        OpenStruct.new(id: "opss_enforcement", name: "OPSS Enforcement"),
+        OpenStruct.new(id: "opss_science", name: "OPSS Science"),
+        OpenStruct.new(id: "opss_general", name: "OPSS General"),
+        OpenStruct.new(id: "opss_imt", name: "OPSS Incident Management Team (IMT)"),
+        OpenStruct.new(id: "trading_standards", name: "Trading Standards"),
+        OpenStruct.new(id: "poison_centre", name: "National Poisons Information Service (NPIS)"),
+      ]
+    end
   end
 end

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/edit_role.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/edit_role.html.erb
@@ -1,0 +1,53 @@
+<% content_for :page_title, "Change account role type" %>
+<% @errors = @user.errors.any? %>
+<% @back_link_href = account_administration_path(@user, q: params[:q]) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @user, url: update_role_account_administration_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <% if @errors %><h1 class="govuk-heading-l"><%= yield :page_title %></h1><% end %>
+      <p class="govuk-body">This will affect what <%= @user.name %> can see and do within the Search Cosmetic Product Notifications service.</p>
+      <%= govuk_details(summary_text: "Help with role types") do %>
+        <p class="govuk-body">In order to assign the correct role type for a search user account, some guidance around each role type and the permissions associated with each role type is listed here:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            <strong>OPSS Enforcement / OPSS Incident Management Team (IMT)</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search.</li>
+              <li>Access ingredients search and ability to see ingredient information including their w/w percentages.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>OPSS Science team</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search.</li>
+              <li>Access to Nanomaterial reports available for download.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>OPSS General users</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>National Poisons Information Service (NPIS)</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search and see RP address history.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Trading Standards</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search and see RP address history.</li>
+              <li>Access to ingredients search and ability to see ingredient information; unable to view the w/w percentage information.</li>
+            </ul>
+          </li>
+        </ul>
+      <% end %>
+      <%= f.govuk_collection_radio_buttons :role, role_radios, :id, :name, legend: { text: "Role type" } %>
+      <%= f.govuk_submit "Save changes" %>
+    <% end %>
+  </div>
+</div>

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/index.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/index.html.erb
@@ -1,1 +1,17 @@
-<%= render partial: @search_query ? "search_results" : "search_box" %>
+<% content_for :page_title, "Account administration" %>
+<% @back_link_href = support_root_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <a href="<%= search_account_administration_index_path %>" class="app-card">
+      <h3 class="govuk-heading-s app-card__heading">Search for an account</h3>
+      <p class="govuk-body">Search for a search or submit user account.</p>
+    </a>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <a href="<%= invite_search_user_account_administration_index_path %>" class="app-card">
+      <h3 class="govuk-heading-s app-card__heading">Add a new search user account</h3>
+      <p class="govuk-body">Invite a new Search Cosmetic Product Notifications user.</p>
+    </a>
+  </div>
+</div>

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/invite_search_user.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/invite_search_user.html.erb
@@ -1,0 +1,57 @@
+<% content_for :page_title, "Invite a new search user" %>
+<% @errors = @user.errors.any? %>
+<% @back_link_href = account_administration_index_path %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @user, url: create_search_user_account_administration_index_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <% if @errors %><h1 class="govuk-heading-l"><%= yield :page_title %></h1><% end %>
+      <p class="govuk-body">Inviting a search user will allow them to search new and existing cosmetic product notifications.</p>
+      <%= f.govuk_text_field :name, label: { text: "Full name" } %>
+      <%= f.govuk_email_field :email, label: { text: "Email address" } %>
+      <%= govuk_details(summary_text: "Help with role types") do %>
+        <p class="govuk-body">In order to assign the correct role type for a search user account, some guidance around each role type and the permissions associated with each role type is listed here:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            <strong>OPSS Enforcement / OPSS Incident Management Team (IMT)</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search.</li>
+              <li>Access ingredients search and ability to see ingredient information including their w/w percentages.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>OPSS Science team</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search.</li>
+              <li>Access to Nanomaterial reports available for download.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>OPSS General users</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>National Poisons Information Service (NPIS)</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search and see RP address history.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Trading Standards</strong>
+            <ul class="govuk-list">
+              <li>Access to Cosmetic products search and see RP address history.</li>
+              <li>Access to ingredients search and ability to see ingredient information; unable to view the w/w percentage information.</li>
+            </ul>
+          </li>
+        </ul>
+      <% end %>
+      <%= f.govuk_collection_radio_buttons :role, role_radios, :id, :name, legend: { text: "Role type" }, hint: { text: "This will inform what actions and permissions the new user will have attached to their account." } %>
+      <%= f.govuk_submit "Send invitation" do %>
+        <%= govuk_button_link_to "Cancel", account_administration_index_path, secondary: true %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/search.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/search.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_title, "Search for an account" %>
-<% @back_link_href = support_root_path %>
+<% @back_link_href = account_administration_index_path(q: params[:q]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: account_administration_index_path, method: :get do |f| %>
+    <%= form_with url: search_results_account_administration_index_path, method: :get do |f| %>
       <div class="moj-search">
         <div class="govuk-form-group">
           <label for="q-field" class="govuk-label moj-search__label">Enter a search term</label>
           <div class="govuk-hint moj-search__hint" id="q-hint">For example, full name or email@example.com</div>
-          <input id="q-field" class="govuk-input moj-search__input" aria-describedby="q-hint" type="search" name="q">
+          <input id="q-field" class="govuk-input moj-search__input" aria-describedby="q-hint" type="search" name="q" value="<%= params[:q] %>">
         </div>
         <button type="submit" formnovalidate="formnovalidate" class="govuk-button moj-search__button" data-module="govuk-button" data-prevent-double-click="true">
           <span class="govuk-visually-hidden">Search</span>

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/search_results.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/search_results.html.erb
@@ -1,12 +1,12 @@
 <% content_for :page_title, "Search for an account" %>
-<% @back_link_href = account_administration_index_path %>
+<% @back_link_href = search_account_administration_index_path(q: params[:q]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Search results</h2>
   </div>
   <div class="govuk-grid-columm-one-third govuk-!-text-align-right">
-    <a href="<%= account_administration_index_path %>" class="govuk-button govuk-button--secondary">Clear search results</a>
+    <a href="<%= search_account_administration_index_path %>" class="govuk-button govuk-button--secondary">Clear search results</a>
   </div>
 </div>
 

--- a/cosmetics-web/support_portal/app/views/support_portal/account_administration/show.html.erb
+++ b/cosmetics-web/support_portal/app/views/support_portal/account_administration/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, @user.name %>
-<% @back_link_href = account_administration_index_path(q: params[:q]) %>
+<% @back_link_href = search_results_account_administration_index_path(q: params[:q]) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -25,6 +25,13 @@
           row.with_value(text: "")
           row.with_action(text: "Reset", href: reset_account_account_administration_path(@user, q: params[:q]), visually_hidden_text: "account")
         end
+        if @user.type == "SearchUser"
+          summary_list.with_row do |row|
+            row.with_key(text: "Role type")
+            row.with_value(text: role_type(@user.role))
+            row.with_action(text: "Change", href: edit_role_account_administration_path(@user, q: params[:q]), visually_hidden_text: "role type")
+          end
+        end
         if @user.type == "SubmitUser" && @responsible_persons.present?
           summary_list.with_row do |row|
             row.with_key(text: "Responsible Person accounts")
@@ -35,21 +42,25 @@
       end
     %>
     <h2 class="govuk-heading-m">Last login details</h2>
-    <%=
-      govuk_table do |table|
-        table.with_head do |head|
-          head.with_row do |row|
-            row.with_cell(text: "Date")
-            row.with_cell(text: "Time")
+    <% if @user.last_sign_in_at %>
+      <%=
+        govuk_table do |table|
+          table.with_head do |head|
+            head.with_row do |row|
+              row.with_cell(text: "Date")
+              row.with_cell(text: "Time")
+            end
+          end
+          table.with_body do |body|
+            body.with_row do |row|
+              row.with_cell(text: display_date(@user.last_sign_in_at))
+              row.with_cell(text: display_time(@user.last_sign_in_at))
+            end
           end
         end
-        table.with_body do |body|
-          body.with_row do |row|
-            row.with_cell(text: display_date(@user.last_sign_in_at))
-            row.with_cell(text: display_time(@user.last_sign_in_at))
-          end
-        end
-      end
-    %>
+      %>
+    <% else %>
+      <p class="govuk-body">This user has not logged in yet.</p>
+    <% end %>
   </div>
 </div>

--- a/cosmetics-web/support_portal/config/routes.rb
+++ b/cosmetics-web/support_portal/config/routes.rb
@@ -13,9 +13,15 @@ SupportPortal::Engine.routes.draw do
     end
   end
 
-  resources :history, only: %i[index]
-
   resources :account_administration, path: "account-admin", only: %i[index show] do
+    collection do
+      get "search"
+      get "search-results"
+      get "invite-search-user"
+      patch "create-search-user"
+      put "create-search-user"
+    end
+
     member do
       get "edit-name"
       patch "update-name"
@@ -23,6 +29,9 @@ SupportPortal::Engine.routes.draw do
       get "edit-email"
       patch "update-email"
       put "update-email"
+      get "edit-role"
+      patch "update-role"
+      put "update-role"
       get "reset-account"
       delete "reset"
       get "edit-responsible-persons"
@@ -30,8 +39,6 @@ SupportPortal::Engine.routes.draw do
       delete "delete-responsible-person-user/:responsible_person_user_id", to: "account_administration#delete_responsible_person_user", as: :delete_responsible_person_user
     end
   end
-
-  resource :invite_support_user, path: "invite-support-user", only: %i[new create]
 
   resources :responsible_persons, path: "responsible-persons", only: %i[index show] do
     member do
@@ -55,4 +62,7 @@ SupportPortal::Engine.routes.draw do
       put "update-assigned-contact-phone-number/:assigned_contact_id", to: "responsible_persons#update_assigned_contact_phone_number"
     end
   end
+
+  resources :history, only: %i[index]
+  resource :invite_support_user, path: "invite-support-user", only: %i[new create]
 end


### PR DESCRIPTION
## Description

Adds functionality to invite new search users and change the role of existing search users.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2179, https://regulatorydelivery.atlassian.net/browse/COSBETA-2180, https://regulatorydelivery.atlassian.net/browse/COSBETA-2181, https://regulatorydelivery.atlassian.net/browse/COSBETA-2186

## Screenshots/video

![Screenshot 2023-08-14 at 12 16 08](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/20714ef5-9f82-4254-a4f7-6aa818e11e1a)

![Screenshot 2023-08-14 at 12 16 24](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/9b275eb2-5449-4a0b-bd80-27dd43036ba4)

![Screenshot 2023-08-14 at 12 16 30](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/be57c58d-9c4a-44de-a039-0acfb3e4b4b5)

![Screenshot 2023-08-14 at 12 16 49](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/c6a3497b-cd12-4b34-9c89-55ff578681ab)

![Screenshot 2023-08-14 at 12 17 07](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/b4a3d34f-f4da-48dc-82dc-85163d0f433e)

![Screenshot 2023-08-14 at 12 17 14](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/186c6934-0df1-4cb5-877b-9761a76c7542)

## Review apps

https://cosmetics-pr-3103-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3103-search-web.london.cloudapps.digital/
https://cosmetics-pr-3103-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

No
