### PR TITLE
Make Responsible Person address county mandatory

### DIFF
--- a/cosmetics-web/app/models/responsible_person.rb
+++ b/cosmetics-web/app/models/responsible_person.rb
@@ -26,6 +26,7 @@ class ResponsiblePerson < ApplicationRecord
     rp.validates :name, presence: true
     rp.validates :address_line_1, presence: true
     rp.validates :city, presence: true
+    rp.validates :county, presence: true
     rp.validates :postal_code, presence: true
     rp.validates :postal_code, uk_postcode: true, if: -> { postal_code.present? }
   end

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -158,6 +158,8 @@ en:
               blank: "Enter a building and street"
             city:
               blank: "Enter a town or city"
+            county:
+              blank: "Enter a county"
             postal_code:
               blank: "Enter a postcode"
         contact_person:
@@ -275,6 +277,8 @@ en:
               blank: "Enter a building and street"
             city:
               blank: "Enter a town or city"
+            county:
+              blank: "Enter a county"
             name:
               blank: "Enter a name"
               invalid: "Enter a valid name"

--- a/cosmetics-web/spec/features/submit/responsible_person/details_edition_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/details_edition_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "Editing responsible person details", :with_stubbed_mailer, type:
     expect(page).to have_css("p#address_line_1-error", text: "Enter a building and street")
     expect(page).to have_link("Enter a town or city", href: "#city")
     expect(page).to have_css("p#city-error", text: "Enter a town or city")
+    expect(page).to have_link("Enter a county", href: "#county")
+    expect(page).to have_css("p#county-error", text: "Enter a county")
     expect(page).to have_link("Enter a postcode", href: "#postal_code")
     expect(page).to have_css("p#postal_code-error", text: "Enter a postcode")
 

--- a/cosmetics-web/spec/forms/responsible_persons/details_form_spec.rb
+++ b/cosmetics-web/spec/forms/responsible_persons/details_form_spec.rb
@@ -231,12 +231,12 @@ RSpec.describe ResponsiblePersons::DetailsForm do
 
       before { form.validate }
 
-      it "is is valid" do
-        expect(form).to be_valid
+      it "is not valid" do
+        expect(form).to be_invalid
       end
 
-      it "does not populate an error message" do
-        expect(form.errors.full_messages).to be_empty
+      it "populates an error message" do
+        expect(form.errors.full_messages).to eq(["Enter a county"])
       end
     end
 

--- a/cosmetics-web/spec/models/responsible_person_spec.rb
+++ b/cosmetics-web/spec/models/responsible_person_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe ResponsiblePerson, type: :model do
       expect(responsible_person.errors[:city]).to include("Enter a town or city")
     end
 
+    it "fails if a county is not specified" do
+      responsible_person.county = nil
+
+      expect(responsible_person.save).to be false
+      expect(responsible_person.errors[:county]).to include("Enter a county")
+    end
+
     it "fails if a postal code is not specified" do
       responsible_person.postal_code = nil
 


### PR DESCRIPTION
## Description

Makes the county field mandatory for Responsible Person addresses.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2155

## Screenshots/video

![Screenshot 2023-08-18 at 14 35 44](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/7274ee4d-3e48-4fcc-8b66-3f6606bb1e15)

## Review apps

https://cosmetics-pr-3118-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3118-search-web.london.cloudapps.digital/
https://cosmetics-pr-3118-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

No
