### PR TITLE
[PSD-2552] - fixing the nil class error on current_user object

### DIFF
--- a/cosmetics-web/app/controllers/secondary_authentication/recovery_code_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/recovery_code_controller.rb
@@ -39,8 +39,8 @@ module SecondaryAuthentication
     end
 
     def interstitial
-      @recovery_codes_used = current_user.secondary_authentication_recovery_codes_used.length
-      @recovery_codes_remaining = current_user.secondary_authentication_recovery_codes.length
+      @recovery_codes_used = current_user&.secondary_authentication_recovery_codes_used&.length
+      @recovery_codes_remaining = current_user&.secondary_authentication_recovery_codes&.length
     end
 
     def redirect_to_saved_path


### PR DESCRIPTION
added safety checks to avoid Nil class error , there are unit tests already in sign_in_spec