### PR TITLE
PSD-4522 - create type and role migration to roles task

### DIFF
--- a/cosmetics-web/lib/tasks/map_legacy_roles_to_rolify.rake
+++ b/cosmetics-web/lib/tasks/map_legacy_roles_to_rolify.rake
@@ -1,0 +1,19 @@
+namespace :map_legacy_roles_to_rolify do
+  desc "Migrate legacy roles and types to Rolify"
+  task migrate: :environment do
+    User.find_each do |user|
+      case user.legacy_type
+      when "submit_user"
+        user.add_role(:submit_user)
+      when "search_user"
+        user.add_role(:search_user)
+      when "support_user"
+        user.add_role(:support_user)
+      end
+
+      user.add_role(user.legacy_role.to_sym) if user.legacy_role.present?
+
+      Rails.logger.info "Processed User #{user.id} with roles: #{user.roles.pluck(:name)}"
+    end
+  end
+end


### PR DESCRIPTION
## Description
We are now looking at populating the roles table for each user. 

For this we will need to run the following command. This will populate the roles table based on the `legacy_type` and `legacy_role` fields in the table. 

```ruby
rails map_legacy_roles_to_rolify:migrate
```
Once we have run this we will need to go onto the server to make sure the user has the right roles. 
So we would check a random user, and then see the roles they have. Then check using the `has_role?(:role_name)` query.

These should match up. 