### PR TITLE
chore/nokogiri_downgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/cosmetics-web"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "nokogiri"
     groups:
       dependencies:
         update-types:

--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -99,3 +99,5 @@ gem "database_cleaner-active_record"
 gem "graphiql-rails", group: :development
 gem "graphql", "~> 2.4"
 gem "rolify"
+
+gem "nokogiri", "1.17.2"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -340,11 +340,11 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.2-arm64-darwin)
+    nokogiri (1.17.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.2-x86_64-darwin)
+    nokogiri (1.17.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.2-x86_64-linux-gnu)
+    nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
@@ -692,6 +692,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  nokogiri (= 1.17.2)
   okcomputer (~> 1.18.6)
   paper_trail (~> 16.0)
   pg (~> 1.5)


### PR DESCRIPTION
## Description
Downgrading the nokogiri gem to 1.17.2, and getting dependabot to ignore updating it again in future.