### PR TITLE
Help text for "children under 3" question - COSBETA-2125

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/product/for_children_under_three.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/product/for_children_under_three.html.erb
@@ -10,12 +10,21 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Is the product intended to be used on children under 3 years old?</h1>
+
+        <%= govukDetails(summaryText: "Help with children under 3") do %>
+          <p class="govuk-body">
+            The safety assessment should take the form of a Cosmetic Product Safety Report (CPSR) signed by a qualified safety assessor.
+            The CPSR provides evidence of how the product is safe for its intended cosmetic use and takes account of reasonably foreseeable use.
+            In addition, a specific safety assessment is required for cosmetic products intended for use on children under the age of three, and for cosmetic products intended exclusively for use in external intimate hygiene.
+          </p>
+        <% end %>
 
       <%= error_summary_for(@notification, first_values: {under_three_years: "true"}) %>
       <%= govukRadios(
             form: form,
             key: :under_three_years,
-            fieldset: { legend: { text: question, classes: "govuk-fieldset__legend--l", isPageHeading: true } },
+            fieldset: { legend: { html: "<span class='govuk-visually-hidden'>Is the product intended to be used on children under 3 years old?</span>".html_safe } },
             items: [{ text: "Yes", value: "true" },
                     { text: "No", value: "false" }],
           ) %>


### PR DESCRIPTION
## Description
Adds help text drop down for "Children under 3?" question on submit

## JIRA ticket(s)
https://regulatorydelivery.atlassian.net/browse/COSBETA-2125

## Screenshots/video

before
![CleanShot 2023-10-09 at 12 00 24@2x](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/fc338b1f-6ad2-4627-bf2f-2a1d6fade60d)

after
![CleanShot 2023-10-09 at 11 57 16@2x](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/bcbe8122-22b5-40b0-91d9-c54eeb2f1eb9)

Help text expanded 
![CleanShot 2023-10-09 at 11 57 21@2x](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/5fa5323d-bb67-44c2-a718-37e1af8e5183)

Form validation failure still works 
![CleanShot 2023-10-09 at 11 57 07@2x](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/28108/e65dea37-4a08-4f58-b2f2-eec1f08c9ae1)

## Review apps
https://cosmetics-pr-3179-submit-web.london.cloudapps.digital/

