### PR TITLE
add back link to authentication code page

### DIFF
--- a/cosmetics-web/app/views/secondary_authentication/app/new.html.erb
+++ b/cosmetics-web/app/views/secondary_authentication/app/new.html.erb
@@ -1,9 +1,15 @@
 <% title = "Enter the access code" %>
 <% page_title(title, errors: @form.errors.any?) %>
 
-<% if @form.user&.multiple_secondary_authentication_methods? %>
-  <% content_for(:after_header) do %>
-    <%= govukBackLink(text: "Back", href: new_secondary_authentication_method_path) %>
+<% content_for :after_header do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <% if @form.user&.multiple_secondary_authentication_methods? %>
+        <%= govuk_back_link(href: new_secondary_authentication_method_path) %>
+      <% else %>
+        <%= govuk_back_link(href: request.referer) %>
+      </div>
+    </div>
   <% end %>
 <% end %>
 

--- a/cosmetics-web/app/views/secondary_authentication/method/new.html.erb
+++ b/cosmetics-web/app/views/secondary_authentication/method/new.html.erb
@@ -1,5 +1,12 @@
 <% title = "Secondary authentication method" %>
 <% page_title(title, errors: @form.errors.any?) %>
+<% content_for :after_header do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= govuk_back_link(href: request.referer) %>
+    </div>
+  </div>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/cosmetics-web/app/views/secondary_authentication/recovery_code/new.html.erb
+++ b/cosmetics-web/app/views/secondary_authentication/recovery_code/new.html.erb
@@ -1,9 +1,18 @@
 <% title = "Enter a recovery code" %>
 <% page_title(title, errors: @form.errors.any?) %>
+<% content_for :after_header do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= govuk_back_link(href: request.referer) %>
+    </div>
+  </div>
+<% end %>
 
-<% if @form.user&.multiple_secondary_authentication_methods? %>
-  <% content_for(:after_header) do %>
-    <%= govukBackLink(text: "Back", href: new_secondary_authentication_method_path) %>
+<% content_for :after_header do %>
+  <% if @form.user&.multiple_secondary_authentication_methods? %>
+    <%= govuk_back_link( href: new_secondary_authentication_method_path) %>
+  <% else %>
+    <%= govuk_back_link(href: request.referer) %>
   <% end %>
 <% end %>
 

--- a/cosmetics-web/app/views/secondary_authentication/sms/new.html.erb
+++ b/cosmetics-web/app/views/secondary_authentication/sms/new.html.erb
@@ -2,19 +2,25 @@
 <% page_title(title, errors: @form.errors.any?) %>
 
 <% content_for(:after_header) do %>
-  <%=
-    if @form.user&.mobile_number_pending_verification? && !request.referer&.end_with?("two-factor/sms/setup")
-      if submit_domain?
-        button_to(registration_reset_account_security_path, method: :delete, class: "button-link govuk-back-link") { "Back" }
-      elsif support_domain?
-        button_to(reset_complete_registration_support_user_path(@form.user), method: :delete, class: "button-link govuk-back-link") { "Back" }
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+    <%=
+      if @form.user&.mobile_number_pending_verification? && !request.referer&.end_with?("two-factor/sms/setup")
+        if submit_domain?
+          button_to(registration_reset_account_security_path, method: :delete, class: "button-link govuk-back-link") { "Back" }
+        elsif support_domain?
+          button_to(reset_complete_registration_support_user_path(@form.user), method: :delete, class: "button-link govuk-back-link") { "Back" }
+        else
+          button_to(reset_complete_registration_user_path(@form.user), method: :delete, class: "button-link govuk-back-link") { "Back" }
+        end
+      elsif !@form.user&.mobile_number_pending_verification? && @form.user&.multiple_secondary_authentication_methods?
+        govuk_back_link(href: new_secondary_authentication_method_path)
       else
-        button_to(reset_complete_registration_user_path(@form.user), method: :delete, class: "button-link govuk-back-link") { "Back" }
+        govuk_back_link(href: request.referer)
       end
-    elsif !@form.user&.mobile_number_pending_verification? && @form.user&.multiple_secondary_authentication_methods?
-      govukBackLink(text: "Back", href: new_secondary_authentication_method_path)
-    end
-  %>
+    %>
+    </div>
+  </div>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Description

Adds back link to authentication code choice page

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2189

## Screenshots/video
![Screenshot 2023-10-11 at 14-01-43 Secondary authentication method - OSU Support Portal](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/afe671fa-c823-4379-b7ec-3c3d3455bf99)


## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3189-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3189-search-web.london.cloudapps.digital/
https://cosmetics-pr-3189-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
