### PR TITLE
chore/PSD-4479-roles_prepwork

### DIFF
--- a/cosmetics-web/db/migrate/20250120105354_add_legacy_fields_to_users.rb
+++ b/cosmetics-web/db/migrate/20250120105354_add_legacy_fields_to_users.rb
@@ -1,0 +1,19 @@
+class AddLegacyFieldsToUsers < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured do
+      change_table :users, bulk: true do |t|
+        t.string :legacy_role
+        t.string :legacy_type
+        t.string :corrected_email
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      change_table :users, bulk: true do |t|
+        t.remove :legacy_role, :legacy_type, :corrected_email
+      end
+    end
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_23_082523) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_20_105354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_trgm"
@@ -386,6 +386,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_082523) do
     t.string "secondary_authentication_recovery_codes", default: [], array: true
     t.string "secondary_authentication_recovery_codes_used", default: [], array: true
     t.datetime "deactivated_at", precision: nil
+    t.string "legacy_role"
+    t.string "legacy_type"
+    t.string "corrected_email"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["name"], name: "index_users_on_name"

--- a/cosmetics-web/lib/tasks/add_legacy_data.rake
+++ b/cosmetics-web/lib/tasks/add_legacy_data.rake
@@ -1,0 +1,29 @@
+module LegacyData
+  def self.remove_plus_part(email)
+    return email unless email
+
+    local, domain = email.split("@", 2)
+    return email unless domain
+
+    local = local.split("+").first
+    [local, domain].join("@")
+  end
+end
+
+namespace :legacy_data do
+  desc "Populate legacy columns on Users and clean up emails"
+  task populate: :environment do
+    User.unscoped.in_batches do |batch|
+      batch.each do |user|
+        corrected_email = LegacyData.remove_plus_part(user.email)
+        user.update_columns(
+          legacy_role: user.role,
+          legacy_type: user.type&.underscore,
+          corrected_email: corrected_email,
+        )
+      end
+    end
+
+    puts "Populated legacy columns and updated emails for all users."
+  end
+end


### PR DESCRIPTION
## Description
Create extra fields on the users table legacy_type, legacy_role and corrected_email in prep for the migration to new roles and removing the STI which is in SCPN at present.
**legacy_type** -  This will be take from the existing types SubmitUser, SearchUser, and SupportUser. We will update this to be `submit_user`, `search_user` and `support_user `which will become our new roles.

**legacy_role** - Contains what is currently in the roles field of the user table. 
```
poison_centre
opss_science
opss_general
opss_enforcement
trading_standards
opss_imt
```

**corrected_email** - We need to take the current email and remove any formatting so any emails which contain +search for example would be formatted correctly and added here so we can find duplicates easily 

To populate these new fields we will need to run `rails legacy_data:populate` which will run the rake task. The task will populate the legacy fields as described above.