### PR TITLE
fix/psd-5664-elasticsearch-circuit-breaker

### DIFF
--- a/cosmetics-web/app/jobs/check_document_sizes_job.rb
+++ b/cosmetics-web/app/jobs/check_document_sizes_job.rb
@@ -1,0 +1,40 @@
+# This job checks for documents that would be too large to index in OpenSearch
+# It helps to proactively identify potential circuit breaker issues
+class CheckDocumentSizesJob < ApplicationJob
+  def perform
+    Rails.logger.info "[Opensearch] Starting document size check job"
+
+    large_notifications = find_large_notifications
+    if large_notifications.any?
+      Rails.logger.warn "[Opensearch] Found #{large_notifications.size} notifications that are too large to index properly"
+
+      large_notifications.each do |notification|
+        doc_size = calculate_document_size(notification)
+        Rails.logger.warn "[Opensearch] Notification #{notification.id} (ref: #{notification.reference_number}) has document size of #{doc_size} bytes, " \
+                        "which exceeds the limit of #{notification.maximum_document_size_bytes} bytes"
+      end
+    else
+      Rails.logger.info "[Opensearch] No notifications found with excessive document sizes"
+    end
+  end
+
+private
+
+  def find_large_notifications
+    # Check all completed and archived notifications
+    large_docs = []
+
+    Notification.opensearch.find_each do |notification|
+      doc_size = calculate_document_size(notification)
+      if doc_size > notification.maximum_document_size_bytes
+        large_docs << notification
+      end
+    end
+
+    large_docs
+  end
+
+  def calculate_document_size(notification)
+    notification.as_indexed_json.to_json.bytesize
+  end
+end

--- a/cosmetics-web/config/initializers/elasticsearch.rb
+++ b/cosmetics-web/config/initializers/elasticsearch.rb
@@ -1,3 +1,42 @@
-Elasticsearch::Model.client = Elasticsearch::Client.new(Rails.application.config_for(:opensearch))
+# Configure the client with settings and middleware
+client_config = Rails.application.config_for(:opensearch)
+
+# Custom middleware to handle circuit breaker exceptions
+module Elasticsearch
+  module Transport
+    module Transport
+      module Middleware
+        class CircuitBreakerMiddleware
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            @app.call(env)
+          rescue Elastic::Transport::Transport::Errors::TooManyRequests => e
+            # Log circuit breaker errors but allow the app to continue
+            Rails.logger.error "[Opensearch] Circuit breaker error: #{e.message}"
+            # Re-raise so the error can be caught elsewhere
+            raise e
+          end
+        end
+      end
+    end
+  end
+end
+
+# Add custom middleware to the client, but after Rails is fully initialized
+# to avoid FrozenError with ActionText
+Rails.application.config.after_initialize do
+  # Setup custom middleware
+  client_config[:transport_options] ||= {}
+  client_config[:transport_options][:middleware] ||= []
+  client_config[:transport_options][:middleware] << lambda { |f|
+    Elasticsearch::Transport::Transport::Middleware::CircuitBreakerMiddleware.new(f)
+  }
+end
+
+Elasticsearch::Model.client = Elasticsearch::Client.new(client_config)
+
 # bypasses the recently introduced version check to allow ES gems to connect to an Opensearch 1 server
 Elasticsearch::Model.client.instance_variable_set("@verified", true)

--- a/cosmetics-web/config/opensearch.yml
+++ b/cosmetics-web/config/opensearch.yml
@@ -2,7 +2,11 @@ default: &default
   :url: <%= ENV.fetch('OPENSEARCH_URL', 'http://localhost:9200') %>
   :transport_options:
     :request:
-      :timeout: 5
+      :timeout: 30
+      :open_timeout: 30
+      :read_timeout: 30
+  :retry_on_failure: 5
+  :request_timeout: 30
 
 development:
   <<: *default
@@ -12,3 +16,10 @@ test:
 
 production:
   <<: *default
+  :transport_options:
+    :request:
+      :timeout: 60
+      :open_timeout: 60
+      :read_timeout: 60
+  :retry_on_failure: 3
+  :request_timeout: 60

--- a/cosmetics-web/docs/elasticsearch_circuit_breaker_fix.md
+++ b/cosmetics-web/docs/elasticsearch_circuit_breaker_fix.md
@@ -1,0 +1,61 @@
+# Elasticsearch/OpenSearch Circuit Breaker Fixes
+
+## Problem
+
+The application was experiencing circuit breaker exceptions in Elasticsearch/OpenSearch when trying to index large notifications. This was manifesting as:
+
+1. `Elastic::Transport::Transport::Errors::TooManyRequests` errors
+2. Circuit breaker exceptions with messages like `[parent] Data too large, data for [<http_request>] would be [1394991036/1.2gb], which is larger than the limit of [1382652313/1.2gb]`
+3. Failures during the `ResponsiblePersons::DraftsController#accept` action
+4. Timeouts during reindexing jobs
+
+## Solutions Implemented
+
+### 1. Document Size Limitations
+
+- Added a method to check document size before indexing
+- Set a maximum document size of 1MB (well below circuit breaker limits)
+- Prevented indexing of documents that exceed this limit
+
+### 2. Optimized JSON Payload
+
+- Streamlined the `as_indexed_json` method in the Notification model
+- Limited the number of ingredients indexed (max 50 per component, 100 total)
+- Reduced the fields included in the indexed document
+- Removed unnecessary nested data
+
+### 3. Error Handling and Recovery
+
+- Added error handling around indexing operations
+- Ensured notification submission continues even if indexing fails
+- Added better logging for OpenSearch-related issues
+- Created custom middleware to handle circuit breaker exceptions
+
+### 4. Connection and Timeout Improvements
+
+- Increased request timeouts (30s default, 60s in production)
+- Added retry mechanism for failed requests
+- Set batch size for bulk operations to 50 documents
+
+### 5. Monitoring and Diagnostics
+
+- Created a new `CheckDocumentSizesJob` to identify problematic documents
+- Added a rake task to run the document size check job
+- Improved logging throughout the codebase
+
+## Future Considerations
+
+1. **Elasticsearch Cluster Scaling**: When migrating to AWS, consider increasing the OpenSearch cluster resources
+   to accommodate larger documents and higher indexing load.
+
+2. **Document Partitioning**: For extremely large notifications, consider partitioning the document or
+   implementing a more selective indexing strategy.
+
+3. **Regular Monitoring**: Schedule regular runs of the `check_document_sizes` task to proactively identify problems.
+
+4. **Database Cleanup**: Consider implementing a cleanup process for old or excessively large notifications.
+
+## References
+
+- PSD-5664: Fix Elasticsearch circuit breaker exceptions
+- [OpenSearch Documentation - Circuit Breaker](https://opensearch.org/docs/latest/monitoring-plugins/pa/circuit-breaker/)

--- a/cosmetics-web/lib/tasks/opensearch.rake
+++ b/cosmetics-web/lib/tasks/opensearch.rake
@@ -3,4 +3,9 @@ namespace :open_search do
   task reindex: :environment do
     ReindexOpensearchJob.perform_later
   end
+
+  desc "Check for large documents that might cause circuit breaker issues"
+  task check_document_sizes: :environment do
+    CheckDocumentSizesJob.perform_later
+  end
 end


### PR DESCRIPTION
# Fix Elasticsearch Circuit Breaker Issues (PSD-5664)

## Problem

The application was experiencing circuit breaker exceptions in Elasticsearch/OpenSearch when trying to index large notifications, resulting in:

- `Elastic::Transport::Transport::Errors::TooManyRequests` errors
- Circuit breaker exceptions with messages like:
  ```
  [parent] Data too large, data for [<http_request>] would be [1394991036/1.2gb], which is larger than the limit of [1382652313/1.2gb]
  ```
- Failures during the `ResponsiblePersons::DraftsController#accept` action
- Timeouts during reindexing jobs

## Solutions Implemented

### 1. Document Size Limitations

- Added a method to check document size before indexing
- Set a maximum document size of 1MB (well below circuit breaker limits)
- Prevented indexing of documents that exceed this limit

### 2. Optimized JSON Payload

- Streamlined the `as_indexed_json` method in the Notification model
- Limited the number of ingredients indexed (max 50 per component, 100 total)
- Reduced the fields included in the indexed document
- Removed unnecessary nested data

### 3. Error Handling and Recovery

- Added error handling around indexing operations
- Ensured notification submission continues even if indexing fails
- Added better logging for OpenSearch-related issues
- Created custom middleware to handle circuit breaker exceptions

### 4. Connection and Timeout Improvements

- Increased request timeouts (30s default, 60s in production)
- Added retry mechanism for failed requests
- Set batch size for bulk operations to 50 documents

### 5. Monitoring and Diagnostics

- Created a new `CheckDocumentSizesJob` to identify problematic documents
- Added a rake task to run the document size check job
- Improved logging throughout the codebase

## QA Notes

The issue is challenging to test manually due to its nature (circuit breaker exceptions are typically only reproducible under high load or with very large documents). However, the following steps can help validate the fix:

### Testing in lower environments:

1. **Run the diagnostic job**: 
   ```
   bundle exec rake open_search:check_document_sizes
   ```
   This will identify any notifications that would be too large for indexing.

2. **Monitor for errors**:
   After deploying to staging, monitor the logs for any Elasticsearch-related errors.

3. **Submit a notification with many ingredients**:
   Create a notification with multiple components and many ingredients to see if indexing works correctly.

4. **Trigger reindexing**:
   ```
   bundle exec rake open_search:reindex
   ```
   This will run the reindexing job with the new batch size settings.

### Expected results:

- Notifications should still be submittable even if they're too large to index
- Large documents should be logged but skipped from indexing
- Reindexing should complete without circuit breaker errors

## Documentation

See `cosmetics-web/docs/elasticsearch_circuit_breaker_fix.md` for detailed documentation about these changes.