### PR TITLE
added copy around image upload guideance for products

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/product/_instructions.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/_instructions.html.erb
@@ -43,5 +43,17 @@
         <li>an image of the label on the box</li>
         <li>a photo of the packing</li>
     </ul>
+    <h2 class="govuk-heading-s">
+      Example 3
+    </h2>
+    <p class="govuk-body">
+      The product contains several components (for example, hair dye).
+    </p>
+    <p class="govuk-body">
+      You must supply the artwork and, a photo of the set. You can also attach the artwork for each bottle label and a photo of each bottle.
+    </p>
+    <p class="govuk-body">
+      If the product features instructions or other information on a separate leaflet, label, tag or card, you must attach this artwork as well.
+    </p>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Description

Adds new copy for image uploads in products

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2262

## Screenshots/video

### before
<img width="888" alt="CleanShot 2023-09-13 at 12 02 49@2x" src="https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/2cc78fab-f71f-4753-b7e6-7f2b92704a28">

### after
<img width="750" alt="CleanShot 2023-09-13 at 12 03 17@2x" src="https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/72c7ac95-9523-4a62-82f2-72dd7d6fb3ec">

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
