### PR TITLE
enforce under three question on cloned notifications

### DIFF
--- a/cosmetics-web/app/helpers/draft_helper.rb
+++ b/cosmetics-web/app/helpers/draft_helper.rb
@@ -47,6 +47,8 @@ module DraftHelper
 
     if notification.state_lower_than?(NotificationStateConcern::READY_FOR_NANOMATERIALS)
       in_progress_badge(id, :product)
+    elsif notification.under_three_years.nil?
+      in_progress_badge(id, :product)
     else
       complete_badge(id, :product)
     end

--- a/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
+++ b/cosmetics-web/app/helpers/responsible_persons/notifications_helper.rb
@@ -77,6 +77,13 @@ module ResponsiblePersons::NotificationsHelper
           actions: notification_step_action(notification, :under_three_years),
         }
       end,
+      if notification.under_three_years.nil?
+        {
+          key: { text: "For children under 3" },
+          value: { text: "Not answered" },
+          actions: notification_step_action(notification, :under_three_years),
+        }
+      end,
       {
         key: { text: "Number of items" },
         value: { text: notification.components.length },

--- a/cosmetics-web/app/validators/accept_and_submit_validator.rb
+++ b/cosmetics-web/app/validators/accept_and_submit_validator.rb
@@ -1,8 +1,13 @@
 class AcceptAndSubmitValidator < ActiveModel::Validator
   def validate(notification)
+    validate_notification(notification)
     validate_nano_materials(notification)
     validate_image_uploads(notification)
     validate_ingredients(notification)
+  end
+
+  def validate_notification(notification)
+    notification.errors.add :under_three_years, "You have not confirmed if the product is intended to be used on children under 3 years old" if notification.under_three_years.nil?
   end
 
   def validate_nano_materials(notification)

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     responsible_person
     sequence(:product_name) { |n| "Product #{n}" }
     cpnp_reference { nil }
+    under_three_years { true }
 
     factory :draft_notification do
       state { NotificationStateConcern::COMPONENTS_COMPLETE }

--- a/cosmetics-web/spec/helpers/responsible_persons/notifications_helper_spec.rb
+++ b/cosmetics-web/spec/helpers/responsible_persons/notifications_helper_spec.rb
@@ -162,9 +162,9 @@ describe ResponsiblePersons::NotificationsHelper do
       end
 
       describe "for children under 3" do
-        it "not included when not available for the notification" do
+        it "included when not available for the notification" do
           notification.under_three_years = nil
-          expect(summary_product_rows).not_to include(hash_including(key: { text: "For children under 3" }))
+          expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "Not answered" } }))
         end
 
         it "included when notification product is for children under 3" do
@@ -277,9 +277,9 @@ describe ResponsiblePersons::NotificationsHelper do
       end
 
       describe "for children under 3" do
-        it "not included when not available for the notification" do
+        it "included when not available for the notification" do
           notification.under_three_years = nil
-          expect(summary_product_rows).not_to include(hash_including(key: { text: "For children under 3" }))
+          expect(summary_product_rows).to include(hash_including({ key: { text: "For children under 3" }, value: { text: "Not answered" }, actions: { items: [hash_including({ href: "#{product_href}/under_three_years" })] } }))
         end
 
         it "included when notification product is for children under 3" do


### PR DESCRIPTION
## Description

When a notification is cloned, one of the attributes that is not cloned is whether the product is suitable for under threes. This question needs to be answered for every notification. This is now enforced on cloned notifications.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-2295

## Screenshots/video
![Screenshot 2023-10-24 at 13-35-38 Accept and submit - review - Submit cosmetic product notifications](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/367349/5ae7d8f3-afb2-413f-9a5b-9a36a529a9a6)


## Review apps

https://cosmetics-pr-3197-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3197-search-web.london.cloudapps.digital/
https://cosmetics-pr-3197-support-web.london.cloudapps.digital/

## Checklist


- [x] All automated checks are passing locally (tests, linting etc)
- [x] Accessibility testing has been done (where appropriate)
  - [x] Usable with JavaScript off
  - [x] Usable with CSS off
  - [x] Usable on a small screen (e.g. mobile phone)
  - [x] Usable with just a keyboard
  - [x] Usable with a screen reader
  - [x] Usable at 400% zoom
- [x] Automated tests have been added or updated
