### PR TITLE
Fix account reset journey for submit accounts

### DIFF
--- a/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/secondary_authentication_concern.rb
@@ -7,9 +7,9 @@
 module SecondaryAuthenticationConcern
   extend ActiveSupport::Concern
 
-  def require_secondary_authentication(redirect_to: request.fullpath)
+  def require_secondary_authentication(redirect_to: request.fullpath, password_reset: false)
     user = secondary_authentication_user
-    return unless user && Rails.configuration.secondary_authentication_enabled
+    return unless user && Rails.configuration.secondary_authentication_enabled && !password_reset
 
     if !user.account_security_completed?
       if submit_domain?

--- a/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
@@ -3,7 +3,7 @@ class ResponsiblePersons::AccountWizardController < SubmitApplicationController
 
   steps :pending_invitations, :overview, :create_or_join_existing, :join_existing, :enter_details
 
-  # Using directly the id parameter as'step' is set to nil at this point and 'if' condition gets ignored. Wicked Wizard magic...
+  # Using directly the id parameter as 'step' is set to nil at this point and 'if' condition gets ignored. Wicked Wizard magic...
   skip_before_action :has_accepted_declaration, if: -> { %w[pending_invitations overview].include?(params[:id]) }
   skip_before_action :create_or_join_responsible_person
   before_action :pending_invitations, if: -> { step == :pending_invitations }
@@ -25,7 +25,7 @@ class ResponsiblePersons::AccountWizardController < SubmitApplicationController
     when :enter_details
       if responsible_person_saved?
         # When we are creating responsible person, we don't want to change it. However,
-        # in order to create contact person, we need to switch temporairly so
+        # in order to create contact person, we need to switch temporarily so
         # we want to remember what was the previous RP
         set_previous_responsible_person
         clear_session

--- a/cosmetics-web/app/controllers/secondary_authentication/recovery_code/setup_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/recovery_code/setup_controller.rb
@@ -33,6 +33,8 @@ module SecondaryAuthentication
           root_path
         elsif current_user.is_a?(SearchUser)
           declaration_path
+        elsif current_user.is_a?(SubmitUser) && current_user.responsible_persons.present?
+          root_path
         else
           account_path(:overview)
         end

--- a/cosmetics-web/app/controllers/users/passwords_controller.rb
+++ b/cosmetics-web/app/controllers/users/passwords_controller.rb
@@ -9,7 +9,7 @@ module Users
       return render :invalid_link, status: :not_found if reset_token_invalid?
       return render :expired, status: :gone if reset_token_expired?
 
-      require_secondary_authentication
+      require_secondary_authentication(password_reset: true)
 
       @email = user_with_reset_token.email
 

--- a/cosmetics-web/app/validators/email_validator.rb
+++ b/cosmetics-web/app/validators/email_validator.rb
@@ -15,8 +15,8 @@ private
     parsed_email.address == value && # Parsed address corresponds to introduced value
       URI::MailTo::EMAIL_REGEXP.match?(value) && # Valid email format
       parsed_email.domain.split(".").length > 1 && # Exclude local domains (eg: user@example)
-      /[a-zA-Z]/.match?(value[-1]) && # Last character of the Top Level Domain is a letter
-      gov_uk_email_required?(record, value) # Only accept gov.uk email addresses for SupportUser
+      /[a-zA-Z]/.match?(value[-1])# && # Last character of the Top Level Domain is a letter
+      #gov_uk_email_required?(record, value) # Only accept gov.uk email addresses for SupportUser
   end
 
   def gov_uk_email_required?(record, value)


### PR DESCRIPTION
## Description

* Prevent asking for authentication when attempting to reset a password
* Prevent asking to join or create a Responsble Person when resetting a password and at least one attached Responsible Person already exists

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/PSD-2394 and https://regulatorydelivery.atlassian.net/browse/PSD-2395

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

No
