### PR TITLE
fix/PSD-4358-SCPN-undefined_method_strip

### DIFF
--- a/cosmetics-web/app/services/send_submit_sms.rb
+++ b/cosmetics-web/app/services/send_submit_sms.rb
@@ -41,6 +41,8 @@ class SendSubmitSms
   end
 
   def self.sanitize_number(number)
+    return nil if number.blank?
+
     sanitized_number = number.strip
 
     # Remove spaces, hyphens, parentheses, and all '+' signs

--- a/cosmetics-web/spec/services/send_submit_sms_spec.rb
+++ b/cosmetics-web/spec/services/send_submit_sms_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe SendSubmitSms, :with_stubbed_notify do
       { input: "+99123456789", description: "invalid country code" },
       { input: "abcdefg", description: "alphabetic characters" },
       { input: "+44!7123*456%789", description: "special characters" },
+      { input: nil, description: "nil value" },
+      { input: "", description: "empty string" },
+      { input: "  ", description: "whitespace only" },
     ]
   end
 


### PR DESCRIPTION
# Add validation for blank phone numbers in SendSubmitSms

## What
- Added validation to handle `nil`, empty strings, and whitespace-only phone numbers in `SendSubmitSms.sanitize_number`
- Added corresponding test cases to verify the behavior

## Why
Fixes a `NoMethodError` that occurred when `nil` values were passed as phone numbers:
```
NoMethodError: undefined method `strip' for nil:NilClass
```

## Changes
- Added early return with `nil` if the phone number is blank (using Rails' `blank?` helper)
- Added test cases for:
  - `nil` values
  - Empty strings
  - Whitespace-only strings

## Testing
- Added test cases in `spec/services/send_submit_sms_spec.rb`
- All tests passing
- Manually verified that the service handles blank phone numbers gracefully