### PR TITLE
fix/user_sign_up

### DIFF
--- a/cosmetics-web/app/controllers/registration/new_accounts_controller.rb
+++ b/cosmetics-web/app/controllers/registration/new_accounts_controller.rb
@@ -1,5 +1,7 @@
 module Registration
   class NewAccountsController < SubmitApplicationController
+    before_action :redirect_if_create_an_account_disabled, only: %i[new create confirm]
+
     skip_before_action :authorize_user!
     skip_before_action :authenticate_user!
     skip_before_action :require_secondary_authentication
@@ -52,6 +54,12 @@ module Registration
 
     def new_account_form_params
       params.require(:registration_new_account_form).permit(:full_name, :email)
+    end
+
+    def redirect_if_create_an_account_disabled
+      unless Flipper.enabled?(:create_an_account)
+        redirect_to submit_root_path, alert: "Account creation is currently disabled."
+      end
     end
   end
 end

--- a/cosmetics-web/spec/features/account/forgotten_password_spec.rb
+++ b/cosmetics-web/spec/features/account/forgotten_password_spec.rb
@@ -188,7 +188,7 @@ RSpec.feature "Resetting your password", :with_2fa, :with_stubbed_mailer, :with_
 
     include_examples "password reset"
 
-    context "when the user hasn't completed their registration" do
+    context "when the user hasn't completed their registration", skip: "TODO: Needs to be refactored." do
       # If the user has confirmed their account but not verified with 2FA, the
       # account may be in 'confirmed' state but still requires verification.
       %i[confirmed_not_verified unconfirmed].each do |status|

--- a/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
+++ b/cosmetics-web/spec/features/account/submit_sign_up_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     configure_requests_for_submit_domain
   end
 
-  scenario "user signs up and verifies its email" do
+  scenario "user signs up and verifies its email", skip: "TODO: Needs to be refactored." do
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")
@@ -114,7 +114,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect_to_be_on_account_overview_page
   end
 
-  scenario "user signs up with authentication app 2FA but without text message" do
+  scenario "user signs up with authentication app 2FA but without text message", skip: "TODO: Needs to be refactored." do
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")
@@ -148,7 +148,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect_to_be_on_account_overview_page
   end
 
-  scenario "user signs up originally selecting both text and app methods but then moving back to only use the app" do
+  scenario "user signs up originally selecting both text and app methods but then moving back to only use the app", skip: "TODO: Needs to be refactored." do
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")
@@ -199,7 +199,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect_to_be_on_account_overview_page
   end
 
-  scenario "user signs up and verifies its email with 2FA disabled for the environment", with_2fa: false do
+  scenario "user signs up and verifies its email with 2FA disabled for the environment", skip: "TODO: Needs to be refactored.", with_2fa: false do
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")
@@ -245,54 +245,54 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
   end
 
   scenario "user signs up and verifies its email with, confirmation expired during the process", skip: "TODO: Needs to be refactored." do
-    # visit "/"
-    # click_on "Create an account"
-    # expect(page).to have_current_path("/create-an-account")
+    visit "/"
+    click_on "Create an account"
+    expect(page).to have_current_path("/create-an-account")
 
-    # fill_in "Full name", with: "Joe Doe"
-    # fill_in "Email address", with: "signing_up@example.com"
-    # click_button "Continue"
+    fill_in "Full name", with: "Joe Doe"
+    fill_in "Email address", with: "signing_up@example.com"
+    click_button "Continue"
 
-    # expect_to_be_on_check_your_email_page("signing_up@example.com")
+    expect_to_be_on_check_your_email_page("signing_up@example.com")
 
-    # # Simulate time travel to expire the token
-    # travel_to 3.days.from_now do
-    #   email = delivered_emails.last
+    # Simulate time travel to expire the token
+    travel_to 3.days.from_now do
+      email = delivered_emails.last
 
-    #   expect(email.recipient).to eq "signing_up@example.com"
-    #   expect(email.personalization[:name]).to eq("Joe Doe")
+      expect(email.recipient).to eq "signing_up@example.com"
+      expect(email.personalization[:name]).to eq("Joe Doe")
 
-    #   verify_url = email.personalization[:verify_email_url]
-    #   visit verify_url
+      verify_url = email.personalization[:verify_email_url]
+      visit verify_url
 
-    #   expect(page).to have_current_path("/#{verify_url}")
-    #   expect(page).to have_css("h1", text: "Confirmation token is expired or invalid")
+      expect(page).to have_current_path("/#{verify_url}")
+      expect(page).to have_css("h1", text: "Confirmation token is expired or invalid")
 
-    #   visit verify_url[0..-2]
-    #   expect(page).to have_css("h1", text: "Confirmation token is expired or invalid")
+      visit verify_url[0..-2]
+      expect(page).to have_css("h1", text: "Confirmation token is expired or invalid")
 
-    #   visit verify_url
+      visit verify_url
 
-    #   fill_in "Create your password", with: "userpassword", match: :prefer_exact
-    #   check "Text message"
-    #   fill_in "Mobile number", with: "07000000000"
-    #   click_button "Continue"
+      fill_in "Create your password", with: "userpassword", match: :prefer_exact
+      check "Text message"
+      fill_in "Mobile number", with: "07000000000"
+      click_button "Continue"
 
-    #   expect_to_be_on_secondary_authentication_sms_page
-    #   complete_secondary_authentication_sms_with(otp_code)
+      expect_to_be_on_secondary_authentication_sms_page
+      complete_secondary_authentication_sms_with(otp_code)
 
-    #   expect_to_be_on_secondary_authentication_recovery_codes_setup_page
-    #   SubmitUser.last.secondary_authentication_recovery_codes.each do |code|
-    #     normalized_code = code.scan(/.{1,4}/).join(" ")
-    #     expect(page).to have_css("div.opss-recovery-codes", text: normalized_code)
-    #   end
-    #   click_link "Continue"
+      expect_to_be_on_secondary_authentication_recovery_codes_setup_page
+      SubmitUser.last.secondary_authentication_recovery_codes.each do |code|
+        normalized_code = code.scan(/.{1,4}/).join(" ")
+        expect(page).to have_css("div.opss-recovery-codes", text: normalized_code)
+      end
+      click_link "Continue"
 
-    #   expect_to_be_on_account_overview_page
-    # end
+      expect_to_be_on_account_overview_page
+    end
   end
 
-  context "when account already exists" do
+  context "when account already exists", skip: "TODO: Needs to be refactored." do
     let(:user) { create(:submit_user) }
 
     scenario "sending existing account information to user" do
@@ -410,7 +410,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     end
   end
 
-  scenario "user signs up and creates new account while signed in as someone else" do
+  scenario "user signs up and creates new account while signed in as someone else", skip: "TODO: Needs to be refactored." do
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")
@@ -455,7 +455,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect_to_be_on_account_overview_page
   end
 
-  scenario "user signs up and skips creating an account while signed in as someone else" do
+  scenario "user signs up and skips creating an account while signed in as someone else", skip: "TODO: Needs to be refactored." do
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")
@@ -494,7 +494,7 @@ RSpec.feature "Signing up as a submit user", :with_2fa, :with_2fa_app, :with_stu
     expect(page).to have_css("h1", text: "Submit cosmetic product notifications")
   end
 
-  scenario "spam user attempts to sign up" do
+  scenario "spam user attempts to sign up", skip: "TODO: Needs to be refactored." do
     visit "/"
     click_on "Create an account"
     expect(page).to have_current_path("/create-an-account")

--- a/cosmetics-web/spec/features/submit/responsible_person/user_account_creation_with_pending_responsible_person_invitations_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/user_account_creation_with_pending_responsible_person_invitations_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Creating an account when having pending responsible person invit
     travel_back
   end
 
-  scenario "user is invited to multiple responsible persons" do
+  scenario "user is invited to multiple responsible persons", skip: "TODO: Needs to be refactored." do
     create(:pending_responsible_person_user,
            :expired,
            email_address: invited_user_email,
@@ -46,7 +46,7 @@ RSpec.describe "Creating an account when having pending responsible person invit
     expect(page).to have_link("create a new Responsible Person", href: "/responsible_persons/account/enter_details")
   end
 
-  scenario "user is invited to responsible person but invitation has expired" do
+  scenario "user is invited to responsible person but invitation has expired", skip: "TODO: Needs to be refactored." do
     create(:pending_responsible_person_user,
            :expired,
            email_address: invited_user_email,

--- a/cosmetics-web/spec/features/submit/responsible_person/user_invitation_spec.rb
+++ b/cosmetics-web/spec/features/submit/responsible_person/user_invitation_spec.rb
@@ -520,7 +520,7 @@ RSpec.describe "Inviting a team member", :with_2fa, :with_2fa_app, :with_stubbed
     expect(invited_user.name).to eq("Joe Doe")
   end
 
-  scenario "accepting an invitation for a new user after user self-registered post-invitation without completing the user registration" do
+  scenario "accepting an invitation for a new user after user self-registered post-invitation without completing the user registration", skip: "TODO: Needs to be refactored." do
     pending = create(:pending_responsible_person_user,
                      email_address: "newusertoregister@example.com",
                      responsible_person:)


### PR DESCRIPTION
## Description
An interim fix to disable the user creation while we refactor the code. 

Will need to create the flipper for `:create_an_account` which should be disabled via the rails console.