### PR TITLE
remove editable links from submitted notifications

### DIFF
--- a/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
+++ b/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
@@ -26,110 +26,77 @@ module ResponsiblePersons::NotificationsHelper
     ].compact
   end
 
+  def notification_step_action(notification, step)
+    return {} unless notification.editable?
+
+    {
+      items: [
+        {
+          href: responsible_person_notification_product_path(notification.responsible_person, notification, step),
+          text: "Edit",
+          visuallyHiddenText: step&.to_s&.humanize&.downcase,
+          classes: ["govuk-link--no-visited-state"],
+        },
+      ],
+    }
+  end
+
+  def notification_product_kit_step_action(notification)
+    return {} unless notification.editable?
+
+    {
+      items: [
+        {
+          href: new_responsible_person_notification_product_kit_path(notification.responsible_person, notification),
+          text: "Edit",
+          visuallyHiddenText: "mixed items",
+          classes: ["govuk-link--no-visited-state"],
+        },
+      ],
+    }
+  end
+
   def notification_summary_product_rows(notification)
     [
       {
         key: { text: "Product name" },
         value: { text: notification.product_name },
-        actions: {
-          items: [
-            {
-              href: responsible_person_notification_product_path(notification.responsible_person, notification, :add_product_name),
-              text: "Edit",
-              visuallyHiddenText: "product name",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
+        actions: notification_step_action(notification, :add_product_name),
       },
       if notification.industry_reference.present?
         {
           key: { text: "Internal reference number" },
           value: { text: notification.industry_reference },
-          actions: {
-            items: [
-              {
-                href: responsible_person_notification_product_path(notification.responsible_person, notification, :add_internal_reference),
-                text: "Edit",
-                visuallyHiddenText: "internal reference",
-                classes: ["govuk-link--no-visited-state"],
-              },
-            ],
-          },
+          actions: notification_step_action(notification, :add_internal_reference),
         }
       end,
       unless notification.under_three_years.nil?
         {
           key: { text: "For children under 3" },
           value: { text: notification.under_three_years ? "Yes" : "No" },
-          actions: {
-            items: [
-              {
-                href: responsible_person_notification_product_path(notification.responsible_person, notification, :under_three_years),
-                text: "Edit",
-                visuallyHiddenText: "under three years",
-                classes: ["govuk-link--no-visited-state"],
-              },
-            ],
-          },
+          actions: notification_step_action(notification, :under_three_years),
         }
       end,
       {
         key: { text: "Number of items" },
         value: { text: notification.components.length },
-        actions: {
-          items: [
-            {
-              href: responsible_person_notification_product_path(notification.responsible_person, notification, :single_or_multi_component),
-              text: "Edit",
-              visuallyHiddenText: "number of items",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
+        actions: notification_step_action(notification, :single_or_multi_component),
       },
       {
         key: { text: "Shades" },
         value: { html: display_shades(notification) },
-        actions: {
-          items: [
-            {
-              href: responsible_person_notification_product_path(notification.responsible_person, notification, :shades),
-              text: "Edit",
-              visuallyHiddenText: "shades",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
+        actions: notification_step_action(notification, :shades),
       },
       {
         key: { text: "Label" },
         value: { html: render("notifications/product_details_label_images",
                               notification:) },
-        actions: {
-          items: [
-            {
-              href: responsible_person_notification_product_path(notification.responsible_person, notification, :add_product_image),
-              text: "Edit",
-              visuallyHiddenText: "product image",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
+        actions: notification_step_action(notification, :add_product_image),
       },
       {
         key: { text: "Are the items mixed?" },
         value: { text: notification.components_are_mixed ? "Yes" : "No" },
-        actions: {
-          items: [
-            {
-              href: new_responsible_person_notification_product_kit_path(notification.responsible_person, notification),
-              text: "Edit",
-              visuallyHiddenText: "mixed items",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
+        actions: notification_product_kit_step_action(notification),
       },
       if can_view_product_ingredients? && notification.ph_min_value.present?
         {
@@ -190,6 +157,21 @@ module ResponsiblePersons::NotificationsHelper
     ].compact
   end
 
+  def notification_summary_component_action(component, step)
+    return {} unless component.notification.editable?
+
+    {
+      items: [
+        {
+          href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, step),
+          text: "Edit",
+          visuallyHiddenText: "#{component.name} category",
+          classes: ["govuk-link--no-visited-state"],
+        },
+      ],
+    }
+  end
+
   def notification_summary_component_rows(component, include_shades: true)
     cmrs = component.cmrs
     nano_materials = component.nano_materials
@@ -202,16 +184,7 @@ module ResponsiblePersons::NotificationsHelper
                                 entities_list: component.shades,
                                 list_classes: "",
                                 list_item_classes: "") },
-          actions: {
-            items: [
-              {
-                href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :number_of_shades),
-                text: "Edit",
-                visuallyHiddenText: "#{component.name} category",
-                classes: ["govuk-link--no-visited-state"],
-              },
-            ],
-          },
+          actions: notification_summary_component_action(component, :number_of_shades),
         }
       end,
       {
@@ -233,16 +206,7 @@ module ResponsiblePersons::NotificationsHelper
                               entities_list: nano_materials_details(nano_materials),
                               list_classes: "",
                               list_item_classes: "") },
-        actions: {
-          items: [
-            {
-              href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :select_nanomaterials),
-              text: "Edit",
-              visuallyHiddenText: "select nanomaterials",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
+        actions: notification_summary_component_action(component, :select_nanomaterials),
       },
       if nano_materials.non_standard.any?
         {
@@ -257,47 +221,20 @@ module ResponsiblePersons::NotificationsHelper
         {
           key: { text: "Application instruction" },
           value: { text: get_exposure_routes_names(component.exposure_routes) },
-          actions: {
-            items: [
-              {
-                href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :add_exposure_routes),
-                text: "Edit",
-                visuallyHiddenText: "exposure root",
-                classes: ["govuk-link--no-visited-state"],
-              },
-            ],
-          },
+          actions: notification_summary_component_action(component, :add_exposure_routes),
         }
       end,
       if nano_materials.present?
         {
           key: { text: "Exposure condition" },
           value: { text: get_exposure_condition_name(component.exposure_condition) },
-          actions: {
-            items: [
-              {
-                href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :add_exposure_condition),
-                text: "Edit",
-                visuallyHiddenText: "exposure condition",
-                classes: ["govuk-link--no-visited-state"],
-              },
-            ],
-          },
+          actions: notification_summary_component_action(component, :add_exposure_condition),
         }
       end,
       {
         key: { text: "Category of product" },
         value: { text: get_category_name(component.root_category) },
-        actions: {
-          items: [
-            {
-              href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :select_root_category),
-              text: "Edit",
-              visuallyHiddenText: "#{component.name} category",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
+        actions: notification_summary_component_action(component, :select_root_category),
       },
       {
         key: { text: "Category of #{get_category_name(component.root_category)&.downcase&.singularize}" },
@@ -310,48 +247,20 @@ module ResponsiblePersons::NotificationsHelper
       {
         key: { text: "Physical form" },
         value: { text: get_physical_form_name(component.physical_form) },
-        actions: {
-          items: [
-            {
-              href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :add_physical_form),
-              text: "Edit",
-              visuallyHiddenText: "physical form",
-              classes: ["govuk-link--no-visited-state"],
-            },
-          ],
-        },
-
+        actions: notification_summary_component_action(component, :add_physical_form),
       },
       if can_view_product_ingredients?
         {
           key: { text: "Special applicator" },
           value: { text: component.special_applicator.present? ? "Yes" : "No" },
-          actions: {
-            items: [
-              {
-                href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :contains_special_applicator),
-                text: "Edit",
-                visuallyHiddenText: "contains special applicator",
-                classes: ["govuk-link--no-visited-state"],
-              },
-            ],
-          },
+          actions: notification_summary_component_action(component, :contains_special_applicator),
         }
       end,
       if can_view_product_ingredients? && component.special_applicator.present?
         {
           key: { text: "Applicator type" },
           value: { text: component_special_applicator_name(component) },
-          actions: {
-            items: [
-              {
-                href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :select_special_applicator_type),
-                text: "Edit",
-                visuallyHiddenText: "select special applicator type",
-                classes: ["govuk-link--no-visited-state"],
-              },
-            ],
-          },
+          actions: notification_summary_component_action(component, :select_special_applicator_type),
         }
       end,
       if can_view_product_ingredients? && component.acute_poisoning_info.present?
@@ -535,7 +444,7 @@ private
   end
 
   def ph_row_actions(component)
-    return {} unless component.ph_required?
+    return {} if !component.ph_required? || !component.notification.editable?
 
     {
       items: [

--- a/cosmetics-web/app/views/responsible_persons/notifications/_product_details.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/_product_details.html.erb
@@ -41,36 +41,50 @@
             value: { text: get_notification_type_name(component.notification_type) },
           },
           if component.predefined?
-            {
-              key: { text: "Frame formulation" },
-              value: { text: get_frame_formulation_name(component.frame_formulation) },
-              actions: {
-                items: [
-                  {
-                    href: responsible_person_notification_product_path(notification.responsible_person, notification, :add_product_image),
-                    text: "Edit",
-                    visuallyHiddenText: "product  image",
-                    classes: ["govuk-link--no-visited-state"]
-                  }
-                ]
-              },
-            }
+            if component.notification.editable?
+              {
+                key: { text: "Frame formulation" },
+                value: { text: get_frame_formulation_name(component.frame_formulation) },
+                actions: {
+                  items: [
+                    {
+                      href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :select_frame_formulation),
+                      text: "Edit",
+                      visuallyHiddenText: "frame formulation",
+                      classes: ["govuk-link--no-visited-state"]
+                    }
+                  ]
+                },
+              }
+            else
+              {
+                key: { text: "Frame formulation" },
+                value: { text: get_frame_formulation_name(component.frame_formulation) },
+              }
+            end
           elsif component.formulation_file.attached?
-            {
-              key: { text: "Formulation" },
-              value: { html: render("notifications/component_details_formulation_ingredients",
-                                    component: component) },
-              actions: {
-                items: [
-                  {
-                    href: responsible_person_notification_product_path(notification.responsible_person, notification, :add_product_image),
-                    text: "Edit",
-                    visuallyHiddenText: "product  image",
-                    classes: ["govuk-link--no-visited-state"]
-                  }
-                ]
-              },
-            }
+            if component.notification.editable?
+              {
+                key: { text: "Formulation" },
+                value: { html: render("notifications/component_details_formulation_ingredients",
+                                      component: component) },
+                actions: {
+                  items: [
+                    {
+                      href: responsible_person_notification_component_build_path(component.notification.responsible_person, component.notification, component, :upload_ingredients_file),
+                      text: "Edit",
+                      visuallyHiddenText: "formulation",
+                      classes: ["govuk-link--no-visited-state"]
+                    }
+                  ]
+                },
+              }
+            else
+              {
+                key: { text: "Formulation" },
+                value: { html: render("notifications/component_details_formulation_ingredients", component: component) },
+              }
+            end
           end
         ].compact
       ) %>

--- a/cosmetics-web/spec/helpers/responsible_persons/notifications_helper_spec.rb
+++ b/cosmetics-web/spec/helpers/responsible_persons/notifications_helper_spec.rb
@@ -130,7 +130,7 @@ describe ResponsiblePersons::NotificationsHelper do
       allow(helper).to receive_messages(render: "", current_user: user)
     end
 
-    context "for a completed notification" do
+    context "with a completed notification" do
       let(:notification_complete_at) { Time.zone.parse("2021-10-04T17:10Z") }
       let(:trait) { :registered }
 
@@ -245,7 +245,7 @@ describe ResponsiblePersons::NotificationsHelper do
       end
     end
 
-    context "for a draft notification" do
+    context "with a draft notification" do
       let(:notification_complete_at) { nil }
       let(:trait) { :draft_complete }
 

--- a/cosmetics-web/spec/helpers/responsible_persons/notifications_helper_spec.rb
+++ b/cosmetics-web/spec/helpers/responsible_persons/notifications_helper_spec.rb
@@ -112,13 +112,13 @@ describe ResponsiblePersons::NotificationsHelper do
 
     let(:notification) do
       build_stubbed(:notification,
-                    :registered,
+                    trait,
                     reference_number: "60162968",
                     product_name: "Product Test",
                     industry_reference: "CPNP-3874065",
                     cpnp_reference: "3796528",
                     cpnp_notification_date: Time.zone.parse("2019-10-04T17:10Z"),
-                    notification_complete_at: Time.zone.parse("2021-05-03T12:08Z"))
+                    notification_complete_at:)
     end
     let(:user) { instance_double(SubmitUser, can_view_product_ingredients?: true) }
 
@@ -130,112 +130,232 @@ describe ResponsiblePersons::NotificationsHelper do
       allow(helper).to receive_messages(render: "", current_user: user)
     end
 
-    it "contains the product name" do
-      expect(summary_product_rows).to include(hash_including({ key: { text: "Product name" }, value: { text: "Product Test" }, actions: { items: [hash_including({ href: "#{product_href}/add_product_name" })] } }))
-    end
+    context "for a completed notification" do
+      let(:notification_complete_at) { Time.zone.parse("2021-10-04T17:10Z") }
+      let(:trait) { :registered }
 
-    it "contains the industry reference number" do
-      expect(summary_product_rows).to include(hash_including({ key: { text: "Internal reference number" }, value: { text: "CPNP-3874065" }, actions: { items: [hash_including({ href: "#{product_href}/add_internal_reference" })] } }))
-    end
-
-    it "contains the number of components associated with the notification" do
-      expect(summary_product_rows).to include(hash_including({ key: { text: "Number of items" }, value: { text: 0 }, actions: { items: [hash_including({ href: "#{product_href}/single_or_multi_component" })] } }))
-    end
-
-    it "contains notification shades html" do
-      allow(helper).to receive(:display_shades).and_return("Shades info")
-      expect(summary_product_rows).to include(hash_including({ key: { text: "Shades" }, value: { html: "Shades info" }, actions: { items: [hash_including({ href: "#{product_href}/shades" })] } }))
-    end
-
-    it "contains info indicating when the notification components are mixed" do
-      notification.components_are_mixed = true
-      expect(summary_product_rows).to include(hash_including({ key: { text: "Are the items mixed?" }, value: { text: "Yes" }, actions: { items: [hash_including({ href: "#{notification_href}/product_kit/new" })] } }))
-    end
-
-    it "contains info indicating when the notification components are not mixed" do
-      notification.components_are_mixed = false
-      expect(summary_product_rows).to include(hash_including({ key: { text: "Are the items mixed?" }, value: { text: "No" }, actions: { items: [hash_including({ href: "#{notification_href}/product_kit/new" })] } }))
-    end
-
-    describe "for children under 3" do
-      it "not included when not available for the notification" do
-        notification.under_three_years = nil
-        expect(summary_product_rows).not_to include(hash_including(key: { text: "For children under 3" }))
+      it "contains the product name" do
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Product name" }, value: { text: "Product Test" } }))
       end
 
-      it "included when notification product is for children under 3" do
-        notification.under_three_years = true
-        expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "Yes" }, actions: { items: [hash_including({ href: "#{product_href}/under_three_years" })] } }))
+      it "contains the industry reference number" do
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Internal reference number" }, value: { text: "CPNP-3874065" } }))
       end
 
-      it "included when notification product is not for children under 3" do
-        notification.under_three_years = false
-        expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "No" }, actions: { items: [hash_including({ href: "#{product_href}/under_three_years" })] } }))
+      it "contains the number of components associated with the notification" do
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Number of items" }, value: { text: 0 } }))
       end
-    end
 
-    describe "PH information" do
-      context "when current user can view the product ingredients" do
-        before { allow(user).to receive(:can_view_product_ingredients?).and_return(true) }
+      it "contains notification shades html" do
+        allow(helper).to receive(:display_shades).and_return("Shades info")
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Shades" }, value: { html: "Shades info" } }))
+      end
 
-        it "contains the product PH minimum value when present" do
-          notification.ph_min_value = 0.3
-          expect(summary_product_rows).to include(
-            { key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }, value: { text: 0.3 } },
-          )
+      it "contains info indicating when the notification components are mixed" do
+        notification.components_are_mixed = true
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Are the items mixed?" }, value: { text: "Yes" } }))
+      end
+
+      it "contains info indicating when the notification components are not mixed" do
+        notification.components_are_mixed = false
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Are the items mixed?" }, value: { text: "No" } }))
+      end
+
+      describe "for children under 3" do
+        it "not included when not available for the notification" do
+          notification.under_three_years = nil
+          expect(summary_product_rows).not_to include(hash_including(key: { text: "For children under 3" }))
         end
 
-        it "does not contain the product PH minimum value when not present" do
-          notification.ph_min_value = nil
-          expect(summary_product_rows).not_to include(
-            hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
-          )
+        it "included when notification product is for children under 3" do
+          notification.under_three_years = true
+          expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "Yes" } }))
         end
 
-        it "contains the product PH maximum value when present" do
-          notification.ph_max_value = 0.7
-          expect(summary_product_rows).to include(
-            { key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }, value: { text: 0.7 } },
-          )
-        end
-
-        it "does not contain the product PH maximum value when not present" do
-          notification.ph_max_value = nil
-          expect(summary_product_rows).not_to include(
-            hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
-          )
+        it "included when notification product is not for children under 3" do
+          notification.under_three_years = false
+          expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "No" } }))
         end
       end
 
-      context "when the current user cannot view the product ingredients" do
-        before { allow(user).to receive(:can_view_product_ingredients?).and_return(false) }
+      describe "PH information" do
+        context "when current user can view the product ingredients" do
+          before { allow(user).to receive(:can_view_product_ingredients?).and_return(true) }
 
-        it "does not contain the product PH minimum value even when is available" do
-          notification.ph_min_value = 0.3
-          expect(summary_product_rows).not_to include(
-            hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
-          )
+          it "contains the product PH minimum value when present" do
+            notification.ph_min_value = 0.3
+            expect(summary_product_rows).to include(
+              { key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }, value: { text: 0.3 } },
+            )
+          end
+
+          it "does not contain the product PH minimum value when not present" do
+            notification.ph_min_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "contains the product PH maximum value when present" do
+            notification.ph_max_value = 0.7
+            expect(summary_product_rows).to include(
+              { key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }, value: { text: 0.7 } },
+            )
+          end
+
+          it "does not contain the product PH maximum value when not present" do
+            notification.ph_max_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
         end
 
-        it "does not contain the product PH minimum value when not available" do
-          notification.ph_min_value = nil
-          expect(summary_product_rows).not_to include(
-            hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
-          )
+        context "when the current user cannot view the product ingredients" do
+          before { allow(user).to receive(:can_view_product_ingredients?).and_return(false) }
+
+          it "does not contain the product PH minimum value even when is available" do
+            notification.ph_min_value = 0.3
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "does not contain the product PH minimum value when not available" do
+            notification.ph_min_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "does not contain the product PH maximum value even when is available" do
+            notification.ph_max_value = 0.7
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "does not contain the product PH maximum value when not available" do
+            notification.ph_max_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+        end
+      end
+    end
+
+    context "for a draft notification" do
+      let(:notification_complete_at) { nil }
+      let(:trait) { :draft_complete }
+
+      it "contains the product name" do
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Product name" }, value: { text: "Product Test" }, actions: { items: [hash_including({ href: "#{product_href}/add_product_name" })] } }))
+      end
+
+      it "contains the industry reference number" do
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Internal reference number" }, value: { text: "CPNP-3874065" }, actions: { items: [hash_including({ href: "#{product_href}/add_internal_reference" })] } }))
+      end
+
+      it "contains the number of components associated with the notification" do
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Number of items" }, value: { text: 0 }, actions: { items: [hash_including({ href: "#{product_href}/single_or_multi_component" })] } }))
+      end
+
+      it "contains notification shades html" do
+        allow(helper).to receive(:display_shades).and_return("Shades info")
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Shades" }, value: { html: "Shades info" }, actions: { items: [hash_including({ href: "#{product_href}/shades" })] } }))
+      end
+
+      it "contains info indicating when the notification components are mixed" do
+        notification.components_are_mixed = true
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Are the items mixed?" }, value: { text: "Yes" }, actions: { items: [hash_including({ href: "#{notification_href}/product_kit/new" })] } }))
+      end
+
+      it "contains info indicating when the notification components are not mixed" do
+        notification.components_are_mixed = false
+        expect(summary_product_rows).to include(hash_including({ key: { text: "Are the items mixed?" }, value: { text: "No" }, actions: { items: [hash_including({ href: "#{notification_href}/product_kit/new" })] } }))
+      end
+
+      describe "for children under 3" do
+        it "not included when not available for the notification" do
+          notification.under_three_years = nil
+          expect(summary_product_rows).not_to include(hash_including(key: { text: "For children under 3" }))
         end
 
-        it "does not contain the product PH maximum value even when is available" do
-          notification.ph_max_value = 0.7
-          expect(summary_product_rows).not_to include(
-            hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
-          )
+        it "included when notification product is for children under 3" do
+          notification.under_three_years = true
+          expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "Yes" }, actions: { items: [hash_including({ href: "#{product_href}/under_three_years" })] } }))
         end
 
-        it "does not contain the product PH maximum value when not available" do
-          notification.ph_max_value = nil
-          expect(summary_product_rows).not_to include(
-            hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
-          )
+        it "included when notification product is not for children under 3" do
+          notification.under_three_years = false
+          expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "No" }, actions: { items: [hash_including({ href: "#{product_href}/under_three_years" })] } }))
+        end
+      end
+
+      describe "PH information" do
+        context "when current user can view the product ingredients" do
+          before { allow(user).to receive(:can_view_product_ingredients?).and_return(true) }
+
+          it "contains the product PH minimum value when present" do
+            notification.ph_min_value = 0.3
+            expect(summary_product_rows).to include(
+              { key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }, value: { text: 0.3 } },
+            )
+          end
+
+          it "does not contain the product PH minimum value when not present" do
+            notification.ph_min_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "contains the product PH maximum value when present" do
+            notification.ph_max_value = 0.7
+            expect(summary_product_rows).to include(
+              { key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }, value: { text: 0.7 } },
+            )
+          end
+
+          it "does not contain the product PH maximum value when not present" do
+            notification.ph_max_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+        end
+
+        context "when the current user cannot view the product ingredients" do
+          before { allow(user).to receive(:can_view_product_ingredients?).and_return(false) }
+
+          it "does not contain the product PH minimum value even when is available" do
+            notification.ph_min_value = 0.3
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "does not contain the product PH minimum value when not available" do
+            notification.ph_min_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Minimum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "does not contain the product PH maximum value even when is available" do
+            notification.ph_max_value = 0.7
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
+
+          it "does not contain the product PH maximum value when not available" do
+            notification.ph_max_value = nil
+            expect(summary_product_rows).not_to include(
+              hash_including(key: { html: "Maximum <abbr title='Power of hydrogen'>pH</abbr> value" }),
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
## Description

Remove editable links from submitted notification summary page

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2287

## Screenshots/video
![Screenshot 2023-10-13 at 13-52-58 Product details Gruel - Submit cosmetic product notifications](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/375623a9-7a85-446c-9542-a55b6ca4d643)



## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3193-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3193-search-web.london.cloudapps.digital/
https://cosmetics-pr-3193-support-web.london.cloudapps.digital/

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
