### PR TITLE
Fix shades error link

### DIFF
--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_cmrs.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_cmrs.html.erb
@@ -9,6 +9,7 @@
 
 <%= form_with model: @component, url: wizard_path, method: :put do |form| %>
   <div class="opss-visibility-hidden">
+    <!-- Hidden button to prevent keyboard "Enter" from triggering the first remove button unexpectedly - it will trigger this which is a submit button -->
     <%= govukButton text: ".", attributes: { "aria-hidden" => "true", "tabindex" => "-1" } %>
   </div>
   <div class="govuk-grid-row">

--- a/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_shades.html.erb
+++ b/cosmetics-web/app/views/responsible_persons/notifications/components/build/add_shades.html.erb
@@ -8,7 +8,7 @@
 <%= form_with model: @component, url: wizard_path, method: :put do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= error_summary_for(@component) %>
+      <%= error_summary_for(@component, first_values: { shades: "0" }) %>
     </div>
   </div>
   <div class="govuk-grid-row">
@@ -18,20 +18,21 @@
   </div>
 
   <div class="opss-visibility-hidden">
+    <!-- Hidden button to prevent keyboard "Enter" from triggering the first remove button unexpectedly - it will trigger this which is a submit button -->
     <%= govukButton text: ".", attributes: { "aria-hidden" => "true", "tabindex" => "-1" } %>
   </div>
 
   <% @component.shades.each_with_index do |shade, index| %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half" id="shade-<%= index %>">
-        <label class="govuk-label" for="component_shades-<%= index %>">
+        <label class="govuk-label" for="component_shades_<%= index %>">
           Shade name
         </label>
-        <div class="govuk-hint" id="component_shades-<%= index %>-hint">
+        <div class="govuk-hint" id="component_shades_<%= index %>-hint">
           For example: Blue 01
         </div>
         <%= form.text_field :shades, multiple: true, value: shade,
-                id: "component_shades-#{index}",
+                id: "component_shades_#{index}",
                 class: "govuk-input shade-input" %>
         <div class="opss-text-align-right">
           <% if index == (@component.shades.size - 1) %>

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/adding_ingredients_to_components_spec.rb
@@ -175,8 +175,8 @@ RSpec.describe "Adding ingredients to components", :with_stubbed_antivirus, type
   context "when the item is available in multiple shades" do
     before do
       answer_is_item_available_in_shades_with "Yes"
-      fill_in "component_shades-0", with: "Blue"
-      fill_in "component_shades-1", with: "Red"
+      fill_in "component_shades_0", with: "Blue"
+      fill_in "component_shades_1", with: "Red"
       click_button "Continue"
 
       answer_what_is_physical_form_of_item_with "Liquid"

--- a/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/ingredients/using_csv_file_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe "Adding ingredients to components using a CSV file", :with_stubbe
     click_link "Go to question - product details"
 
     answer_is_item_available_in_shades_with "Yes"
-    fill_in "component_shades-0", with: "Blue"
-    fill_in "component_shades-1", with: "Blue"
+    fill_in "component_shades_0", with: "Blue"
+    fill_in "component_shades_1", with: "Blue"
     click_button "Continue"
 
     answer_what_is_physical_form_of_item_with "Liquid"

--- a/cosmetics-web/spec/features/submit/notification_wizard/shades_spec.rb
+++ b/cosmetics-web/spec/features/submit/notification_wizard/shades_spec.rb
@@ -15,27 +15,27 @@ RSpec.describe "Adding and removing shades", :with_stubbed_antivirus, type: :fea
 
   scenario "Adding Red, Orange, Yellow, Blue shades, Removing Yellow" do
     answer_is_item_available_in_shades_with "Yes"
-    fill_in "component_shades-0", with: "Red"
-    fill_in "component_shades-1", with: "Orange"
+    fill_in "component_shades_0", with: "Red"
+    fill_in "component_shades_1", with: "Orange"
     click_on "Add another shade"
 
-    expect(page).to have_field("component_shades-0", with: "Red")
-    expect(page).to have_field("component_shades-1", with: "Orange")
-    fill_in "component_shades-2", with: "Yellow"
+    expect(page).to have_field("component_shades_0", with: "Red")
+    expect(page).to have_field("component_shades_1", with: "Orange")
+    fill_in "component_shades_2", with: "Yellow"
     click_on "Add another shade"
 
-    expect(page).to have_field("component_shades-0", with: "Red")
-    expect(page).to have_field("component_shades-1", with: "Orange")
-    expect(page).to have_field("component_shades-2", with: "Yellow")
-    fill_in "component_shades-3", with: "Blue"
+    expect(page).to have_field("component_shades_0", with: "Red")
+    expect(page).to have_field("component_shades_1", with: "Orange")
+    expect(page).to have_field("component_shades_2", with: "Yellow")
+    fill_in "component_shades_3", with: "Blue"
 
     within "#shade-2" do
       click_on "Remove shade"
     end
 
-    expect(page).to have_field("component_shades-0", with: "Red")
-    expect(page).to have_field("component_shades-1", with: "Orange")
-    expect(page).to have_field("component_shades-2", with: "Blue")
+    expect(page).to have_field("component_shades_0", with: "Red")
+    expect(page).to have_field("component_shades_1", with: "Orange")
+    expect(page).to have_field("component_shades_2", with: "Blue")
 
     click_on "Add another shade" # attempt to add a blank shade
 


### PR DESCRIPTION
## Description

Fixes the error message shown when no shades are entered to correctly link to the first shade text box.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/PSD-2109

## Screenshots/video

![Screenshot 2023-11-15 at 10 27 16](https://github.com/OfficeForProductSafetyAndStandards/cosmetic-product-notifications/assets/444232/ad702643-f50d-4ce1-ad58-ce3a5cbada2f)

## Review apps

https://cosmetics-pr-3214-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3214-search-web.london.cloudapps.digital/
https://cosmetics-pr-3214-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
