### PR TITLE
bug/psd-5108-prevent-new-sms-2fa-before-expiry

### DIFF
--- a/cosmetics-web/app/controllers/secondary_authentication/sms_controller.rb
+++ b/cosmetics-web/app/controllers/secondary_authentication/sms_controller.rb
@@ -11,7 +11,10 @@ module SecondaryAuthentication
       return redirect_to(root_path) unless user_id && sms_authentication_available?
 
       @form = Sms::AuthForm.new(user_id:)
-      @form.secondary_authentication.generate_and_send_code(current_operation)
+
+      if @form.secondary_authentication.otp_resend_allowed? || @form.secondary_authentication.otp_expired? || @form.secondary_authentication.direct_otp.blank?
+        @form.secondary_authentication.generate_and_send_code(current_operation)
+      end
     end
 
     def create

--- a/cosmetics-web/app/models/secondary_authentication/direct_otp.rb
+++ b/cosmetics-web/app/models/secondary_authentication/direct_otp.rb
@@ -5,7 +5,8 @@ module SecondaryAuthentication
     OTP_LENGTH = 5
     MAX_ATTEMPTS = Rails.configuration.two_factor_attempts
     MAX_ATTEMPTS_COOLDOWN = 3600 # 1 hour
-    OTP_EXPIRY_SECONDS = 300
+    OTP_RESEND_SECONDS = 60 # 1 min
+    OTP_EXPIRY_SECONDS = 300 # 5 mins
     WHITELISTED_OTP_CODE = Rails.configuration.whitelisted_direct_otp_code
 
     attr_accessor :user
@@ -17,6 +18,10 @@ module SecondaryAuthentication
     def generate_and_send_code(operation)
       generate_code(operation)
       send_secondary_authentication_code
+    end
+
+    def otp_resend_allowed?
+      user.direct_otp_sent_at && (user.direct_otp_sent_at + OTP_RESEND_SECONDS) < Time.zone.now
     end
 
     def otp_expired?

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       totp_secret_key { ROTP::Base32.random }
       mobile_number { "+447500000000" }
       mobile_number_verified { true }
-      direct_otp_sent_at { Time.zone.now }
+      direct_otp_sent_at { 5.minutes.ago }
       direct_otp { "12345" }
       secondary_authentication_methods { %w[app sms] }
       secondary_authentication_recovery_codes_generated_at { Time.zone.now }
@@ -39,7 +39,7 @@ FactoryBot.define do
       last_recovery_code_at { nil }
       mobile_number { "+447500000000" }
       mobile_number_verified { true }
-      direct_otp_sent_at { Time.zone.now }
+      direct_otp_sent_at { 5.minutes.ago }
       direct_otp { "12345" }
       last_totp_at { nil }
       totp_secret_key { nil }

--- a/cosmetics-web/spec/features/account/sign_in_spec.rb
+++ b/cosmetics-web/spec/features/account/sign_in_spec.rb
@@ -309,16 +309,43 @@ RSpec.feature "Signing in as a user", :with_2fa, :with_stubbed_mailer, :with_stu
 
         expect_to_be_on_secondary_authentication_sms_page
 
+        travel_to(2.minutes.from_now) do
+          click_link "Not received a text message?"
+
+          expect_to_be_on_resend_secondary_authentication_page
+
+          click_button "Resend security code"
+
+          expect_user_to_have_received_sms_code("54321")
+
+          expect_to_be_on_secondary_authentication_sms_page
+          complete_secondary_authentication_sms_with(otp_code)
+
+          expect(page).to have_css("h1", text: "Responsible Person Declaration")
+          expect(page).to have_button "Sign out"
+        end
+      end
+
+      scenario "user signs in with the correct secondary authentication code after requesting a second code too soon" do
+        allow(SecureRandom).to receive(:random_number).and_return(12_345, 54_321)
+
+        visit "/sign-in"
+        fill_in_credentials
+
+        expect_user_to_have_received_sms_code("12345")
+
+        expect_to_be_on_secondary_authentication_sms_page
+
         click_link "Not received a text message?"
 
         expect_to_be_on_resend_secondary_authentication_page
 
         click_button "Resend security code"
 
-        expect_user_to_have_received_sms_code("54321")
+        expect_user_not_to_have_received_sms_code("54321")
 
         expect_to_be_on_secondary_authentication_sms_page
-        complete_secondary_authentication_sms_with(otp_code)
+        complete_secondary_authentication_sms_with("12345")
 
         expect(page).to have_css("h1", text: "Responsible Person Declaration")
         expect(page).to have_button "Sign out"
@@ -609,19 +636,21 @@ RSpec.feature "Signing in as a user", :with_2fa, :with_stubbed_mailer, :with_stu
 
         expect_to_be_on_secondary_authentication_sms_page
 
-        click_link "Not received a text message?"
+        travel_to(2.minutes.from_now) do
+          click_link "Not received a text message?"
 
-        expect_to_be_on_resend_secondary_authentication_page
+          expect_to_be_on_resend_secondary_authentication_page
 
-        click_button "Resend security code"
+          click_button "Resend security code"
 
-        expect_user_to_have_received_sms_code("54321")
+          expect_user_to_have_received_sms_code("54321")
 
-        expect_to_be_on_secondary_authentication_sms_page
-        complete_secondary_authentication_sms_with(otp_code)
+          expect_to_be_on_secondary_authentication_sms_page
+          complete_secondary_authentication_sms_with(otp_code)
 
-        expect(page).to have_css("h1", text: "Cosmetic products search")
-        expect(page).to have_button("Sign out")
+          expect(page).to have_css("h1", text: "Cosmetic products search")
+          expect(page).to have_button("Sign out")
+        end
       end
 
       context "when using wrong credentials over and over again" do

--- a/cosmetics-web/spec/support/feature_helpers.rb
+++ b/cosmetics-web/spec/support/feature_helpers.rb
@@ -34,6 +34,15 @@ def expect_user_to_have_received_sms_code(code, current_user = nil)
   ).once
 end
 
+def expect_user_not_to_have_received_sms_code(code, current_user = nil)
+  if current_user.nil?
+    current_user = user
+  end
+  expect(notify_stub).not_to have_received(:send_sms).with(
+    hash_including(phone_number: current_user.mobile_number, personalisation: { code: }),
+  )
+end
+
 def complete_secondary_authentication_sms_with(security_code)
   fill_in "Enter security code", with: security_code
   click_on "Continue"


### PR DESCRIPTION
## Description

Prevent sending SMS 2FA codes more than once per minute, whether by refreshing the page or asking for the code to be re-sent.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/PSD-5108

## Screenshots/video

N/A

## Review apps

<!-- Edit the following links after the PR is created to replace "xxxx" with the PR number -->
https://cosmetics-pr-3586-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3586-search-web.london.cloudapps.digital/
https://cosmetics-pr-3586-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [x] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

<!-- If anything needs to be done after deploying this PR (e.g. enabling a feature flag, running a rake task etc), document it here -->
