### PR TITLE
fix/PSD-2762-undefined_method_for_nil

### DIFF
--- a/cosmetics-web/app/helpers/draft_helper.rb
+++ b/cosmetics-web/app/helpers/draft_helper.rb
@@ -76,7 +76,8 @@ module DraftHelper
     return cannot_start_yet_badge(id, hidden_text) unless section_can_be_used?(ITEMS_SECTION)
 
     notification = component&.notification
-    if notification.empty? || notification.product_name_added? || notification.details_complete?
+
+    if notification&.empty? || notification&.product_name_added? || notification&.details_complete?
       cannot_start_yet_badge(id, hidden_text)
     elsif component.empty?
       not_started_badge(id, hidden_text)


### PR DESCRIPTION
## Description
Fix for the `undefined method 'empty?' for nil:NilClass (NoMethodError)` raised by sentry.