### PR TITLE
fix/PSD-3020-fix_undefined_method

### DIFF
--- a/cosmetics-web/app/helpers/draft_helper.rb
+++ b/cosmetics-web/app/helpers/draft_helper.rb
@@ -79,9 +79,9 @@ module DraftHelper
 
     if notification&.empty? || notification&.product_name_added? || notification&.details_complete?
       cannot_start_yet_badge(id, hidden_text)
-    elsif component.empty?
+    elsif component&.empty?
       not_started_badge(id, hidden_text)
-    elsif component.component_complete?
+    elsif component&.component_complete?
       complete_badge(id, hidden_text)
     else
       cannot_start_yet_badge(id, hidden_text)


### PR DESCRIPTION
## Description
Fixing the sentry alert for the following error

```
undefined method `empty?' for nil:NilClass (NoMethodError)
    elsif component.empty?
                   ^^^^^^^
```