### PR TITLE
fix/PSD-3947-SCPN-url_generation_error

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notifications/product_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notifications/product_controller.rb
@@ -26,7 +26,8 @@ class ResponsiblePersons::Notifications::ProductController < SubmitApplicationCo
     case step
     when :completed
       @notification.set_state_on_product_wizard_completed!
-      render template: "responsible_persons/notifications/task_completed", locals: { continue_path: }
+      @continue_path = continue_path
+      render template: "responsible_persons/notifications/task_completed", locals: { continue_path: continue_path }
     when :add_product_image
       @clone_image_job = NotificationCloner::JobTracker.new(@notification.id) if @notification.cloned?
       render_wizard
@@ -67,7 +68,8 @@ private
     elsif @notification.multi_component?
       new_responsible_person_notification_product_kit_path(@notification.responsible_person, @notification)
     else
-      new_responsible_person_notification_component_build_path(@notification.responsible_person, @notification, @notification.components.first)
+      component = @notification.components.first_or_create!
+      new_responsible_person_notification_component_build_path(@notification.responsible_person, @notification, component)
     end
   end
 

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/product_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/product_controller_spec.rb
@@ -52,12 +52,88 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
     end
 
     context "when the notification is already submitted" do
-      subject(:request) { get(:show, params: params.merge({ id: "add_internal_reference" })) }
-
       let(:notification) { create(:registered_notification, responsible_person:) }
 
       it "redirects to the notifications page" do
-        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+        get(:show, params: params.merge({ id: "add_internal_reference" }))
+        expect(response).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+      end
+    end
+
+    context "when on the completed step" do
+      let(:params_with_completed) { params.merge(id: :completed) }
+
+      context "when notification has nanomaterials" do
+        let(:nano_material) { create(:nano_material, notification: notification) }
+
+        before do
+          notification.nano_materials << nano_material
+        end
+
+        it "renders task completed template" do
+          get(:show, params: params_with_completed)
+          expect(response).to render_template("responsible_persons/notifications/task_completed")
+        end
+
+        it "assigns correct continue path" do
+          get(:show, params: params_with_completed)
+          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_nanomaterial_build_path(responsible_person, notification, nano_material))
+        end
+      end
+
+      context "when notification is multi-component" do
+        before do
+          notification.components.destroy_all
+          notification.update_column(:state, "ready_for_components")
+          create_list(:component, 2, notification: notification)
+        end
+
+        it "renders task completed template" do
+          get(:show, params: params_with_completed)
+          expect(response).to render_template("responsible_persons/notifications/task_completed")
+        end
+
+        it "assigns correct continue path" do
+          get(:show, params: params_with_completed)
+          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_product_kit_path(responsible_person, notification))
+        end
+      end
+
+      context "when notification is single component with no components yet" do
+        before do
+          allow(notification).to receive(:multi_component?).and_return(false)
+        end
+
+        it "creates a component" do
+          expect {
+            get(:show, params: params_with_completed)
+          }.to change(Component, :count).by(1)
+        end
+
+        it "renders task completed template" do
+          get(:show, params: params_with_completed)
+          expect(response).to render_template("responsible_persons/notifications/task_completed")
+        end
+
+        it "assigns correct continue path" do
+          get(:show, params: params_with_completed)
+          component = notification.components.first
+          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_component_build_path(responsible_person, notification, component))
+        end
+      end
+
+      context "when notification already has a component" do
+        let!(:component) { create(:component, notification: notification) }
+
+        it "renders task completed template" do
+          get(:show, params: params_with_completed)
+          expect(response).to render_template("responsible_persons/notifications/task_completed")
+        end
+
+        it "assigns correct continue path" do
+          get(:show, params: params_with_completed)
+          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_component_build_path(responsible_person, notification, component))
+        end
       end
     end
   end
@@ -75,7 +151,6 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
 
     it "creates a component if single_or_multi_component set to single" do
       post(:update, params: params.merge(id: :single_or_multi_component, single_or_multi_component_form: { single_or_multi_component: "single" }))
-      Notification.find(notification.id).components
       expect(Notification.find(notification.id).components).to have(1).item
     end
 
@@ -139,12 +214,11 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
     end
 
     context "when the notification is already submitted" do
-      subject(:request) { post(:update, params: params.merge(id: :add_product_name, notification: { product_name: "Super Shampoo" })) }
-
       let(:notification) { create(:registered_notification, responsible_person:) }
 
       it "redirects to the notifications page" do
-        expect(request).to redirect_to(responsible_person_notification_path(responsible_person, notification))
+        post(:update, params: params.merge(id: :add_product_name, notification: { product_name: "Super Shampoo" }))
+        expect(response).to redirect_to(responsible_person_notification_path(responsible_person, notification))
       end
     end
   end

--- a/cosmetics-web/spec/controllers/responsible_persons/notifications/product_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/responsible_persons/notifications/product_controller_spec.rb
@@ -75,9 +75,11 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
           expect(response).to render_template("responsible_persons/notifications/task_completed")
         end
 
-        it "assigns correct continue path" do
+        it "sets correct continue path" do
           get(:show, params: params_with_completed)
-          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_nanomaterial_build_path(responsible_person, notification, nano_material))
+          expect(assigns(:continue_path)).to eq(
+            new_responsible_person_notification_nanomaterial_build_path(responsible_person, notification, nano_material),
+          )
         end
       end
 
@@ -93,9 +95,11 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
           expect(response).to render_template("responsible_persons/notifications/task_completed")
         end
 
-        it "assigns correct continue path" do
+        it "sets correct continue path" do
           get(:show, params: params_with_completed)
-          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_product_kit_path(responsible_person, notification))
+          expect(assigns(:continue_path)).to eq(
+            new_responsible_person_notification_product_kit_path(responsible_person, notification),
+          )
         end
       end
 
@@ -115,10 +119,12 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
           expect(response).to render_template("responsible_persons/notifications/task_completed")
         end
 
-        it "assigns correct continue path" do
+        it "sets correct continue path" do
           get(:show, params: params_with_completed)
           component = notification.components.first
-          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_component_build_path(responsible_person, notification, component))
+          expect(assigns(:continue_path)).to eq(
+            new_responsible_person_notification_component_build_path(responsible_person, notification, component),
+          )
         end
       end
 
@@ -130,9 +136,11 @@ RSpec.describe ResponsiblePersons::Notifications::ProductController, :with_stubb
           expect(response).to render_template("responsible_persons/notifications/task_completed")
         end
 
-        it "assigns correct continue path" do
+        it "sets correct continue path" do
           get(:show, params: params_with_completed)
-          expect(assigns(:continue_path)).to eq(new_responsible_person_notification_component_build_path(responsible_person, notification, component))
+          expect(assigns(:continue_path)).to eq(
+            new_responsible_person_notification_component_build_path(responsible_person, notification, component),
+          )
         end
       end
     end


### PR DESCRIPTION
# Fix component routing issue and refactor tests

## Description
This PR addresses a production error where the notification component build path was failing due to missing component IDs. It also includes a comprehensive refactor of the associated tests to improve maintainability and follow best practices.

## Changes
- Fixed component routing in `ProductController` by ensuring component creation with `first_or_create!`
- Refactored tests to follow single expectation pattern
- Added proper test coverage for all notification states (nanomaterials, multi-component, single component)
- Updated multi-component tests to use real data setup instead of stubs

## Related Issues
Fixes Sentry: `ActionController::UrlGenerationError` in `ResponsiblePersons::Notifications::ProductController#show`

## Testing
- All existing functionality remains unchanged
- Added new test cases to cover edge cases
- All tests passing
- RuboCop compliant