### PR TITLE
add ability to reinvite deactivated users

### DIFF
--- a/cosmetics-web/app/services/invite_support_user.rb
+++ b/cosmetics-web/app/services/invite_support_user.rb
@@ -26,7 +26,6 @@ private
       user.skip_password_validation = true
       user.role = :opss_general # All support users also have the OPSS General role for the search service
       user.invite = true
-      user.deactivated_at = nil
     end
   end
 
@@ -37,6 +36,8 @@ private
       if !user.invitation_token || (user.invited_at < 1.hour.ago)
         user.update! invitation_token: (user.invitation_token || SecureRandom.hex(15)), invited_at: Time.zone.now
       end
+
+      user.update! deactivated_at: nil
 
       SupportNotifyMailer.invitation_email(user).deliver_later
     end

--- a/cosmetics-web/spec/services/invite_support_user_spec.rb
+++ b/cosmetics-web/spec/services/invite_support_user_spec.rb
@@ -144,6 +144,12 @@ RSpec.describe InviteSupportUser, :with_stubbed_mailer do
       create(:support_user, :registration_incomplete, email: "deactivatedtuser@example.gov.uk", deactivated_at: 1.week.ago)
     end
 
+    it "sets deactivated_at to nil" do
+      inviter.call
+      user.reload
+      expect(user.deactivated_at).to be_nil
+    end
+
     include_examples "existing user"
   end
 end


### PR DESCRIPTION
## Description

Sets deacvtivated_at to nil for invited support users.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2260

## Review apps

https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Automated tests have been added or updated
