### PR TITLE
Send email on account reactivation

### DIFF
--- a/cosmetics-web/app/mailers/search_notify_mailer.rb
+++ b/cosmetics-web/app/mailers/search_notify_mailer.rb
@@ -5,6 +5,7 @@ class SearchNotifyMailer < NotifyMailer
     # please add email name in Notify as comment
     {
       invitation: "afa69f3d-1c7e-4f1f-86a2-4e8ecf7da1dc", # Invite to join Search Cosmetic Product Notifications
+      reactivate_account: "969698e7-51cd-4e08-a82e-620090bc11fc", # Reactivate account
       reset_password_instruction: "b40f6179-915a-40a9-94ef-32a0d8d82bba", # Reset password
       reset_account_instruction: "fc3f3475-7c67-47b9-a491-bdf61c59bdaa", # Account reset
       account_locked: "417fd139-8bc8-4c91-bae0-91dedda64c16", # Unlock account / reset password after too many incorrect password attempts
@@ -19,6 +20,19 @@ class SearchNotifyMailer < NotifyMailer
     invitation_url = complete_registration_user_url(user.id, invitation: user.invitation_token, host: @host)
 
     set_personalisation(invitation_url:)
+    mail(to: user.email)
+  end
+
+  def account_reactivated_email(user, token)
+    set_host(user)
+    set_template(TEMPLATES[:reactivate_account])
+    set_reference("Reactivate account")
+    reset_url = edit_search_user_password_url(reset_password_token: token, host: @host)
+    set_personalisation(
+      name: user.name,
+      edit_user_password_url_token: reset_url,
+    )
+
     mail(to: user.email)
   end
 end

--- a/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
+++ b/cosmetics-web/support_portal/app/controllers/support_portal/account_administration_controller.rb
@@ -93,7 +93,7 @@ module SupportPortal
     def reactivate
       return redirect_to account_administration_path unless @user.is_a?(::SearchUser) && @user.deactivated?
 
-      if @user.update(deactivated_at: nil) && @user.reset_secondary_authentication!
+      if @user.update(deactivated_at: nil) && @user.reset_secondary_authentication!(reactivated: true)
         redirect_to account_administration_path, notice: "The account has been reactivated<br>An email was sent to #{@user.email} to inform #{@user.name}."
       else
         redirect_to account_administration_path


### PR DESCRIPTION
## Description

Sends an email when a search user account is reactivated via the Support Portal.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/PSD-2106

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-3222-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3222-search-web.london.cloudapps.digital/
https://cosmetics-pr-3222-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
