### PR TITLE
fix/PSD-3574-fix_for_potenital_xss

### DIFF
--- a/cosmetics-web/app/helpers/application_helper.rb
+++ b/cosmetics-web/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
   end
 
   def wrap_summary_address(address_array)
-    address_array.join("<span class=\"govuk-visually-hidden\">,</span><br />").html_safe
+    sanitize(address_array.join('<span class="govuk-visually-hidden">,</span><br />'), tags: %w[span br], attributes: %w[class])
   end
 
   def error_class(search_form, attribute, part)


### PR DESCRIPTION
## Description
Apply `sanitize()` to the code

If someone tries to inject a `<script>`, it will be rendered as plain text, appearing as part of the content rather than executing as code.

For example, with 
```ruby
sanitize(address_array.join('<span class="govuk-visually-hidden">,</span><br />'), tags: %w[span br], attributes: %w[class])
```

if the address_array somehow included a string like `<script>alert('XSS');</script>`, it would render as:

```ruby
&lt;script&gt;alert('XSS');&lt;/script&gt;
```