### PR TITLE
bug/psd-5684-respect-antivirus-result-for-nanomaterial-notification-file-upload

### DIFF
--- a/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
+++ b/cosmetics-web/app/controllers/nanomaterial_notifications_controller.rb
@@ -113,10 +113,19 @@ class NanomaterialNotificationsController < SubmitApplicationController
     end
 
     if @nanomaterial_notification.save(context: :upload_file)
-      redirect_to review_nanomaterial_path(@nanomaterial_notification)
-    else
-      render "upload_file"
+      if @nanomaterial_notification.passed_antivirus_check?
+        # File has been checked for viruses and is safe
+        return redirect_to review_nanomaterial_path(@nanomaterial_notification)
+      elsif @nanomaterial_notification.failed_antivirus_check?
+        # File has been checked for viruses and is infected
+        @file_upload_error = "The file is infected with a virus and will be deleted - please upload another file"
+      else
+        # File has not yet been checked for viruses
+        @file_upload_error = "The file has not yet been checked for viruses - click Continue for an update"
+      end
     end
+
+    render "upload_file"
   end
 
   def review; end

--- a/cosmetics-web/app/views/nanomaterial_notifications/upload_file.html.erb
+++ b/cosmetics-web/app/views/nanomaterial_notifications/upload_file.html.erb
@@ -54,8 +54,8 @@
 
       <% label_text = @nanomaterial_notification.file.attached? ? "Upload a replacement file" : "Upload a file" %>
 
-      <% if @nanomaterial_notification.errors.full_messages_for(:file).any? %>
-        <% error_message = {text: @nanomaterial_notification.errors.full_messages_for(:file).first} %>
+      <% if @nanomaterial_notification.errors.full_messages_for(:file).any? || @file_upload_error.present? %>
+        <% error_message = { text: @file_upload_error || @nanomaterial_notification.errors.full_messages_for(:file).first } %>
       <% end %>
 
       <%= govukFileUpload(

--- a/cosmetics-web/spec/features/submit/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/features/submit/nanomaterial_notifications_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     attach_file "Upload a file", Rails.root.join("spec/fixtures/files/testPdf.pdf")
     click_button "Continue"
 
+    expect(page).to have_selector("#nanomaterial_notification_file-error", text: "The file has not yet been checked for viruses - click Continue for an update")
+    click_button "Continue"
+
     expect(page).to have_selector("h1", text: "Check your answers")
     click_button "Accept and send"
 
@@ -95,6 +98,9 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     attach_file "Upload a file", Rails.root.join("spec/fixtures/files/testPdf.pdf")
     click_button "Continue"
 
+    expect(page).to have_selector("#nanomaterial_notification_file-error", text: "The file has not yet been checked for viruses - click Continue for an update")
+    click_button "Continue"
+
     expect(page).to have_selector("h1", text: "Check your answers")
     click_button "Accept and send"
 
@@ -116,5 +122,27 @@ RSpec.describe "Nanomaterial notifications", type: :feature do
     expect(page).to have_summary_item(key: "Review period end", value: "1 August 2017")
     expect(page).to have_summary_item(key: "UK nanomaterial number", value: last_notification.ukn)
     expect(page).to have_selector("dd.govuk-summary-list__value", text: "testPdf.pdf (PDF, 11.6 KB)")
+  end
+
+  scenario "submitting a nanomaterial that has not been notified to the EU with an infected file", :with_stubbed_antivirus_returning_false do
+    visit "/responsible_persons/#{responsible_person.id}/nanomaterials"
+
+    click_link "Add a nanomaterial"
+
+    fill_in "What is the name of the nanomaterial?", with: "My nanomaterial"
+    click_button "Continue"
+
+    expect(page).to have_selector("h1", text: "Was the EU notified about My nanomaterial on CPNP before 1 January 2021?")
+    choose "No"
+    click_button "Continue"
+
+    expect(page).to have_selector("h1", text: "Upload details about the nanomaterial")
+    attach_file "Upload a file", Rails.root.join("spec/fixtures/files/testPdf.pdf")
+    click_button "Continue"
+
+    expect(page).to have_selector("#nanomaterial_notification_file-error", text: "The file has not yet been checked for viruses - click Continue for an update")
+    click_button "Continue"
+
+    expect(page).to have_selector("#nanomaterial_notification_file-error", text: "The file is infected with a virus and will be deleted - please upload another file")
   end
 end

--- a/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
+++ b/cosmetics-web/spec/requests/nanomaterial_notifications_spec.rb
@@ -518,8 +518,8 @@ RSpec.describe "Nanomaterial notifications", :with_stubbed_antivirus, type: :req
         let(:file) { Rack::Test::UploadedFile.new("spec/fixtures/files/testPdf.pdf", "application/pdf", true) }
         let(:params) { { nanomaterial_notification: { file: } } }
 
-        it "redirects to the Check your answers page" do
-          expect(response).to redirect_to("/nanomaterials/#{nanomaterial_notification.id}/review")
+        it "shows a message about antivirus scanning" do
+          expect(response.body).to include("The file has not yet been checked for viruses - click Continue for an update")
         end
       end
 


### PR DESCRIPTION
## Description

Adds checking of antivirus results for nanomaterial notification file uploads and prevents progress until a clean result is returned.

## JIRA ticket(s)

https://regulatorydelivery.atlassian.net/browse/PSD-5684

## Screenshots/video

<img width="648" alt="Screenshot 2025-05-15 at 09 43 29" src="https://github.com/user-attachments/assets/9bed80fd-74ce-49a6-adf5-76a487a508a2" />

<img width="643" alt="Screenshot 2025-05-15 at 09 43 43" src="https://github.com/user-attachments/assets/85f83bfe-6431-4fbc-8966-9601d05a4f7d" />

## Review apps

https://cosmetics-pr-3616-submit-web.london.cloudapps.digital/
https://cosmetics-pr-3616-search-web.london.cloudapps.digital/
https://cosmetics-pr-3616-support-web.london.cloudapps.digital/

## Checklist

- [x] All automated checks are passing locally (tests, linting etc)
- [ ] Accessibility testing has been done (where appropriate)
  - [ ] Usable with JavaScript off
  - [ ] Usable with CSS off
  - [ ] Usable on a small screen (e.g. mobile phone)
  - [ ] Usable with just a keyboard
  - [ ] Usable with a screen reader
  - [ ] Usable at 400% zoom
- [ ] Automated tests have been added or updated
- [ ] Documentation has been added or updated
- [ ] Database seeds have been updated
- [ ] Database migrations have been tested (both up and down) and are safe (e.g. stop using a column before removing it)
- [ ] A feature flag has been added (if required in the ticket; a ticket has also been added to remove the feature flag once deployment is completed)
- [ ] Comms have been sent to users (if required in the ticket)
- [ ] OSU Support service has been updated (if required in the ticket)

## Post-deploy tasks

N/A
