### PR TITLE
fix/PSD-5062-av_code_update

### DIFF
--- a/cosmetics-web/app/analyzers/anti_virus_analyzer.rb
+++ b/cosmetics-web/app/analyzers/anti_virus_analyzer.rb
@@ -5,9 +5,41 @@ class AntiVirusAnalyzer < ActiveStorage::Analyzer
 
   def metadata
     download_blob_to_tempfile do |file|
-      response = RestClient::Request.execute method: :post, url: Rails.application.config.antivirus_url, user: ENV["ANTIVIRUS_USERNAME"], password: ENV["ANTIVIRUS_PASSWORD"], payload: { file: }
-      body = JSON.parse(response.body)
-      { safe: body["safe"] }
+      file_obj = nil
+      begin
+        antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+
+        file_obj = File.new(file.path, "rb")
+        file_content = file_obj.read
+
+        response = RestClient::Request.execute(
+          method: :post,
+          url: antivirus_url,
+          user: ENV["ANTIVIRUS_USERNAME"],
+          password: ENV["ANTIVIRUS_PASSWORD"],
+          headers: {
+            "Content-Type" => "application/octet-stream",
+            "Transfer-Encoding" => "chunked",
+          },
+          payload: file_content,
+        )
+
+        if response.code == 200
+          result = JSON.parse(response.body)
+          if result["malware"]
+            { safe: false, message: result["reason"] }
+          else
+            { safe: true }
+          end
+        else
+          { safe: false, message: response.body }
+        end
+      rescue StandardError => e
+        Rails.logger.error("AntiVirus scan error: #{e.class} - #{e.message}")
+        { safe: false, error: e.message }
+      ensure
+        file_obj&.close if file_obj && !file_obj.closed?
+      end
     end
   end
 end

--- a/cosmetics-web/spec/analyzers/anti_virus_analyzer_spec.rb
+++ b/cosmetics-web/spec/analyzers/anti_virus_analyzer_spec.rb
@@ -10,17 +10,64 @@ RSpec.describe AntiVirusAnalyzer, type: :analyzer do
         content_type: "image/png",
       )
     end
+    let(:file) { Tempfile.new("") }
 
-    context "when the antivirus does not detect a virus", :with_stubbed_antivirus do
+    before do
+      allow(analyzer).to receive(:download_blob_to_tempfile).and_yield(file)
+    end
+
+    context "when the antivirus does not detect a virus" do
+      before do
+        allow(RestClient::Request).to receive(:execute).and_return(
+          instance_double(RestClient::Response, code: 200, body: '{"malware": false, "reason": null, "time": 0.001}'),
+        )
+      end
+
       it "sets as safe on the metadata" do
         expect(analyzer.metadata).to eq({ safe: true })
       end
     end
 
-    context "when the antivirus detects a virus", :with_stubbed_antivirus_returning_false do
-      it "sets as not safe on the metadata" do
-        expect(analyzer.metadata).to eq({ safe: false })
+    context "when the antivirus detects a virus" do
+      before do
+        allow(RestClient::Request).to receive(:execute).and_return(
+          instance_double(RestClient::Response, code: 200, body: '{"malware": true, "reason": "Eicar-Test-Signature", "time": 0.001}'),
+        )
       end
+
+      it "sets as not safe on the metadata with the reason" do
+        expect(analyzer.metadata).to eq({ safe: false, message: "Eicar-Test-Signature" })
+      end
+    end
+
+    context "when there is an error connecting to the antivirus service" do
+      before do
+        allow(RestClient::Request).to receive(:execute).and_raise(StandardError.new("Connection error"))
+      end
+
+      it "handles the error gracefully" do
+        result = analyzer.metadata
+        expect(result[:safe]).to be(false)
+        expect(result[:error]).to eq("Connection error")
+      end
+    end
+
+    context "when the file is missing or cannot be accessed" do
+      let(:metadata_result) { { safe: false, error: "File not found" } }
+
+      it "handles the missing file error" do
+        allow(analyzer).to receive(:download_blob_to_tempfile).and_return(metadata_result)
+
+        result = analyzer.metadata
+        expect(result[:safe]).to be(false)
+        expect(result[:error]).to eq("File not found")
+      end
+    end
+  end
+
+  describe ".accept?" do
+    it "accepts all blobs" do
+      expect(described_class.accept?(nil)).to be true
     end
   end
 end

--- a/cosmetics-web/spec/support/antivirus.rb
+++ b/cosmetics-web/spec/support/antivirus.rb
@@ -2,8 +2,11 @@ RSpec.shared_context "with stubbed Antivirus API", shared_context: :metadata do
   let(:with_stubbed_antivirus_result) { true }
 
   before do
-    antivirus_url = Rails.application.config.antivirus_url
-    stubbed_response = JSON.generate(safe: with_stubbed_antivirus_result)
+    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+
+    # For clamav-rest API, the opposite of "safe: true" is "malware: false"
+    stubbed_response = with_stubbed_antivirus_result ? '{"malware": false, "reason": null, "time": 0.001}' : '{"malware": true, "reason": "Test-Virus-Found", "time": 0.001}'
+
     stub_request(:any, /#{Regexp.quote(antivirus_url)}/).to_return(body: stubbed_response, status: 200)
   end
 end
@@ -14,8 +17,11 @@ end
 
 RSpec.shared_context "with stubbed Antivirus API returning false", shared_context: :metadata do
   before do
-    antivirus_url = Rails.application.config.antivirus_url
-    stubbed_response = JSON.generate(safe: false)
+    antivirus_url = ENV["ANTIVIRUS_URL"] ? "#{ENV['ANTIVIRUS_URL'].chomp('/')}/v2/scan-chunked" : "http://localhost:3000/v2/scan-chunked"
+
+    # For clamav-rest API, this would be "malware: true"
+    stubbed_response = '{"malware": true, "reason": "Test-Virus-Found", "time": 0.001}'
+
     stub_request(:any, /#{Regexp.quote(antivirus_url)}/).to_return(body: stubbed_response, status: 200)
   end
 end

--- a/cosmetics-web/spec/validators/accept_and_submit_validator_spec.rb
+++ b/cosmetics-web/spec/validators/accept_and_submit_validator_spec.rb
@@ -44,10 +44,19 @@ RSpec.describe AcceptAndSubmitValidator, :with_stubbed_antivirus do
   end
 
   describe "image still being processed" do
-    let(:with_stubbed_antivirus_result) { nil }
     let(:image_upload) { create(:image_upload, notification:) }
 
+    # Create an image that's not yet been scanned
+    before do
+      # Make sure the file is attached but has no metadata
+      image_upload.file.blob.metadata = {}
+      image_upload.file.blob.save!
+
+      notification.reload.valid?(:accept_and_submit)
+    end
+
     it "complains about image" do
+      expect(image_upload.pending_antivirus_check?).to be true
       expect(notification.errors.messages_for(:image_uploads)).to eq(["Image #{image_upload.filename} is pending virus scan"])
     end
   end


### PR DESCRIPTION
# Update to ClamAV REST Integration

## What
Updated our antivirus scanning to use the recommended `/v2/scan-chunked` endpoint from the dit-clamav-rest service.

## Changes
- Modified `AntiVirusAnalyzer` to use the correct endpoint, headers, and content format
- Updated response handling to parse JSON response properly
- Fixed and expanded tests to verify correct behavior

## Why
Improves virus scanning efficiency, especially for larger files, by using the recommended API endpoint.