### PR TITLE
[PSD-2553] - fixed the Nil class error on the object responsible_person 

### DIFF
--- a/cosmetics-web/app/views/layouts/_navbar.html.erb
+++ b/cosmetics-web/app/views/layouts/_navbar.html.erb
@@ -1,5 +1,5 @@
 <nav class="app-navigation govuk-clearfix" aria-labelledby="nav-label">
-  <h2 class="responsible-person-name govuk-heading-s" id="nav-label"><%= @responsible_person.name %></h2>
+  <h2 class="responsible-person-name govuk-heading-s" id="nav-label"><%= @responsible_person&.name %></h2>
   <ul class="app-navigation__list">
     <li class="<%= "app-navigation--current-page" if params[:controller] == "submit/landing_page" %>">
       <%= link_to "Home", submit_root_path, "data-topnav": "submit/landing_page", class: "govuk-link--no-visited-state" %>

--- a/cosmetics-web/spec/features/submit/notifications_dashboard_spec.rb
+++ b/cosmetics-web/spec/features/submit/notifications_dashboard_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Notifications Dashboard", type: :feature do
     visit responsible_person_notifications_path(responsible_person)
 
     expect(body).to have_css("#main-content")
+    expect(page).to have_css("#nav-label", text: responsible_person.name)
   end
 
   context "when the user has an incomplete notification" do


### PR DESCRIPTION
the responsible person Name shown in the Nav bar of the Project screen was throwing Nil class error, which i have fixed using the Nil check