### PR TITLE
fix-sed-command

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -63,7 +63,7 @@ jobs:
           WORKER_INSTANCES: 4
           SENTRY_SERVICE_NAME: cosmetics-sentry-env
         run: |
-          sed -i '' 's/      - cosmetics-puma-env/      - cosmetics-puma-env\n      - antivirus-auth-env/g' ./cosmetics-web/manifest.yml
+          sed -i 's/      - cosmetics-puma-env/      - cosmetics-puma-env\n      - antivirus-auth-env/g' ./cosmetics-web/manifest.yml
           cf target -o 'beis-opss' -s $SPACE
           chmod +x ./cosmetics-web/deploy.sh
           ./cosmetics-web/deploy.sh


### PR DESCRIPTION
# Fix production deployment sed command issue

Fix the failing `sed` command in the production deployment workflow by removing BSD-style empty string argument that's incompatible with GNU sed in the deployment environment.

```bash
sed -i 's/      - cosmetics-puma-env/      - cosmetics-puma-env\n      - antivirus-auth-env/g' ./cosmetics-web/manifest.yml
```
```