### PR TITLE
fix/PSD-4362-SCPN-invalid_phone_number

### DIFF
--- a/cosmetics-web/app/services/send_submit_sms.rb
+++ b/cosmetics-web/app/services/send_submit_sms.rb
@@ -49,6 +49,11 @@ class SendSubmitSms
     # Replace leading '00' with '+'
     sanitized_number = sanitized_number.sub(/\A00/, "+")
 
+    # Add '+44' if the number starts with '7' or '07' (UK mobile numbers)
+    if sanitized_number.match?(/\A0?7\d{9}\z/)
+      sanitized_number = sanitized_number.sub(/\A0?/, "+44")
+    end
+
     # Add '+' if the number starts with '44' and doesn't start with '+'
     sanitized_number = "+#{sanitized_number}" if sanitized_number.start_with?("44") && !sanitized_number.start_with?("+")
 

--- a/cosmetics-web/spec/services/send_submit_sms_spec.rb
+++ b/cosmetics-web/spec/services/send_submit_sms_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe SendSubmitSms, :with_stubbed_notify do
       { input: "+1 (202) 456-1111", expected: "+12024561111", description: "US number with formatting" },
       { input: "+33123456789", expected: "+33123456789", description: "French number with '+' country code" },
       { input: "0033123456789", expected: "+33123456789", description: "French number with '00' country code" },
+
+      # UK mobile numbers without leading zero
+      { input: "7436672784", expected: "+447436672784", description: "UK mobile number without leading zero" },
     ]
   end
 


### PR DESCRIPTION
# Add support for UK mobile numbers without leading zero

## What
- Added handling for UK mobile numbers that start with '7' without a leading zero
- Added test case to verify the new functionality

## Why
We were seeing errors in Sentry where valid UK mobile numbers without a leading zero (e.g. "7436672784") were being rejected as invalid, despite being accepted by our PhoneValidator.

This change ensures that such numbers are properly formatted with the "+44" country code before being validated by Phonelib.

## Relevant logs/errors
ArgumentError: Invalid mobile number provided: 7436672784

## Testing
- Added specific test case for UK mobile number without leading zero
- Verified all existing test cases continue to pass
- Manually tested with the number from the Sentry error