### PR TITLE
fix/PSD-3951-SCPN-Notifications_Client_BadRequestError

### DIFF
--- a/cosmetics-web/app/mailers/submit_notify_mailer.rb
+++ b/cosmetics-web/app/mailers/submit_notify_mailer.rb
@@ -56,7 +56,7 @@ class SubmitNotifyMailer < NotifyMailer
     set_reference("Send confirmation code")
 
     set_personalisation(
-      name: user.name,
+      name: user.name.presence || "",
       verify_email_url: registration_confirm_submit_user_url(confirmation_token: user.confirmation_token, host: @host),
     )
 

--- a/cosmetics-web/spec/mailers/submit_notify_mailer_spec.rb
+++ b/cosmetics-web/spec/mailers/submit_notify_mailer_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe SubmitNotifyMailer, :with_stubbed_mailer do
+  let(:user) { create(:submit_user) }
+
+  describe "#send_account_confirmation_email" do
+    context "when user has a name" do
+      it "sends email with the user's name" do
+        described_class.send_account_confirmation_email(user).deliver_now
+
+        email = delivered_emails.last
+        expect(email.personalization[:name]).to eq(user.name)
+      end
+    end
+
+    context "when user has no name" do
+      before do
+        user.update_column(:name, nil)
+      end
+
+      it "sends email with empty string as name" do
+        expect {
+          described_class.send_account_confirmation_email(user).deliver_now
+        }.not_to raise_error
+
+        email = delivered_emails.last
+        expect(email.personalization[:name]).to eq("")
+      end
+    end
+
+    context "when user has blank name" do
+      before do
+        user.update_column(:name, "")
+      end
+
+      it "sends email with empty string as name" do
+        expect {
+          described_class.send_account_confirmation_email(user).deliver_now
+        }.not_to raise_error
+
+        email = delivered_emails.last
+        expect(email.personalization[:name]).to eq("")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
Added tests to verify the fix for `BadRequestError` occurring in GOV.UK Notify when sending account confirmation emails to users with missing names.

## Changes
- Added test cases in `spec/mailers/submit_notify_mailer_spec.rb` to verify:
  - Normal case: users with names
  - Edge case: users with nil names
  - Edge case: users with blank names
- Tests confirm that the `name: user.name.presence || ""` fix properly handles missing names in the personalization parameters