### PR TITLE
OSU Support Portal: display address changes in logical order

### DIFF
--- a/cosmetics-web/support_portal/app/helpers/support_portal/history_helper.rb
+++ b/cosmetics-web/support_portal/app/helpers/support_portal/history_helper.rb
@@ -65,8 +65,11 @@ module SupportPortal
     end
 
     def display_responsible_person_action_details(object_changes)
-      account_type_change = object_changes.except("updated_at").keys.first == "account_type"
-      changes = object_changes.except("updated_at").values
+      object_changes = object_changes.except("updated_at")
+      account_type_change = object_changes.keys.first == "account_type"
+      address_change = %w[address_line_1 address_line_2 city county postal_code].include?(object_changes.keys.first)
+      # Display address changes in a logical order
+      changes = address_change ? object_changes.values_at("address_line_1", "address_line_2", "city", "county", "postal_code") : object_changes.values
 
       if account_type_change
         changes.map { |change|


### PR DESCRIPTION
## Description

Changes the Support Portal change history log to display address changes in a logical order rather than randomly.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/PSD-2107

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-3223-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3223-search-web.london.cloudapps.digital/
https://cosmetics-pr-3223-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
