### PR TITLE
chore/dbt-platform-compatability

### DIFF
--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -26,7 +26,6 @@ applications:
     - cosmetics-flipper-env
     - cosmetics-puma-env
     - cosmetics-scout-env
-    - antivirus-auth-env
     - cosmetics-support-portal-env
     - cosmetics-devise-env
   path: .


### PR DESCRIPTION
## Description
Removing the `antivirus-auth-env` service we we wont use that moving forward and we need to test the backwards compatability.