### PR TITLE
fix/psd-5071 - Disallow new SMS 2FA setup

### DIFF
--- a/cosmetics-web/app/controllers/secondary_authentication/sms/setup_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/sms/setup_controller.rb
@@ -3,14 +3,14 @@ module SecondaryAuthentication
     class SetupController < ApplicationController
       def new
         @user = current_user
-        return redirect_to(root_path) unless @user
+        return redirect_to(root_path) unless @user && @user.sms_authentication_set?
 
         @form = SetupForm.new(mobile_number: @user.mobile_number, user: @user)
       end
 
       def create
         @user = current_user
-        return render("errors/forbidden", status: :forbidden) unless @user
+        return render("errors/forbidden", status: :forbidden) unless @user && @user.sms_authentication_set?
 
         previously_set = @user.mobile_number.present?
 

--- a/cosmetics-web/app/views/my_account/show.html.erb
+++ b/cosmetics-web/app/views/my_account/show.html.erb
@@ -154,19 +154,21 @@
     <%= govukSummaryList(
           classes: "govuk-!-margin-bottom-9",
           rows: [
-            {
-              key: { text: "Text message" },
-              value: { text: current_user.mobile_number },
-              actions: {
-                items: [
-                  {
-                    href: new_secondary_authentication_sms_setup_path,
-                    text: current_user.sms_authentication_set? ? "Change" : "Add",
-                    visuallyHiddenText: "text message"
-                  }
-                ]
+            if current_user.sms_authentication_set?
+              {
+                key: { text: "Text message" },
+                value: { text: current_user.mobile_number },
+                actions: {
+                  items: [
+                    {
+                      href: new_secondary_authentication_sms_setup_path,
+                      text: "Change",
+                      visuallyHiddenText: "text message"
+                    }
+                  ]
+                }
               }
-            },
+            end,
             {
               key: { text: "Authenticator app" },
               value: { text: ("Authenticator app is set" if current_user.app_authentication_set?) },
@@ -192,7 +194,7 @@
                 ]
               }
             },
-          ]
+          ].compact
         ) %>
 
     <% if support_domain? %>

--- a/cosmetics-web/spec/features/account/security_preferences/setting_up_text_message_authentication_spec.rb
+++ b/cosmetics-web/spec/features/account/security_preferences/setting_up_text_message_authentication_spec.rb
@@ -12,12 +12,12 @@ RSpec.feature "Setting up text message authentication", :with_2fa, :with_2fa_app
     travel_to((wait_for + 1).seconds.from_now)
   end
 
-  feature "user has no text message authentication" do
+  feature "user has not set up text message authentication" do
     let(:user) do
       create(:submit_user, :with_responsible_person, :with_app_secondary_authentication, has_accepted_declaration: true)
     end
 
-    scenario "user sets text message authentication" do
+    scenario "user attempts to set up text message authentication" do
       # User visits its account
       visit "/sign-in"
       fill_in_credentials
@@ -30,62 +30,15 @@ RSpec.feature "Setting up text message authentication", :with_2fa, :with_2fa_app
 
       # User attempts to set text message as secondary authentication method
       expect_to_be_on_my_account_page
-      expect(page).to have_summary_item(key: "Text message", value: "")
-      force_2fa_for_mobile_number_change
-      click_on "Add text message"
+      expect(page).not_to have_summary_item(key: "Text message", value: "")
 
-      # User needs to go through its current 2FA method (APP) prior to change the 2FA methods.
-      expect_to_be_on_secondary_authentication_app_page
-      complete_secondary_authentication_app
-
-      expect(page).to have_css("h1", text: "Set your mobile number")
-      # Update gets rejected when the password is wrong
-      fill_in "Password", with: "wrongPassword"
-      fill_in "Mobile number", with: "+447500000000"
-      click_on "Continue"
-
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Password is incorrect", href: "#old_password")
-
-      # Update gets rejected when the mobile number is empty
-      fill_in "Password", with: user.password
-      fill_in "Mobile number", with: ""
-      click_on "Continue"
-
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Enter a mobile number, like 07700 900 982 or +44 7700 900 982", href: "#new_mobile_number")
-
-      # Update gets rejected when the mobile number format is incorrect
-      fill_in "Password", with: user.password
-      fill_in "Mobile number", with: "12345678(wrong)9101112"
-      click_on "Continue"
-
-      expect(page).to have_css("h2#error-summary-title", text: "There is a problem")
-      expect(page).to have_link("Enter a mobile number, like 07700 900 982 or +44 7700 900 982", href: "#new_mobile_number")
-
-      # User sets a correct mobile number and provides the right password
-      fill_in "Password", with: user.password
-      fill_in "Mobile number", with: "+447500000000"
-      click_on "Continue"
-
-      # User needs to confirm its new mobile number through a SMS
-      expect(page).to have_css("h1", text: "Check your phone")
-      fill_in "Enter security code", with: "#{otp_code} "
-      click_on "Continue"
-
-      # 2FA method successfully updated
-      expect_to_be_on_my_account_page
-      expect(page).to have_text(/Mobile number set successfully/)
-      expect(page).to have_summary_item(key: "Text message", value: "+447500000000")
-
-      # Confirm SMS is now an available option for 2FA
-      force_2fa_for_mobile_number_change
-      click_on "Change text message"
-      expect_to_be_on_secondary_authentication_method_selection_page
+      # User attempts to visit the text message authentication set up page directly
+      visit "/two-factor/sms/setup"
+      expect(page).to have_current_path("/")
     end
   end
 
-  feature "user has set previously their text message authentication" do
+  feature "user has previously set up text message authentication" do
     let(:user) do
       create(:submit_user, :with_responsible_person, :with_sms_secondary_authentication, has_accepted_declaration: true)
     end
@@ -156,7 +109,7 @@ RSpec.feature "Setting up text message authentication", :with_2fa, :with_2fa_app
     end
   end
 
-  feature "user has set previously both text and app authentication" do
+  feature "user has previously set up both text message and app authentication" do
     let(:user) do
       create(:submit_user, :with_responsible_person, :with_all_secondary_authentication_methods, has_accepted_declaration: true)
     end


### PR DESCRIPTION
## Description

Disallow new setups of SMS 2FA. Existing users that already have SMS 2FA set up will be able to amend their details, but existing users that only have app 2FA set up and all new users will not be able to set up SMS 2FA.

This is a prerequisite for eventually disabling SMS 2FA altogether.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/PSD-5071

## Screenshots/video

N/A

## Review apps

https://cosmetics-pr-xxxx-submit-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-search-web.london.cloudapps.digital/
https://cosmetics-pr-xxxx-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
