### PR TITLE
Add nanomaterial explainer copy - COSBETA-2261

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/_purposes_form.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/nanomaterials/build/_purposes_form.html.erb
@@ -7,6 +7,11 @@
   end
 %>
 
+<% legend_html = capture do %>
+  <h1 class="govuk-fieldset__heading govuk-label--l">What is the purpose of this nanomaterial?</h1>
+  <p class="govuk-body"><%= link_to "How to notify nanomaterials  (opens in a new tab)", how_to_notify_nanomaterials_path, target: :_blank %></p>
+<% end %>
+
 <%= form_with(model: purposes_form, url: form_url, scope: :purposes_form, method: form_method, html: { novalidate: true }) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -24,9 +29,7 @@
       <%= govukRadios(
             form: f,
             key: :purpose_type,
-            fieldset: { legend: { text: "What is the purpose of this nanomaterial?",
-                                  classes: "govuk-label--l",
-                                  isPageHeading: true } },
+            fieldset: { legend: { html: legend_html } },
             items: [{ text: to_sentence(standard_purposes.map(&:upcase_display_name), last_word_connector: " or "),
                       value: "standard",
                       conditional: { html: standard_purposes_checkboxes_html } },

--- a/cosmetics-web/app/views/responsible_persons/notifications/product/contains_nanomaterials.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/contains_nanomaterials.html.erb
@@ -25,6 +25,7 @@
           <p class="govuk-body">Cosmetic products available to consumers must be safe for human health. <abbr>OPSS</abbr> will take the necessary action to ensure the safety of consumers including but not limited to prohibiting or restricting specific nanomaterials if a risk to human health is identified. Any scientific data submitted for the safety assessment <span class="govuk-!-font-weight-bold">must include all</span> relevant elements as prescribed in the <a href="/pdf/sccs_1611_19.pdf" class="govuk-link govuk-link--no-visited-state" rel="noreferrer noopener" target="_blank">Scientific Committee on Consumer Safety Notes of Guidance on the Safety of Nanomaterials in Cosmetics (opens in a new tab)</a>.</p>
           <p class="govuk-body">Products containing nanomaterials notified in <abbr>GB</abbr> after 1 January 2021 can be placed on the market 6 months after the nanomaterial has first been notified.</p>
           <p class="govuk-body govuk-!-font-weight-bold">Note that you cannot use a nanomaterial as a preservative, UV-filter or colourant that is not listed in the Annexes.</p>
+          <p class="govuk-body"><%= link_to "How to notify nanomaterials  (opens in a new tab)", how_to_notify_nanomaterials_path, target: :_blank %></p>
         <% end %>
 
         <% count_input_html = capture do %>


### PR DESCRIPTION
## Description

Adds links to the nanomaterial guideance in two forms - one for selecting whether or not a product has them, and the other to describe them

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/COSBETA-2261

## Screenshots/video

### before

![image-20230831-104929](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/4b5ec06d-d0b8-489d-ad42-b85a97637103)
![image-20230831-105251](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/1671ce2a-6a5e-4d8e-9f35-516201738f52)

### after
<img width="816" alt="CleanShot 2023-09-13 at 14 46 34@2x" src="https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/a2e0edbd-9ff0-4bff-830e-68196ecf4b0a">
<img width="776" alt="CleanShot 2023-09-13 at 14 47 20@2x" src="https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/ef553e94-9eda-4902-8040-521a8c8c53e5">


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3155-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3155-search-web.london.cloudapps.digital/
https://cosmetics-pr-3155-support-web.london.cloudapps.digital/
