### PR TITLE
chore/PSD-2640-disable-cypress-tests

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -80,13 +80,13 @@ jobs:
         run: |
           source cosmetics-web/deploy-github-functions.sh
           gh_deploy_failure staging $LOG_URL
-      - name: Trigger automated test framework
-        if: success()
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: OfficeForProductSafetyAndStandards
-          repo: scpn-automation
-          github_token: "${{ secrets.SCPN_AUTOMATION_KEY }}"
-          workflow_file_name: staging.yml
-          ref: master
-          wait_interval: 10
+      # - name: Trigger automated test framework
+      #   if: success()
+      #   uses: convictional/trigger-workflow-and-wait@v1.6.5
+      #   with:
+      #     owner: OfficeForProductSafetyAndStandards
+      #     repo: scpn-automation
+      #     github_token: "${{ secrets.SCPN_AUTOMATION_KEY }}"
+      #     workflow_file_name: staging.yml
+      #     ref: master
+      #     wait_interval: 10


### PR DESCRIPTION
## Description
Disabling the cypress tests due to them causing the releases to fail when deploying. Need to investigate this further. 